### PR TITLE
 Allow mapping of of System.ChangedBy for revision history & Fix history migrator message

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,19 @@
+# Starter pipeline
+# Start with a minimal pipeline that you can customize to build and deploy your code.
+# Add steps that build, run tests, deploy, and more:
+# https://aka.ms/yaml
+
+trigger:
+- master
+
+pool:
+  vmImage: 'ubuntu-latest'
+
+steps:
+- script: echo Hello, world!
+  displayName: 'Run a one-line script'
+
+- script: |
+    echo Add other tasks to build, test, and deploy your project.
+    echo See https://aka.ms/yaml
+  displayName: 'Run a multi-line script'

--- a/src/VstsSyncMigrator.Core/Execution/FieldMaps/FieldMapBase.cs
+++ b/src/VstsSyncMigrator.Core/Execution/FieldMaps/FieldMapBase.cs
@@ -39,5 +39,27 @@ namespace VstsSyncMigrator.Engine.ComponentContext
         public abstract string MappingDisplayName { get; }
 
         internal abstract void InternalExecute(WorkItem source, WorkItem target);
+
+        internal virtual void InternalExecute(FieldCollection source, FieldCollection target)
+        {
+            return;
+        }
+
+        public void Execute(FieldCollection source, FieldCollection target)
+        {
+            try
+            {
+                InternalExecute(source, target);
+            }
+            catch (Exception ex)
+            {
+                Telemetry.Current.TrackException(ex,
+                       new Dictionary<string, string> {
+                            { "Source", source.ToString() },
+                            { "Target",  target.ToString()}
+                       });
+                Trace.TraceError($"  [EXCEPTION] {ex}");
+            }
+        }
     }
 }

--- a/src/VstsSyncMigrator.Core/Execution/FieldMaps/FieldToTagFieldMap.cs
+++ b/src/VstsSyncMigrator.Core/Execution/FieldMaps/FieldToTagFieldMap.cs
@@ -51,5 +51,10 @@ namespace VstsSyncMigrator.Engine
                 
             }
         }
+
+        public void Execute(FieldCollection source, FieldCollection target)
+        {
+            return;
+        }
     }
 }

--- a/src/VstsSyncMigrator.Core/Execution/FieldMaps/FieldValueMap.cs
+++ b/src/VstsSyncMigrator.Core/Execution/FieldMaps/FieldValueMap.cs
@@ -42,5 +42,27 @@ namespace VstsSyncMigrator.Engine.ComponentContext
             }
 
         }
+
+        internal override void InternalExecute(FieldCollection source, FieldCollection target)
+        {
+            if (source.Contains(config.sourceField))
+            {
+                string sourceValue = source[config.sourceField].Value != null
+                    ? source[config.sourceField].Value.ToString()
+                    : null;
+
+                if (sourceValue != null && config.valueMapping.ContainsKey(sourceValue))
+                {
+                    target[config.targetField].Value = config.valueMapping[sourceValue];
+                    Trace.WriteLine($"  [UPDATE] field value mapped {config.sourceField}:{sourceValue} to {config.targetField}{target[config.targetField].Value}");
+                }
+                else if (sourceValue != null && !string.IsNullOrEmpty(config.defaultValue))
+                {
+                    target[config.targetField].Value = config.defaultValue;
+                    Trace.WriteLine($"  [UPDATE] field set to default value {config.sourceField} to {config.targetField}");
+                }
+            }
+
+        }
     }
 }

--- a/src/VstsSyncMigrator.Core/Execution/FieldMaps/FieldValuetoTagMap.cs
+++ b/src/VstsSyncMigrator.Core/Execution/FieldMaps/FieldValuetoTagMap.cs
@@ -73,6 +73,11 @@ namespace VstsSyncMigrator.Engine
             }
         }
 
+        public void Execute(FieldCollection source, FieldCollection target)
+        {
+            return;
+        }
+
     }
 
 }

--- a/src/VstsSyncMigrator.Core/Execution/FieldMaps/IFieldMap.cs
+++ b/src/VstsSyncMigrator.Core/Execution/FieldMaps/IFieldMap.cs
@@ -13,5 +13,7 @@ namespace VstsSyncMigrator.Engine.ComponentContext
         string MappingDisplayName { get; }
 
         void Execute(WorkItem source, WorkItem target);
+
+        void Execute(FieldCollection source, FieldCollection target);
     }
 }

--- a/src/VstsSyncMigrator.Core/Execution/FieldMaps/RegexFieldMap.cs
+++ b/src/VstsSyncMigrator.Core/Execution/FieldMaps/RegexFieldMap.cs
@@ -37,5 +37,10 @@ namespace VstsSyncMigrator.Engine
                 }
             }
         }
+
+        public void Execute(FieldCollection source, FieldCollection target)
+        {
+            return;
+        }
     }
 }

--- a/src/VstsSyncMigrator.Core/Execution/FieldMaps/TreeToTagFieldMap.cs
+++ b/src/VstsSyncMigrator.Core/Execution/FieldMaps/TreeToTagFieldMap.cs
@@ -44,5 +44,10 @@ namespace VstsSyncMigrator.Engine
             List<string> bits = new List<string>(value.Split(char.Parse(@"\"))).Skip(config.toSkip).ToList();
             target.Tags = string.Join(";", newTags.Union(bits).ToArray());
         }
+
+        public void Execute(FieldCollection source, FieldCollection target)
+        {
+            return;
+        }
     }
 }

--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemRevisionReplayMigrationContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemRevisionReplayMigrationContext.cs
@@ -172,6 +172,8 @@ namespace VstsSyncMigrator.Engine
                         newwit.Fields["System.ChangedBy"].Value =
                             currentRevisionWorkItem.Revisions[revision.Index].Fields["System.ChangedBy"].Value;
 
+                        me.ApplyFieldMappings(currentRevisionWorkItem.Revisions[revision.Index].Fields, newwit.Fields);
+
                         newwit.Fields["System.History"].Value =
                             currentRevisionWorkItem.Revisions[revision.Index].Fields["System.History"].Value;
 

--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemRevisionReplayMigrationContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemRevisionReplayMigrationContext.cs
@@ -205,7 +205,7 @@ namespace VstsSyncMigrator.Engine
                     }
                     var history = new StringBuilder();
                     history.Append(
-                        "Migrated by <a href='https://dev.azure.com/nkdagility/migration-tools/'>Azure DevOps Migration Tools</a> open source.'>Azure DevOps Migration Tools</a>.");
+                        "Migrated by <a href='https://dev.azure.com/nkdagility/migration-tools/'>Azure DevOps Migration Tools</a>");
                     newwit.History = history.ToString();
 
                     newwit.Save();

--- a/src/VstsSyncMigrator.Core/MigrationEngine.cs
+++ b/src/VstsSyncMigrator.Core/MigrationEngine.cs
@@ -214,6 +214,14 @@ namespace VstsSyncMigrator.Engine
             }
         }
 
+        internal void ApplyFieldMappings(FieldCollection source, FieldCollection target)
+        {
+            if (fieldMapps.ContainsKey("*"))
+            {
+                ProcessFieldMapList(source, target, fieldMapps["*"]);
+            }
+        }
+
         internal void ApplyFieldMappings(WorkItem target)
         {
             if (fieldMapps.ContainsKey("*"))
@@ -235,5 +243,13 @@ namespace VstsSyncMigrator.Engine
             }
         }
 
+        private void ProcessFieldMapList(FieldCollection source, FieldCollection target, List<IFieldMap> list)
+        {
+            foreach (IFieldMap map in list)
+            {
+                Trace.WriteLine(string.Format("Running Field Map: {0} {1}", map.Name, map.MappingDisplayName));
+                map.Execute(source, target);
+            }
+        }
     }
 }


### PR DESCRIPTION
When migration is done including the revision history, mapping does not take place against the historic work item.

This is a rudimentary solution for also allowing to map the System.ChangedBy for the revision history, so the history of the work item will contain usernames according to the configured mapping.

This may cause unwanted side effects, but generally I suppose the best approach would be to set Fields from the applicable historic revision and not the current item.