### PR TITLE
Change start array int for extrapolation of commitId

### DIFF
--- a/src/VstsSyncMigrator.Core/Execution/ProcessingContext/FixGitCommitLinks.cs
+++ b/src/VstsSyncMigrator.Core/Execution/ProcessingContext/FixGitCommitLinks.cs
@@ -79,7 +79,7 @@ namespace VstsSyncMigrator.Engine
                         if (bits.Count() >= 3)
                         {
                             oldCommitId = $"{bits[2]}";
-                            for (int i = 2; i < bits.Count(); i++)
+                            for (int i = 3; i < bits.Count(); i++)
                             {
                                 oldCommitId += $"%2f{bits[i]}";
                             }


### PR DESCRIPTION
When the "bits" variable was greater than 3, it was adding the string at index 2 twice. Once before the for loop, then the same index position again since the start index position (i) was also 2. 