### PR TITLE
404 support, tfs url alias, delete temp files, new download method

### DIFF
--- a/src/VstsSyncMigrator.Core/Configuration/Processing/HtmlFieldEmbeddedImageMigrationConfig.cs
+++ b/src/VstsSyncMigrator.Core/Configuration/Processing/HtmlFieldEmbeddedImageMigrationConfig.cs
@@ -5,20 +5,14 @@ namespace VstsSyncMigrator.Engine.Configuration.Processing
 {
     public class HtmlFieldEmbeddedImageMigrationConfig : ITfsProcessingConfig
     {
-        public string Status
-        {
-            get { return "Experimental"; }
-        }
+        public string Status => "Experimental";
 
         public bool Enabled { get; set; }
         public string QueryBit { get; set; }
 
         public bool FromAnyCollection { get; set; }
 
-        public Type Processor
-        {
-            get { return typeof(HtmlFieldEmbeddedImageMigrationContext); }
-        }
+        public Type Processor => typeof(HtmlFieldEmbeddedImageMigrationContext);
 
         /// <summary>
         /// Username used for VSTS basic authentication using alternate credentials. Leave empty for default credentials 
@@ -29,6 +23,21 @@ namespace VstsSyncMigrator.Engine.Configuration.Processing
         /// Password used for VSTS basic authentication using alternate credentials. Leave empty for default credentials 
         /// </summary>
         public string AlternateCredentialsPassword { get; set; }
+
+        /// <summary>
+        /// Ignore 404 errors and continue on images that don't exist anymore
+        /// </summary>
+        public bool Ignore404Errors { get; set; }
+
+        /// <summary>
+        /// Delete temporary files that were downloaded
+        /// </summary>
+        public bool DeleteTemporaryImageFiles { get; set; }
+
+        /// <summary>
+        /// TFS Aliases to use to match source images (e.g. https://myserver.company.com)
+        /// </summary>
+        public string[] SourceServerAliases { get; set; }
 
         /// <inheritdoc />
         public bool IsProcessorCompatible(IReadOnlyList<ITfsProcessingConfig> otherProcessors)


### PR DESCRIPTION
- Uses HttpClient instead of WebClient to fully prevent redirects
- Allow to skip 404 errors
- Allow to configure to delete the temporary images from disk
- Ability to set multiple source URL's for TFS matching