### PR TITLE
FixForFilterQuery

### DIFF
--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemMigrationContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemMigrationContext.cs
@@ -129,7 +129,11 @@ namespace VstsSyncMigrator.Engine
             targetQuery.AddParameter("TeamProject", me.Target.Config.Name);
             targetQuery.Query =
                 string.Format(
-                    @"SELECT [System.Id], [{0}] FROM WorkItems WHERE [System.TeamProject] = @TeamProject ORDER BY [System.ChangedDate] desc", me.Target.Config.ReflectedWorkItemIDFieldName);
+                    @"SELECT [System.Id], [{0}] FROM WorkItems WHERE [System.TeamProject] = @TeamProject {1} ORDER BY {2}",
+                     me.Target.Config.ReflectedWorkItemIDFieldName,
+                    _config.QueryBit,
+                    _config.OrderBit
+                    );
             var targetFoundItems = targetQuery.Execute();
             var targetFoundIds = (from WorkItem twi in targetFoundItems select targetStore.GetReflectedWorkItemId(twi, me.Target.Config.ReflectedWorkItemIDFieldName)).ToList();
             //////////////////////////////////////////////////////////


### PR DESCRIPTION
This commit fixes the filter query to also use the QueryBit and OrderBit. This removes the likleyhood of hitting the Query limit.