### PR TITLE
Fix issue that areas / iterations cannot start with Area / Iteration

### DIFF
--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemRevisionReplayMigrationContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemRevisionReplayMigrationContext.cs
@@ -299,7 +299,7 @@ namespace VstsSyncMigrator.Engine
             } else
             {
                 var regex = new Regex(Regex.Escape(oldProjectName));
-                if (oldNodeName.StartsWith($@"{oldProjectName}\{nodePath}"))
+                if (oldNodeName.StartsWith($@"{oldProjectName}\{nodePath}\"))
                 {
                     newNodeName = regex.Replace(oldNodeName, newProjectName, 1);
                 }


### PR DESCRIPTION
If a TFS project uses iterations that start with the word "Iteration" (like the OOTB iterations "Iteration 1/2/3") or areas that start with the word "Area" the injection of the word "Iteration" / "Area" fails to a wrong replacement.