### PR TITLE
Fix for edit name 

### DIFF
--- a/src/VstsSyncMigrator.Console/Program.cs
+++ b/src/VstsSyncMigrator.Console/Program.cs
@@ -185,11 +185,13 @@ namespace VstsSyncMigrator.ConsoleApp
                 ec = JsonConvert.DeserializeObject<EngineConfiguration>(configurationjson, 
                     new FieldMapConfigJsonConverter(),
                     new ProcessorConfigJsonConverter());
+#if !DEBUG
                 if (ec.Version != System.Reflection.Assembly.GetExecutingAssembly().GetName().Version.ToString(3))
                 {
                     Trace.WriteLine("The config version does not match the current version. There may be compatability issues and we recommend that you generate a new default config and then tranfer the settings accross.", "[Info]");
                     return 1;
                 }
+#endif
             }
             Trace.WriteLine("Config Loaded, creating engine", "[Info]");
 

--- a/src/VstsSyncMigrator.Core/Execution/OMatics/AttachmentOMatic.cs
+++ b/src/VstsSyncMigrator.Core/Execution/OMatics/AttachmentOMatic.cs
@@ -99,6 +99,7 @@ namespace VstsSyncMigrator.Core.Execution.OMatics
                 {
                     Attachment a = new Attachment(filepath);
                     targetWorkItem.Attachments.Add(a);
+                    targetWorkItem.Fields["System.ChangedBy"].Value = "Migration";
                     targetWorkItem.Save();
                 }
                 else

--- a/src/VstsSyncMigrator.Core/Execution/OMatics/WorkItemLinkOMatic.cs
+++ b/src/VstsSyncMigrator.Core/Execution/OMatics/WorkItemLinkOMatic.cs
@@ -98,7 +98,10 @@ namespace VstsSyncMigrator.Core.Execution.OMatics
             }
 
             if (wiTargetL.IsDirty)
+            {
+                wiTargetL.Fields["System.ChangedBy"].Value = "Migration";
                 wiTargetL.Save();
+            }
         }
 
         private void CreateExternalLink(ExternalLink sourceLink, WorkItem target)
@@ -114,6 +117,7 @@ namespace VstsSyncMigrator.Core.Execution.OMatics
                 ExternalLink el = new ExternalLink(sourceLink.ArtifactLinkType, sourceLink.LinkedArtifactUri);
                 el.Comment = sourceLink.Comment;
                 target.Links.Add(el);
+                target.Fields["System.ChangedBy"].Value = "Migration";
                 target.Save();
             }
             else
@@ -186,6 +190,7 @@ namespace VstsSyncMigrator.Core.Execution.OMatics
                         RelatedLink newRl = new RelatedLink(linkTypeEnd, wiTargetR.Id);
 
                         wiTargetL.Links.Add(newRl);
+                        wiTargetL.Fields["System.ChangedBy"].Value = "Migration";
                         wiTargetL.Save();
                         Trace.WriteLine(
                             string.Format(
@@ -260,6 +265,7 @@ namespace VstsSyncMigrator.Core.Execution.OMatics
                 Hyperlink hl = new Hyperlink(sourceLink.Location);
                 hl.Comment = sourceLink.Comment;
                 target.Links.Add(hl);
+                target.Fields["System.ChangedBy"].Value = "Migration";
                 target.Save();
             }
         }


### PR DESCRIPTION
Fix applies to set changed by name to "migration" for all attachement…and link saves.