### PR TITLE
Add TeamSettings migration

### DIFF
--- a/docs/Processors/TeamMigrationConfig.md
+++ b/docs/Processors/TeamMigrationConfig.md
@@ -10,3 +10,4 @@ This should be run after `VstsSyncMigrator.Engine.Configuration.Processing.NodeS
 | `Enabled`                     | Boolean | Active the processor if it true.                                           | false                                                                |
 | `ObjectType`                  | string  | The name of the processor                                                  | VstsSyncMigrator.Engine.Configuration.Processing.TeamMigrationConfig |
 | `EnableTeamSettingsMigration` | Boolean | Migrate original team settings after their creation on target team project | false                                                                |
+| `PrefixProjectToNodes`        | Boolean | Prefix your iterations and areas with the project name. If you have enabled this in `VstsSyncMigrator.Engine.Configuration.Processing.NodeStructuresMigrationConfig` you must do it here too. | false |

--- a/docs/Processors/TeamMigrationConfig.md
+++ b/docs/Processors/TeamMigrationConfig.md
@@ -5,7 +5,8 @@ This processor can migrate teams. (I currently don't know how much preview this 
 This should be run after `VstsSyncMigrator.Engine.Configuration.Processing.NodeStructuresMigrationConfig` and before all other processors.
 
 
-| Parameter name | Type    | Description                      | Default Value                            |
-|----------------|---------|----------------------------------|------------------------------------------|
-| `Enabled`      | Boolean | Active the processor if it true. | false                                    |
-| `ObjectType`   | string  | The name of the processor        | VstsSyncMigrator.Engine.Configuration.Processing.TeamMigrationConfig |
+| Parameter name                | Type    | Description                                                                | Default Value                                                        |
+|-------------------------------|---------|----------------------------------------------------------------------------|----------------------------------------------------------------------|
+| `Enabled`                     | Boolean | Active the processor if it true.                                           | false                                                                |
+| `ObjectType`                  | string  | The name of the processor                                                  | VstsSyncMigrator.Engine.Configuration.Processing.TeamMigrationConfig |
+| `EnableTeamSettingsMigration` | Boolean | Migrate original team settings after their creation on target team project | false                                                                |

--- a/src/VstsSyncMigrator.Core/Configuration/Processing/TeamMigrationConfig.cs
+++ b/src/VstsSyncMigrator.Core/Configuration/Processing/TeamMigrationConfig.cs
@@ -8,6 +8,8 @@ namespace VstsSyncMigrator.Engine.Configuration.Processing
         /// <inheritdoc />
         public bool Enabled { get; set; }
 
+        public bool PrefixProjectToNodes { get; set; }
+
         /// <summary>
         ///     Do we automatically migrate Team Settings after Team creation ?
         /// </summary>

--- a/src/VstsSyncMigrator.Core/Configuration/Processing/TeamMigrationConfig.cs
+++ b/src/VstsSyncMigrator.Core/Configuration/Processing/TeamMigrationConfig.cs
@@ -8,6 +8,11 @@ namespace VstsSyncMigrator.Engine.Configuration.Processing
         /// <inheritdoc />
         public bool Enabled { get; set; }
 
+        /// <summary>
+        ///     Do we automatically migrate Team Settings after Team creation ?
+        /// </summary>
+        public bool EnableTeamSettingsMigration { get; set; } = false;
+
         /// <inheritdoc />
         public Type Processor
         {

--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/TeamMigrationContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/TeamMigrationContext.cs
@@ -83,10 +83,28 @@ namespace VstsSyncMigrator.Engine
                                 continue;
                             }
 
-                            Trace.WriteLine(string.Format("-> Processing team '{0}' settings:", sourceTeam.Name));
-                            targetConfig.TeamSettings.BacklogIterationPath = sourceConfig.TeamSettings.BacklogIterationPath;
-                            targetConfig.TeamSettings.IterationPaths = sourceConfig.TeamSettings.IterationPaths;
-                            targetConfig.TeamSettings.TeamFieldValues = sourceConfig.TeamSettings.TeamFieldValues;
+                            Trace.WriteLine(string.Format("-> Settings found for team '{0}'..", sourceTeam.Name));
+                            if (_config.PrefixProjectToNodes)
+                            {
+                                targetConfig.TeamSettings.BacklogIterationPath = 
+                                    string.Format("{0}\\{1}", me.Source.Config.Name, sourceConfig.TeamSettings.BacklogIterationPath);
+                                targetConfig.TeamSettings.IterationPaths = sourceConfig.TeamSettings.IterationPaths
+                                    .Select(path => string.Format("{0}\\{1}", me.Source.Config.Name, path))
+                                    .ToArray();
+                                targetConfig.TeamSettings.TeamFieldValues = sourceConfig.TeamSettings.TeamFieldValues
+                                    .Select(field => new TeamFieldValue
+                                    {
+                                        IncludeChildren = field.IncludeChildren,
+                                        Value = string.Format("{0}\\{1}", me.Source.Config.Name, field.Value)
+                                    })
+                                    .ToArray();
+                            }
+                            else
+                            {
+                                targetConfig.TeamSettings.BacklogIterationPath = sourceConfig.TeamSettings.BacklogIterationPath;
+                                targetConfig.TeamSettings.IterationPaths = sourceConfig.TeamSettings.IterationPaths;
+                                targetConfig.TeamSettings.TeamFieldValues = sourceConfig.TeamSettings.TeamFieldValues;
+                            }
 
                             targetTSCS.SetTeamSettings(targetConfig.TeamId, targetConfig.TeamSettings);
                             Trace.WriteLine(string.Format("-> Team '{0}' settings... applied", targetConfig.TeamName));


### PR DESCRIPTION
Add the ability to migrate TeamSettings from source Team Project to target Team Project.
Configuration and doc has been updated.