### PR TITLE
Move to 2 digit version for config

### DIFF
--- a/src/VstsSyncMigrator.Console/Program.cs
+++ b/src/VstsSyncMigrator.Console/Program.cs
@@ -186,7 +186,7 @@ namespace VstsSyncMigrator.ConsoleApp
                     new FieldMapConfigJsonConverter(),
                     new ProcessorConfigJsonConverter());
 #if !DEBUG
-                if (ec.Version != System.Reflection.Assembly.GetExecutingAssembly().GetName().Version.ToString(3))
+                if (ec.Version != System.Reflection.Assembly.GetExecutingAssembly().GetName().Version.ToString(2))
                 {
                     Trace.WriteLine("The config version does not match the current version. There may be compatability issues and we recommend that you generate a new default config and then tranfer the settings accross.", "[Info]");
                     return 1;

--- a/src/VstsSyncMigrator.Core/Configuration/EngineConfiguration.cs
+++ b/src/VstsSyncMigrator.Core/Configuration/EngineConfiguration.cs
@@ -53,7 +53,7 @@ namespace VstsSyncMigrator.Engine.Configuration
         {
             EngineConfiguration ec = new EngineConfiguration();
             ec.TelemetryEnableTrace = false;
-            ec.Version = System.Reflection.Assembly.GetExecutingAssembly().GetName().Version.ToString(3);
+            ec.Version = System.Reflection.Assembly.GetExecutingAssembly().GetName().Version.ToString(2);
             ec.Source = new TeamProjectConfig() { Name = "DemoProjs", Collection = new Uri("https://dev.azure.com/psd45"), ReflectedWorkItemIDFieldName = "TfsMigrationTool.ReflectedWorkItemId" };
             ec.Target = new TeamProjectConfig() { Name = "DemoProjt", Collection = new Uri("https://dev.azure.com/psd46"), ReflectedWorkItemIDFieldName = "ProcessName.ReflectedWorkItemId" };
             ec.FieldMaps = new List<IFieldMapConfig>();


### PR DESCRIPTION
Changed version matching for config to 2 digits to get rid of the constant change. Need to remember to update version when changing configs. +semver: minor