### PR TITLE
Fix for Issue #232 Move File throws exception

### DIFF
--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/AttachementImportMigrationContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/AttachementImportMigrationContext.cs
@@ -1,10 +1,8 @@
 ﻿using Microsoft.TeamFoundation.WorkItemTracking.Client;
-using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Net;
 using VstsSyncMigrator.Engine.Configuration.Processing;
 
 namespace VstsSyncMigrator.Engine
@@ -54,7 +52,7 @@ namespace VstsSyncMigrator.Engine
                         File.Delete(renamedFilePath);
 
                     File.Move(file, renamedFilePath);
-                    targetWI = targetStore.FindReflectedWorkItemByReflectedWorkItemId(sourceReflectedID,  me.ReflectedWorkItemIdFieldName, true);
+                    targetWI = targetStore.FindReflectedWorkItemByReflectedWorkItemId(sourceReflectedID, me.ReflectedWorkItemIdFieldName, true);
                     if (targetWI != null)
                     {
                         Trace.WriteLine(string.Format("{0} of {1} - Import {2} to {3}", current, files.Count, fileName, targetWI.Id));
@@ -78,10 +76,11 @@ namespace VstsSyncMigrator.Engine
                         skipped++;
                     }
                     System.IO.File.Delete(renamedFilePath);
-                } catch (FileAttachmentException ex)
+                }
+                catch (FileAttachmentException ex)
                 {
                     // Probably due to attachment being over size limit
-                    Trace.WriteLine(ex.Message) ;
+                    Trace.WriteLine(ex.Message);
                     failures++;
                 }
                 current--;

--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/AttachementImportMigrationContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/AttachementImportMigrationContext.cs
@@ -50,6 +50,9 @@ namespace VstsSyncMigrator.Engine
 
                     var targetFileName = fileNameParts[1];
                     var renamedFilePath = Path.Combine(Path.GetDirectoryName(file), targetFileName);
+                    if (File.Exists(renamedFilePath))
+                        File.Delete(renamedFilePath);
+
                     File.Move(file, renamedFilePath);
                     targetWI = targetStore.FindReflectedWorkItemByReflectedWorkItemId(sourceReflectedID,  me.ReflectedWorkItemIdFieldName, true);
                     if (targetWI != null)

--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/AttachementImportMigrationContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/AttachementImportMigrationContext.cs
@@ -75,7 +75,7 @@ namespace VstsSyncMigrator.Engine
                         Trace.WriteLine(string.Format("{0} of {1} - Skipping {2} to {3}", current, files.Count, fileName, 0));
                         skipped++;
                     }
-                    System.IO.File.Delete(renamedFilePath);
+                    File.Delete(renamedFilePath);
                 }
                 catch (FileAttachmentException ex)
                 {


### PR DESCRIPTION
… when that file already exists.  Check if the file exists before performing the move and delete it.  See stack trace in Issue #232 
