### PR TITLE
Status Dates Fixes

### DIFF
--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemRevisionReplayMigrationContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemRevisionReplayMigrationContext.cs
@@ -47,12 +47,6 @@ namespace VstsSyncMigrator.Engine
                 "System.NodeName",
                 "System.RelatedLinkCount",
                 "System.WorkItemType",
-                "Microsoft.VSTS.Common.ActivatedDate",
-                "Microsoft.VSTS.Common.ActivatedBy",
-                "Microsoft.VSTS.Common.ResolvedDate",
-                "Microsoft.VSTS.Common.ResolvedBy",
-                "Microsoft.VSTS.Common.ClosedDate",
-                "Microsoft.VSTS.Common.ClosedBy",
                 "Microsoft.VSTS.Common.StateChangeDate",
                 "System.ExternalLinkCount",
                 "System.HyperLinkCount",
@@ -301,7 +295,7 @@ namespace VstsSyncMigrator.Engine
 
             foreach (Field f in oldWi.Fields)
             {
-                if (newwit.Fields.Contains(f.ReferenceName) && !_ignore.Contains(f.ReferenceName))
+                if (newwit.Fields.Contains(f.ReferenceName) && !_ignore.Contains(f.ReferenceName) && (!newwit.Fields[f.ReferenceName].IsChangedInRevision || newwit.Fields[f.ReferenceName].IsEditable))
                 {
                     newwit.Fields[f.ReferenceName].Value = oldWi.Fields[f.ReferenceName].Value;
                 }


### PR DESCRIPTION
Allows the Closed Date, Activated Date and Resolved Date  to be changed.

I discovered that the value cannot be written in the revision where the change happens but in subsequent revisions this is not a problem.
To bypass the Closed Date issue a new revision needs to be added in the item to migrate. I was not able to do that in the code yet, but adding in the work item on the server to migrate ensures all date values are correctly passed.