### PR TITLE
Issue/166

### DIFF
--- a/src/VstsSyncMigrator.Core/Execution/ComponentContext/WorkItemStoreContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/ComponentContext/WorkItemStoreContext.cs
@@ -129,6 +129,7 @@ namespace VstsSyncMigrator.Engine
 
             var foundWorkItem = QueryWorkItems().FirstOrDefault(wi => wi.Fields[reflectedWotkItemIdField].Value.ToString().EndsWith("/" + refId));
             if (cache && foundWorkItem != null) foundWis[sourceIdKey] = foundWorkItem;
+            return foundWorkItem;
         }
 
         public WorkItem FindReflectedWorkItemByReflectedWorkItemId(string refId, string reflectedWotkItemIdField)

--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/AttachementExportMigrationContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/AttachementExportMigrationContext.cs
@@ -49,7 +49,7 @@ namespace VstsSyncMigrator.Engine
                 Trace.Write(string.Format("Attachement Export: {0} of {1} - {2}", current, sourceWIS.Count, wi.Id));
                 foreach (Attachment wia in wi.Attachments)
                 {
-                    string reflectedId = wi.Fields[me.ReflectedWorkItemIdFieldName].Value.ToString(); 
+                    string reflectedId = wi.Fields[me.SourceReflectedWorkItemIdFieldName].Value.ToString(); 
                     reflectedId = int.Parse(reflectedId.Substring(reflectedId.LastIndexOf(@"/") + 1)).ToString();
                     string fname = string.Format("{0}#{1}", reflectedId, wia.Name);
                     Trace.Write("-");

--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/AttachementExportMigrationContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/AttachementExportMigrationContext.cs
@@ -49,9 +49,7 @@ namespace VstsSyncMigrator.Engine
                 Trace.Write(string.Format("Attachement Export: {0} of {1} - {2}", current, sourceWIS.Count, wi.Id));
                 foreach (Attachment wia in wi.Attachments)
                 {
-                    string reflectedId = wi.Fields[me.SourceReflectedWorkItemIdFieldName].Value.ToString(); 
-                    reflectedId = int.Parse(reflectedId.Substring(reflectedId.LastIndexOf(@"/") + 1)).ToString();
-                    string fname = string.Format("{0}#{1}", reflectedId, wia.Name);
+                    string fname = string.Format("{0}#{1}", wi.Id, wia.Name);
                     Trace.Write("-");
                     Trace.Write(fname);
                     string fpath = Path.Combine(exportPath, fname);

--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/AttachementImportMigrationContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/AttachementImportMigrationContext.cs
@@ -44,14 +44,14 @@ namespace VstsSyncMigrator.Engine
                 try
                 {
                     var fileNameParts = fileName.Split('#');
-                    if (fileNameParts.Length != 2)
+                    if (fileNameParts.Length != 2
+                        || !int.TryParse(fileNameParts[0], out var sourceReflectedID))
                         continue;
 
-                    int reflectedID = int.Parse(fileNameParts[0]);
-                    string targetFileName = fileNameParts[1];
+                    var targetFileName = fileNameParts[1];
                     var renamedFilePath = Path.Combine(Path.GetDirectoryName(file), targetFileName);
                     File.Move(file, renamedFilePath);
-                    targetWI = targetStore.Store.GetWorkItem(reflectedID);
+                    targetWI = targetStore.FindReflectedWorkItemByReflectedWorkItemId(sourceReflectedID,  me.ReflectedWorkItemIdFieldName);
                     if (targetWI != null)
                     {
                         Trace.WriteLine(string.Format("{0} of {1} - Import {2} to {3}", current, files.Count, fileName, targetWI.Id));

--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/AttachementImportMigrationContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/AttachementImportMigrationContext.cs
@@ -51,7 +51,7 @@ namespace VstsSyncMigrator.Engine
                     var targetFileName = fileNameParts[1];
                     var renamedFilePath = Path.Combine(Path.GetDirectoryName(file), targetFileName);
                     File.Move(file, renamedFilePath);
-                    targetWI = targetStore.FindReflectedWorkItemByReflectedWorkItemId(sourceReflectedID,  me.ReflectedWorkItemIdFieldName);
+                    targetWI = targetStore.FindReflectedWorkItemByReflectedWorkItemId(sourceReflectedID,  me.ReflectedWorkItemIdFieldName, true);
                     if (targetWI != null)
                     {
                         Trace.WriteLine(string.Format("{0} of {1} - Import {2} to {3}", current, files.Count, fileName, targetWI.Id));


### PR DESCRIPTION
Not only was the incorrect reflected ID field value being used, but I discovered that attachment migration does not work unless the reflected ID for the target had been updated on the source work item. That prevents users from doing test run throughs. I switched it to use the reflected ID field set on the target work item to match the ID from the source work item.