### PR TITLE
Sort order

### DIFF
--- a/src/VstsSyncMigrator.Core/Configuration/Processing/WorkItemRevisionReplayMigrationConfig.cs
+++ b/src/VstsSyncMigrator.Core/Configuration/Processing/WorkItemRevisionReplayMigrationConfig.cs
@@ -19,6 +19,7 @@ namespace VstsSyncMigrator.Engine.Configuration.Processing
         }
 
         public string QueryBit { get; set; }
+        public string OrderBit { get; set; } = "[System.ChangedDate] desc";
 
         /// <inheritdoc />
         public bool IsProcessorCompatible(IReadOnlyList<ITfsProcessingConfig> otherProcessors)

--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemRevisionReplayMigrationContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemRevisionReplayMigrationContext.cs
@@ -77,7 +77,7 @@ namespace VstsSyncMigrator.Engine
 			tfsqc.AddParameter("TeamProject", me.Source.Name);
 			tfsqc.Query =
 				string.Format(
-					@"SELECT [System.Id], [System.Tags] FROM WorkItems WHERE [System.TeamProject] = @TeamProject {0} ORDER BY [System.ChangedDate] desc",
+					@"SELECT [System.Id], [System.Tags] FROM WorkItems WHERE [System.TeamProject] = @TeamProject {0} ORDER BY [System.ChangedDate] asc",
 					_config.QueryBit);
 			var sourceWorkItems = tfsqc.Execute();
 			Trace.WriteLine($"Replay all revisions of {sourceWorkItems.Count} work items?", Name);

--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemRevisionReplayMigrationContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemRevisionReplayMigrationContext.cs
@@ -77,8 +77,8 @@ namespace VstsSyncMigrator.Engine
 			tfsqc.AddParameter("TeamProject", me.Source.Name);
 			tfsqc.Query =
 				string.Format(
-                    @"SELECT [System.Id], [System.Tags] FROM WorkItems WHERE [System.TeamProject] = @TeamProject {0} ORDER BY [System.CreatedDate] asc",
-					_config.QueryBit);
+                    @"SELECT [System.Id], [System.Tags] FROM WorkItems WHERE [System.TeamProject] = @TeamProject {0} ORDER BY {1}",
+					_config.QueryBit, _config.OrderBit);
 			var sourceWorkItems = tfsqc.Execute();
 			Trace.WriteLine($"Replay all revisions of {sourceWorkItems.Count} work items?", Name);
 

--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemRevisionReplayMigrationContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemRevisionReplayMigrationContext.cs
@@ -77,7 +77,7 @@ namespace VstsSyncMigrator.Engine
 			tfsqc.AddParameter("TeamProject", me.Source.Name);
 			tfsqc.Query =
 				string.Format(
-					@"SELECT [System.Id], [System.Tags] FROM WorkItems WHERE [System.TeamProject] = @TeamProject {0} ORDER BY [System.ChangedDate] asc",
+                    @"SELECT [System.Id], [System.Tags] FROM WorkItems WHERE [System.TeamProject] = @TeamProject {0} ORDER BY [System.CreatedDate] asc",
 					_config.QueryBit);
 			var sourceWorkItems = tfsqc.Execute();
 			Trace.WriteLine($"Replay all revisions of {sourceWorkItems.Count} work items?", Name);


### PR DESCRIPTION
When copying work items, the sort order was changed from `changeddate` to `createddate` so that items created in the target location would at least retain IDs that ascend as they get newer as sorting by ChangedDate makes this effectively a random.