### PR TITLE
Updated , ReflectedWorkItemID to pull from the Team Project Config to…

### DIFF
--- a/src/VstsSyncMigrator.Core.Tests/EngineConfigurationTests.cs
+++ b/src/VstsSyncMigrator.Core.Tests/EngineConfigurationTests.cs
@@ -12,9 +12,8 @@ namespace _VstsSyncMigrator.Engine.Tests
         {
             EngineConfiguration ec = new EngineConfiguration();
             ec.TelemetryEnableTrace = true;
-            ec.Source = new TeamProjectConfig() { Name = "DemoProjs", Collection = new Uri("https://sdd2016.visualstudio.com/") };
-            ec.Target = new TeamProjectConfig() { Name = "DemoProjt", Collection = new Uri("https://sdd2016.visualstudio.com/") };
-            ec.ReflectedWorkItemIDFieldName = "TfsMigrationTool.ReflectedWorkItemId";
+            ec.Source = new TeamProjectConfig() { Name = "DemoProjs", Collection = new Uri("https://sdd2016.visualstudio.com/"), ReflectedWorkItemIDFieldName = "TfsMigrationTool.ReflectedWorkItemId" };
+            ec.Target = new TeamProjectConfig() { Name = "DemoProjt", Collection = new Uri("https://sdd2016.visualstudio.com/"), ReflectedWorkItemIDFieldName = "TfsMigrationTool.ReflectedWorkItemId" };
             Assert.IsNotNull(ec);
             Assert.IsNotNull(ec.Source);
             Assert.AreEqual(ec.Source.Name, "DemoProjs");

--- a/src/VstsSyncMigrator.Core/Configuration/EngineConfiguration.cs
+++ b/src/VstsSyncMigrator.Core/Configuration/EngineConfiguration.cs
@@ -15,8 +15,6 @@ namespace VstsSyncMigrator.Engine.Configuration
         public bool workaroundForQuerySOAPBugEnabled { get; set; }
         public TeamProjectConfig Source { get; set; }
         public TeamProjectConfig Target { get; set; }
-        public string ReflectedWorkItemIDFieldName { get; set; }
-        public string SourceReflectedWorkItemIDFieldName { get; set; }
         public List<IFieldMapConfig> FieldMaps { get; set; }
         public Dictionary<string, string> WorkItemTypeDefinition { get; set; }
         public List<ITfsProcessingConfig> Processors { get; set; }
@@ -25,10 +23,8 @@ namespace VstsSyncMigrator.Engine.Configuration
         {
             EngineConfiguration ec = new EngineConfiguration();
             ec.TelemetryEnableTrace = false;
-            ec.Source = new TeamProjectConfig() { Name = "DemoProjs", Collection = new Uri("https://sdd2016.visualstudio.com/") };
-            ec.Target = new TeamProjectConfig() { Name = "DemoProjt", Collection = new Uri("https://sdd2016.visualstudio.com/") };
-            ec.ReflectedWorkItemIDFieldName = "TfsMigrationTool.ReflectedWorkItemId";
-            ec.SourceReflectedWorkItemIDFieldName = "ProcessName.ReflectedWorkItemId";
+            ec.Source = new TeamProjectConfig() { Name = "DemoProjs", Collection = new Uri("https://sdd2016.visualstudio.com/"), ReflectedWorkItemIDFieldName = "TfsMigrationTool.ReflectedWorkItemId" };
+            ec.Target = new TeamProjectConfig() { Name = "DemoProjt", Collection = new Uri("https://sdd2016.visualstudio.com/"), ReflectedWorkItemIDFieldName = "ProcessName.ReflectedWorkItemId" };
             ec.FieldMaps = new List<IFieldMapConfig>();
             ec.FieldMaps.Add(new MultiValueConditionalMapConfig()
             {

--- a/src/VstsSyncMigrator.Core/Configuration/TeamProjectConfig.cs
+++ b/src/VstsSyncMigrator.Core/Configuration/TeamProjectConfig.cs
@@ -10,5 +10,6 @@ namespace VstsSyncMigrator.Engine.Configuration
     {
         public Uri Collection { get; set; }
         public string Name { get; set; }
+        public string ReflectedWorkItemIDFieldName { get; set; }
     }
 }

--- a/src/VstsSyncMigrator.Core/Execution/ComponentContext/ITeamProjectContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/ComponentContext/ITeamProjectContext.cs
@@ -4,13 +4,14 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using VstsSyncMigrator.Engine.Configuration;
 
 namespace VstsSyncMigrator.Engine
 {
     public interface ITeamProjectContext
     {
         TfsTeamProjectCollection Collection { get; }
-        string Name { get; }
+        TeamProjectConfig Config { get; }
         void Connect();
     }
 }

--- a/src/VstsSyncMigrator.Core/Execution/ComponentContext/TestManagementContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/ComponentContext/TestManagementContext.cs
@@ -19,7 +19,7 @@ namespace VstsSyncMigrator.Engine.ComponentContext
             this.testPlanQueryBit = testPlanQueryBit;
             this.source = source;
             tms = (ITestManagementService)source.Collection.GetService(typeof(ITestManagementService));
-            Project = tms.GetTeamProject(source.Name);
+            Project = tms.GetTeamProject(source.Config.Name);
         }
 
         internal ITestPlanCollection GetTestPlans()

--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/AttachementExportMigrationContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/AttachementExportMigrationContext.cs
@@ -36,7 +36,7 @@ namespace VstsSyncMigrator.Engine
 
 			WorkItemStoreContext sourceStore = new WorkItemStoreContext(me.Source, WorkItemStoreFlags.None);
             TfsQueryContext tfsqc = new TfsQueryContext(sourceStore);
-            tfsqc.AddParameter("TeamProject", me.Source.Name);
+            tfsqc.AddParameter("TeamProject", me.Source.Config.Name);
             tfsqc.Query = string.Format(@"SELECT [System.Id], [System.Tags] FROM WorkItems WHERE [System.TeamProject] = @TeamProject {0} ORDER BY [System.ChangedDate] desc", _config.QueryBit);
             WorkItemCollection sourceWIS = tfsqc.Execute();
 

--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/FakeProcessor.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/FakeProcessor.cs
@@ -33,7 +33,7 @@ namespace VstsSyncMigrator.Engine
 			//////////////////////////////////////////////////
 			WorkItemStoreContext sourceStore = new WorkItemStoreContext(me.Source, WorkItemStoreFlags.None);
             TfsQueryContext tfsqc = new TfsQueryContext(sourceStore);
-            tfsqc.AddParameter("TeamProject", me.Source.Name);
+            tfsqc.AddParameter("TeamProject", me.Source.Config.Name);
             tfsqc.Query = @"SELECT [System.Id] FROM WorkItems WHERE  [System.TeamProject] = @TeamProject ";// AND [System.Id] = 188708 ";
             WorkItemCollection sourceWIS = tfsqc.Execute();
             Trace.WriteLine(string.Format("Migrate {0} work items?", sourceWIS.Count));

--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/HtmlFieldEmbeddedImageMigrationContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/HtmlFieldEmbeddedImageMigrationContext.cs
@@ -41,7 +41,7 @@ namespace VstsSyncMigrator.Engine
 
 			WorkItemStoreContext targetStore = new WorkItemStoreContext(me.Target, WorkItemStoreFlags.BypassRules);
             TfsQueryContext tfsqc = new TfsQueryContext(targetStore);
-            tfsqc.AddParameter("TeamProject", me.Target.Name);
+            tfsqc.AddParameter("TeamProject", me.Target.Config.Name);
             tfsqc.Query =
                 $@"SELECT [System.Id], [System.Tags] FROM WorkItems WHERE [System.TeamProject] = @TeamProject {_config.QueryBit} ORDER BY [System.ChangedDate] desc";
             WorkItemCollection targetWIS = tfsqc.Execute();

--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/LinkMigrationContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/LinkMigrationContext.cs
@@ -37,7 +37,7 @@ namespace VstsSyncMigrator.Engine
         {
             WorkItemStoreContext sourceStore = new WorkItemStoreContext(me.Source, WorkItemStoreFlags.BypassRules);
             TfsQueryContext tfsqc = new TfsQueryContext(sourceStore);
-            tfsqc.AddParameter("TeamProject", me.Source.Name);
+            tfsqc.AddParameter("TeamProject", me.Source.Config.Name);
             tfsqc.Query = string.Format(@"SELECT [System.Id] FROM WorkItems WHERE  [System.TeamProject] = @TeamProject {0} ORDER BY [System.ChangedDate] desc ", config.QueryBit); // AND  [Microsoft.VSTS.Common.ClosedDate] = ''
             WorkItemCollection sourceWIS = tfsqc.Execute();
             //////////////////////////////////////////////////
@@ -54,7 +54,7 @@ namespace VstsSyncMigrator.Engine
                 WorkItem wiTargetL = null;
                 try
                 {
-                    wiTargetL = targetWitsc.FindReflectedWorkItem(wiSourceL, me.ReflectedWorkItemIdFieldName, true);
+                    wiTargetL = targetWitsc.FindReflectedWorkItem(wiSourceL, true);
                 }
                 catch (Exception)
                 {
@@ -141,8 +141,7 @@ namespace VstsSyncMigrator.Engine
             foreach (WorkItem sourceSharedStep in sourceSharedSteps)
             {
                 WorkItem matchingTargetSharedStep =
-                    targetStore.FindReflectedWorkItemByReflectedWorkItemId(sourceSharedStep,
-                        me.ReflectedWorkItemIdFieldName);
+                    targetStore.FindReflectedWorkItemByReflectedWorkItemId(sourceSharedStep);
 
                 if (matchingTargetSharedStep != null)
                 {
@@ -287,7 +286,7 @@ namespace VstsSyncMigrator.Engine
             else
             {
                 // Moving to Other Team Project from Source
-                wiTargetR = targetStore.FindReflectedWorkItem(wiSourceR, me.ReflectedWorkItemIdFieldName, true);
+                wiTargetR = targetStore.FindReflectedWorkItem(wiSourceR, true);
                 if (wiTargetR == null) // Assume source only (other team project)
                 {
                     wiTargetR = wiSourceR;

--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/MigrationContextBase.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/MigrationContextBase.cs
@@ -45,9 +45,9 @@ namespace VstsSyncMigrator.Engine
                     new Dictionary<string, string>
                     {
                         {"Name", Name},
-                        {"Target Project", me.Target.Name},
+                        {"Target Project", me.Target.Config.Name},
                         {"Target Collection", me.Target.Collection.Name},
-                        {"Source Project", me.Source.Name},
+                        {"Source Project", me.Source.Config.Name},
                         {"Source Collection", me.Source.Collection.Name},
                         {"Status", Status.ToString()}
                     },
@@ -69,7 +69,7 @@ namespace VstsSyncMigrator.Engine
         internal string NodeStructreSourceToTarget(string input)
         {
             //input = [sourceTeamProject]\[AreaPath]
-            return string.Format("{0}\\{1}", me.Target.Name, input);
+            return string.Format("{0}\\{1}", me.Target.Config.Name, input);
 
 
             //Regex r = new Regex(source.Name, RegexOptions.IgnoreCase);
@@ -82,9 +82,9 @@ namespace VstsSyncMigrator.Engine
         internal string ReplaceFirstInstanceOf(string input)
         {
             //input = [sourceTeamProject]\[AreaPath]
-            var r = new Regex(me.Source.Name, RegexOptions.IgnoreCase);
+            var r = new Regex(me.Source.Config.Name, RegexOptions.IgnoreCase);
             //// Output = [targetTeamProject]\[sourceTeamProject]\[AreaPath]
-            return r.Replace(input, me.Target.Name, 1);
+            return r.Replace(input, me.Target.Config.Name, 1);
         }
     }
 }

--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/NodeStructuresMigrationContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/NodeStructuresMigrationContext.cs
@@ -30,7 +30,7 @@ namespace VstsSyncMigrator.Engine
         {
             //////////////////////////////////////////////////
             ICommonStructureService sourceCss = (ICommonStructureService)me.Source.Collection.GetService(typeof(ICommonStructureService));
-            ProjectInfo sourceProjectInfo = sourceCss.GetProjectFromName(me.Source.Name);
+            ProjectInfo sourceProjectInfo = sourceCss.GetProjectFromName(me.Source.Config.Name);
             NodeInfo[] sourceNodes = sourceCss.ListStructures(sourceProjectInfo.Uri);
             //////////////////////////////////////////////////
             ICommonStructureService targetCss = (ICommonStructureService)me.Target.Collection.GetService(typeof(ICommonStructureService4));
@@ -46,10 +46,10 @@ namespace VstsSyncMigrator.Engine
         {
             NodeInfo sourceNode = (from n in sourceNodes where n.Path.Contains(treeType) select n).Single();
             XmlElement sourceTree = sourceCss.GetNodesXml(new string[] { sourceNode.Uri }, true);
-            NodeInfo structureParent = targetCss.GetNodeFromPath(string.Format("\\{0}\\{1}", me.Target.Name, treeType));
+            NodeInfo structureParent = targetCss.GetNodeFromPath(string.Format("\\{0}\\{1}", me.Target.Config.Name, treeType));
             if (config.PrefixProjectToNodes)
             {
-                structureParent = CreateNode(targetCss, me.Source.Name, structureParent);
+                structureParent = CreateNode(targetCss, me.Source.Config.Name, structureParent);
             }
             if (sourceTree.ChildNodes[0].HasChildNodes)
             {

--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/TeamMigrationContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/TeamMigrationContext.cs
@@ -39,7 +39,7 @@ namespace VstsSyncMigrator.Engine
 			//////////////////////////////////////////////////
 			WorkItemStoreContext sourceStore = new WorkItemStoreContext(me.Source, WorkItemStoreFlags.BypassRules);
             TfsTeamService sourceTS = me.Source.Collection.GetService<TfsTeamService>();
-            List<TeamFoundationTeam> sourceTL = sourceTS.QueryTeams(me.Source.Name).ToList();
+            List<TeamFoundationTeam> sourceTL = sourceTS.QueryTeams(me.Source.Config.Name).ToList();
             Trace.WriteLine(string.Format("Found {0} teams in Source?", sourceTL.Count));
             var sourceTSCS = me.Source.Collection.GetService<TeamSettingsConfigurationService>();
             //////////////////////////////////////////////////
@@ -47,7 +47,7 @@ namespace VstsSyncMigrator.Engine
             Project targetProject = targetStore.GetProject();
             Trace.WriteLine(string.Format("Found target project as {0}", targetProject.Name));
             TfsTeamService targetTS = me.Target.Collection.GetService<TfsTeamService>();
-            List<TeamFoundationTeam> targetTL = targetTS.QueryTeams(me.Target.Name).ToList();
+            List<TeamFoundationTeam> targetTL = targetTS.QueryTeams(me.Target.Config.Name).ToList();
             Trace.WriteLine(string.Format("Found {0} teams in Target?", targetTL.Count));
             var targetTSCS = me.Target.Collection.GetService<TeamSettingsConfigurationService>();
             //////////////////////////////////////////////////
@@ -119,11 +119,11 @@ namespace VstsSyncMigrator.Engine
         {
             ///////////////////////////////////////////////////
             TeamSettings newTeamSettings = sourceTCfU.TeamSettings;
-            newTeamSettings.BacklogIterationPath = newTeamSettings.BacklogIterationPath.Replace(me.Source.Name, me.Target.Name);
+            newTeamSettings.BacklogIterationPath = newTeamSettings.BacklogIterationPath.Replace(me.Source.Config.Name, me.Target.Config.Name);
             List<string> newIterationPaths = new List<string>();
             foreach (var ip in newTeamSettings.IterationPaths)
             {
-                newIterationPaths.Add(ip.Replace(me.Source.Name, me.Target.Name));
+                newIterationPaths.Add(ip.Replace(me.Source.Config.Name, me.Target.Config.Name));
             }
             newTeamSettings.IterationPaths = newIterationPaths.ToArray();
 

--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/TestConfigurationsMigrationContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/TestConfigurationsMigrationContext.cs
@@ -45,7 +45,7 @@ namespace VstsSyncMigrator.Engine
                 {
                     Trace.WriteLine($"{sourceTestConf.Name} - Create new", Name);
                     targetTc = targetTmc.Project.TestConfigurations.Create();
-                    targetTc.AreaPath = sourceTestConf.AreaPath.Replace(me.Source.Name, me.Target.Name);
+                    targetTc.AreaPath = sourceTestConf.AreaPath.Replace(me.Source.Config.Name, me.Target.Config.Name);
                     targetTc.Description = sourceTestConf.Description;
                     targetTc.IsDefault = sourceTestConf.IsDefault;
                     targetTc.Name = sourceTestConf.Name;

--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemMigrationContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemMigrationContext.cs
@@ -70,7 +70,7 @@ namespace VstsSyncMigrator.Engine
 			//////////////////////////////////////////////////
 			WorkItemStoreContext sourceStore = new WorkItemStoreContext(me.Source, WorkItemStoreFlags.BypassRules);
             TfsQueryContext tfsqc = new TfsQueryContext(sourceStore);
-            tfsqc.AddParameter("TeamProject", me.Source.Name);
+            tfsqc.AddParameter("TeamProject", me.Source.Config.Name);
             tfsqc.Query = string.Format(@"SELECT [System.Id] FROM WorkItems WHERE [System.TeamProject] = @TeamProject {0} ORDER BY [System.ChangedDate] desc", _config.QueryBit);
             WorkItemCollection sourceWIS = tfsqc.Execute();
             Trace.WriteLine(string.Format("Migrate {0} work items?", sourceWIS.Count), this.Name);
@@ -89,7 +89,7 @@ namespace VstsSyncMigrator.Engine
             {
                 Stopwatch witstopwatch = Stopwatch.StartNew();
 				WorkItem targetFound;
-                targetFound = targetStore.FindReflectedWorkItem(sourceWI, me.ReflectedWorkItemIdFieldName, false);
+                targetFound = targetStore.FindReflectedWorkItem(sourceWI, false);
                 Trace.WriteLine(string.Format("{0} - Migrating: {1}-{2}", current, sourceWI.Id, sourceWI.Type.Name), this.Name);
                 if (targetFound == null)
                 {

--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemPostProcessingContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemPostProcessingContext.cs
@@ -54,7 +54,7 @@ namespace VstsSyncMigrator.Engine
 			//////////////////////////////////////////////////
 			WorkItemStoreContext sourceStore = new WorkItemStoreContext(me.Source, WorkItemStoreFlags.None);
             TfsQueryContext tfsqc = new TfsQueryContext(sourceStore);
-            tfsqc.AddParameter("TeamProject", me.Source.Name);
+            tfsqc.AddParameter("TeamProject", me.Source.Config.Name);
 
             //Builds the constraint part of the query
             string constraints = BuildQueryBitConstraints();
@@ -76,7 +76,7 @@ namespace VstsSyncMigrator.Engine
             {
                 Stopwatch witstopwatch = Stopwatch.StartNew();
 				WorkItem targetFound;
-                targetFound = targetStore.FindReflectedWorkItem(sourceWI, me.ReflectedWorkItemIdFieldName, false);
+                targetFound = targetStore.FindReflectedWorkItem(sourceWI, false);
                 Trace.WriteLine(string.Format("{0} - Updating: {1}-{2}", current, sourceWI.Id, sourceWI.Type.Name));
                 if (targetFound == null)
                 {

--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemQueryMigrationContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemQueryMigrationContext.cs
@@ -64,8 +64,8 @@ namespace VstsSyncMigrator.Engine
 			var sourceStore = new WorkItemStoreContext(me.Source, WorkItemStoreFlags.None);
             var targetStore = new WorkItemStoreContext(me.Target, WorkItemStoreFlags.None);
 
-            var sourceQueryHierarchy = sourceStore.Store.Projects[me.Source.Name].QueryHierarchy;
-            var targetQueryHierarchy = targetStore.Store.Projects[me.Target.Name].QueryHierarchy;
+            var sourceQueryHierarchy = sourceStore.Store.Projects[me.Source.Config.Name].QueryHierarchy;
+            var targetQueryHierarchy = targetStore.Store.Projects[me.Target.Config.Name].QueryHierarchy;
 
             Trace.WriteLine(string.Format("Found {0} root level child WIQ folders", sourceQueryHierarchy.Count));
             //////////////////////////////////////////////////
@@ -99,13 +99,13 @@ namespace VstsSyncMigrator.Engine
                 this.totalFoldersAttempted++;
 
                 // we need to replace the team project name in folder names as it included in query paths
-                var requiredPath = sourceFolder.Path.Replace($"{me.Source.Name}/", $"{me.Target.Name}/");
+                var requiredPath = sourceFolder.Path.Replace($"{me.Source.Config.Name}/", $"{me.Target.Config.Name}/");
 
                 // Is the project name to be used in the migration as an extra folder level?
                 if (config.PrefixProjectToNodes == true)
                 {
                     // we need to inject the team name as a folder in the structure
-                    requiredPath = requiredPath.Replace(config.SharedFolderName, $"{config.SharedFolderName}/{me.Source.Name}");
+                    requiredPath = requiredPath.Replace(config.SharedFolderName, $"{config.SharedFolderName}/{me.Source.Config.Name}");
 
                     // If on the root level we need to check that the extra folder has already been added
                     if (sourceFolder.Path.Count(f => f == '/') == 1)
@@ -115,8 +115,8 @@ namespace VstsSyncMigrator.Engine
                         if (extraFolder == null)
                         {
                             // we are at the root level on the first pass and need to create the extra folder for the team name
-                            Trace.WriteLine($"Adding a folder '{me.Source.Name}'");
-                            extraFolder = new QueryFolder(me.Source.Name);
+                            Trace.WriteLine($"Adding a folder '{me.Source.Config.Name}'");
+                            extraFolder = new QueryFolder(me.Source.Config.Name);
                             targetSharedFolderRoot.Add(extraFolder);
                             targetHierarchy.Save(); // moved the save here a more immediate and relavent error message
                         }
@@ -172,12 +172,12 @@ namespace VstsSyncMigrator.Engine
             else
             {
                 // Sort out any path issues in the quertText
-                var fixedQueryText = query.QueryText.Replace($"'{me.Source.Name}", $"'{me.Target.Name}"); // the ' should only items at the start of areapath etc.
+                var fixedQueryText = query.QueryText.Replace($"'{me.Source.Config.Name}", $"'{me.Target.Config.Name}"); // the ' should only items at the start of areapath etc.
 
                 if (config.PrefixProjectToNodes)
                 {
                     // we need to inject the team name as a folder in the structure too
-                    fixedQueryText = fixedQueryText.Replace($"{me.Target.Name}\\", $"{me.Target.Name}\\{me.Source.Name}\\");
+                    fixedQueryText = fixedQueryText.Replace($"{me.Target.Config.Name}\\", $"{me.Target.Config.Name}\\{me.Source.Config.Name}\\");
                 }
 
                 // you cannot just add an item from one store to another, we need to create a new object

--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemRevisionReplayMigrationContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemRevisionReplayMigrationContext.cs
@@ -74,7 +74,7 @@ namespace VstsSyncMigrator.Engine
 			//////////////////////////////////////////////////
 			var sourceStore = new WorkItemStoreContext(me.Source, WorkItemStoreFlags.BypassRules);
 			var tfsqc = new TfsQueryContext(sourceStore);
-			tfsqc.AddParameter("TeamProject", me.Source.Name);
+			tfsqc.AddParameter("TeamProject", me.Source.Config.Name);
 			tfsqc.Query =
 				string.Format(
 					@"SELECT [System.Id], [System.Tags] FROM WorkItems WHERE [System.TeamProject] = @TeamProject {0} ORDER BY [System.ChangedDate] desc",
@@ -97,7 +97,7 @@ namespace VstsSyncMigrator.Engine
 			foreach (WorkItem sourceWorkItem in sourceWorkItems)
 			{
 				var witstopwatch = Stopwatch.StartNew();
-				var targetFound = targetStore.FindReflectedWorkItem(sourceWorkItem, me.ReflectedWorkItemIdFieldName, false);
+				var targetFound = targetStore.FindReflectedWorkItem(sourceWorkItem, false);
 				Trace.WriteLine($"{current} - Migrating: {sourceWorkItem.Id} - {sourceWorkItem.Type.Name}", Name);
 
 				if (targetFound == null)
@@ -134,7 +134,7 @@ namespace VstsSyncMigrator.Engine
 		private void ConfigValidation()
 		{
 			//Make sure that the ReflectedWorkItemId field name specified in the config exists in the target process, preferably on each work item type
-			var fields = witClient.GetFieldsAsync(me.Target.Name).Result;
+			var fields = witClient.GetFieldsAsync(me.Target.Config.Name).Result;
 			bool rwiidFieldExists = fields.Any(x => x.ReferenceName == me.ReflectedWorkItemIdFieldName || x.Name == me.ReflectedWorkItemIdFieldName);
 			Trace.WriteLine($"Found {fields.Count.ToString("n0")} work item fields.");
 			if (rwiidFieldExists)

--- a/src/VstsSyncMigrator.Core/Execution/ProcessingContext/CreateTeamFolders.cs
+++ b/src/VstsSyncMigrator.Core/Execution/ProcessingContext/CreateTeamFolders.cs
@@ -38,8 +38,8 @@ namespace VstsSyncMigrator.Engine
             TfsQueryContext tfsqc = new TfsQueryContext(targetStore);
 
             TfsTeamService teamService = me.Target.Collection.GetService<TfsTeamService>();
-            QueryHierarchy qh = targetStore.Store.Projects[me.Target.Name].QueryHierarchy;
-            List<TeamFoundationTeam> teamList = teamService.QueryTeams(me.Target.Name).ToList();
+            QueryHierarchy qh = targetStore.Store.Projects[me.Target.Config.Name].QueryHierarchy;
+            List<TeamFoundationTeam> teamList = teamService.QueryTeams(me.Target.Config.Name).ToList();
 
             Trace.WriteLine(string.Format("Found {0} teams?", teamList.Count));
             //////////////////////////////////////////////////

--- a/src/VstsSyncMigrator.Core/Execution/ProcessingContext/ExportTeamList.cs
+++ b/src/VstsSyncMigrator.Core/Execution/ProcessingContext/ExportTeamList.cs
@@ -37,7 +37,7 @@ namespace VstsSyncMigrator.Engine
 			//////////////////////////////////////////////////
 			// Retrieve the project URI. Needed to enumerate teams.     
 			var css4 = me.Target.Collection.GetService<ICommonStructureService4>();
-            ProjectInfo projectInfo = css4.GetProjectFromName(me.Target.Name);
+            ProjectInfo projectInfo = css4.GetProjectFromName(me.Target.Config.Name);
             // Retrieve a list of all teams on the project.     
             TfsTeamService teamService = me.Target.Collection.GetService<TfsTeamService>();
 

--- a/src/VstsSyncMigrator.Core/Execution/ProcessingContext/FixGitCommitLinks.cs
+++ b/src/VstsSyncMigrator.Core/Execution/ProcessingContext/FixGitCommitLinks.cs
@@ -34,14 +34,14 @@ namespace VstsSyncMigrator.Engine
             Stopwatch stopwatch = Stopwatch.StartNew();
 			//////////////////////////////////////////////////
 			var sourceGitRepoService = me.Source.Collection.GetService<GitRepositoryService>();
-            var sourceGitRepos = sourceGitRepoService.QueryRepositories(me.Source.Name);
+            var sourceGitRepos = sourceGitRepoService.QueryRepositories(me.Source.Config.Name);
             //////////////////////////////////////////////////
             var targetGitRepoService = me.Target.Collection.GetService<GitRepositoryService>();
-            var targetGitRepos = targetGitRepoService.QueryRepositories(me.Target.Name);
+            var targetGitRepos = targetGitRepoService.QueryRepositories(me.Target.Config.Name);
 
             WorkItemStoreContext targetStore = new WorkItemStoreContext(me.Target, WorkItemStoreFlags.BypassRules);
             TfsQueryContext tfsqc = new TfsQueryContext(targetStore);
-            tfsqc.AddParameter("TeamProject", me.Target.Name);
+            tfsqc.AddParameter("TeamProject", me.Target.Config.Name);
             tfsqc.Query = string.Format(@"SELECT [System.Id] FROM WorkItems WHERE  [System.TeamProject] = @TeamProject");
             WorkItemCollection workitems = tfsqc.Execute();
             Trace.WriteLine(string.Format("Update {0} work items?", workitems.Count));
@@ -98,7 +98,7 @@ namespace VstsSyncMigrator.Engine
                                 : oldGitRepo.Name;
 
                             // Source and Target project names match
-                            if (oldGitRepo.ProjectReference.Name == me.Target.Name)
+                            if (oldGitRepo.ProjectReference.Name == me.Target.Config.Name)
                             {
                                 newGitRepo = (from g in targetGitRepos
                                                   where

--- a/src/VstsSyncMigrator.Core/Execution/ProcessingContext/ProcessingContextBase.cs
+++ b/src/VstsSyncMigrator.Core/Execution/ProcessingContext/ProcessingContextBase.cs
@@ -47,7 +47,7 @@ namespace VstsSyncMigrator.Engine
                 Telemetry.Current.TrackEvent("ProcessingContextComplete",
                     new Dictionary<string, string> {
                         { "Name", Name},
-                        { "Target Project", me.Target.Name},
+                        { "Target Project", me.Target.Config.Name},
                         { "Target Collection", me.Target.Collection.Name },
                         { "Status", Status.ToString() }
                     },
@@ -63,7 +63,7 @@ namespace VstsSyncMigrator.Engine
                 Telemetry.Current.TrackException(ex,
                       new Dictionary<string, string> {
                           { "Name", Name},
-                          { "Target Project", me.Target.Name},
+                          { "Target Project", me.Target.Config.Name},
                           { "Target Collection", me.Target.Collection.Name },
                           { "Status", Status.ToString() }
                       },

--- a/src/VstsSyncMigrator.Core/Execution/ProcessingContext/WorkItemDelete.cs
+++ b/src/VstsSyncMigrator.Core/Execution/ProcessingContext/WorkItemDelete.cs
@@ -34,8 +34,8 @@ namespace VstsSyncMigrator.Engine
 			//////////////////////////////////////////////////
 			WorkItemStoreContext targetStore = new WorkItemStoreContext(me.Target, WorkItemStoreFlags.BypassRules);
             TfsQueryContext tfsqc = new TfsQueryContext(targetStore);
-            tfsqc.AddParameter("TeamProject", me.Target.Name);
-            tfsqc.Query = string.Format(@"SELECT [System.Id] FROM WorkItems WHERE  [System.TeamProject] = @TeamProject  AND [System.AreaPath] UNDER '{0}\_DeleteMe'", me.Target.Name);
+            tfsqc.AddParameter("TeamProject", me.Target.Config.Name);
+            tfsqc.Query = string.Format(@"SELECT [System.Id] FROM WorkItems WHERE  [System.TeamProject] = @TeamProject  AND [System.AreaPath] UNDER '{0}\_DeleteMe'", me.Target.Config.Name);
             WorkItemCollection  workitems = tfsqc.Execute();
             Trace.WriteLine(string.Format("Update {0} work items?", workitems.Count));
             //////////////////////////////////////////////////

--- a/src/VstsSyncMigrator.Core/Execution/ProcessingContext/WorkItemUpdate.cs
+++ b/src/VstsSyncMigrator.Core/Execution/ProcessingContext/WorkItemUpdate.cs
@@ -37,7 +37,7 @@ namespace VstsSyncMigrator.Engine
 			WorkItemStoreContext targetStore = new WorkItemStoreContext(me.Target, WorkItemStoreFlags.BypassRules);
 
             TfsQueryContext tfsqc = new TfsQueryContext(targetStore);
-            tfsqc.AddParameter("TeamProject", me.Target.Name);
+            tfsqc.AddParameter("TeamProject", me.Target.Config.Name);
             tfsqc.Query = string.Format(@"SELECT [System.Id], [System.Tags] FROM WorkItems WHERE [System.TeamProject] = @TeamProject {0} ORDER BY [System.ChangedDate] desc", _config.QueryBit);
             WorkItemCollection  workitems = tfsqc.Execute();
             Trace.WriteLine(string.Format("Update {0} work items?", workitems.Count));

--- a/src/VstsSyncMigrator.Core/Execution/ProcessingContext/WorkItemUpdateAreasAsTagsContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/ProcessingContext/WorkItemUpdateAreasAsTagsContext.cs
@@ -36,7 +36,7 @@ namespace VstsSyncMigrator.Engine
 			WorkItemStoreContext targetStore = new WorkItemStoreContext(me.Target, WorkItemStoreFlags.BypassRules);
 
             TfsQueryContext tfsqc = new TfsQueryContext(targetStore);
-            tfsqc.AddParameter("TeamProject", me.Target.Name);
+            tfsqc.AddParameter("TeamProject", me.Target.Config.Name);
             tfsqc.AddParameter("AreaPath", config.AreaIterationPath);
             tfsqc.Query = @"SELECT [System.Id], [System.Tags] FROM WorkItems WHERE  [System.TeamProject] = @TeamProject and [System.AreaPath] under @AreaPath";
             WorkItemCollection  workitems = tfsqc.Execute();

--- a/src/VstsSyncMigrator.Core/MigrationEngine.cs
+++ b/src/VstsSyncMigrator.Core/MigrationEngine.cs
@@ -38,14 +38,12 @@ namespace VstsSyncMigrator.Engine
             Telemetry.EnableTrace = config.TelemetryEnableTrace;
             if (config.Source != null)
             {
-                this.SetSource(new TeamProjectContext(config.Source.Collection, config.Source.Name));
+                this.SetSource(new TeamProjectContext(config.Source));
             }
             if (config.Target != null)
             {
-                this.SetTarget(new TeamProjectContext(config.Target.Collection, config.Target.Name));
+                this.SetTarget(new TeamProjectContext(config.Target));
             }           
-            this.SetReflectedWorkItemIdFieldName(config.ReflectedWorkItemIDFieldName);
-            this.SetSourceReflectedWorkItemIdFieldName(config.SourceReflectedWorkItemIDFieldName);
             if (config.FieldMaps != null)
             {
                 foreach (IFieldMapConfig fieldmapConfig in config.FieldMaps)
@@ -161,18 +159,6 @@ namespace VstsSyncMigrator.Engine
         {
             processors.Add(processor);
         }
-
-
-        public void SetReflectedWorkItemIdFieldName(string fieldName)
-        {
-            reflectedWorkItemIdFieldName = fieldName;
-        }
-
-        public void SetSourceReflectedWorkItemIdFieldName(string fieldName)
-        {
-            sourceReflectedWorkItemIdFieldName = fieldName;
-        }
-
 
         public void SetSource(ITeamProjectContext teamProjectContext)
         {


### PR DESCRIPTION
It seams that the Reflected Work Item ID was everywhere and was not getting passed correctly between Source and Target. I have move the ReflectedWorkItemIDFieldRef to the Team Project Config so that it does not need to be passed everywhere and will always be the right one in queries.