### PR TITLE
Allow Cross-Project Linking of Work Items

### DIFF
--- a/src/VstsSyncMigrator.Console/Program.cs
+++ b/src/VstsSyncMigrator.Console/Program.cs
@@ -208,7 +208,7 @@ namespace VstsSyncMigrator.ConsoleApp
                 me = new MigrationEngine(ec);
             else
                 me = new MigrationEngine(ec, sourceCredentials, targetCredentials);
-            Console.Title = $"Azure DevOps Migration Tools: {System.IO.Path.GetFileName(opts.ConfigFile)} - {System.Reflection.Assembly.GetExecutingAssembly().GetName().Version.ToString(3)} - {ec.Source.Name} - {ec.Target.Name}";
+            Console.Title = $"Azure DevOps Migration Tools: {System.IO.Path.GetFileName(opts.ConfigFile)} - {System.Reflection.Assembly.GetExecutingAssembly().GetName().Version.ToString(3)} - {ec.Source.Project} - {ec.Target.Project}";
             Trace.WriteLine("Engine created, running...", "[Info]");
             me.Run();
             Trace.WriteLine("Run complete...", "[Info]");

--- a/src/VstsSyncMigrator.Core.Tests/EngineConfigurationTests.cs
+++ b/src/VstsSyncMigrator.Core.Tests/EngineConfigurationTests.cs
@@ -12,11 +12,11 @@ namespace _VstsSyncMigrator.Engine.Tests
         {
             EngineConfiguration ec = new EngineConfiguration();
             ec.TelemetryEnableTrace = true;
-            ec.Source = new TeamProjectConfig() { Name = "DemoProjs", Collection = new Uri("https://sdd2016.visualstudio.com/"), ReflectedWorkItemIDFieldName = "TfsMigrationTool.ReflectedWorkItemId" };
-            ec.Target = new TeamProjectConfig() { Name = "DemoProjt", Collection = new Uri("https://sdd2016.visualstudio.com/"), ReflectedWorkItemIDFieldName = "TfsMigrationTool.ReflectedWorkItemId" };
+            ec.Source = new TeamProjectConfig() { Project = "DemoProjs", Collection = new Uri("https://sdd2016.visualstudio.com/"), ReflectedWorkItemIDFieldName = "TfsMigrationTool.ReflectedWorkItemId" };
+            ec.Target = new TeamProjectConfig() { Project = "DemoProjt", Collection = new Uri("https://sdd2016.visualstudio.com/"), ReflectedWorkItemIDFieldName = "TfsMigrationTool.ReflectedWorkItemId" };
             Assert.IsNotNull(ec);
             Assert.IsNotNull(ec.Source);
-            Assert.AreEqual(ec.Source.Name, "DemoProjs");
+            Assert.AreEqual(ec.Source.Project, "DemoProjs");
         }
 
         [TestMethod]
@@ -25,7 +25,7 @@ namespace _VstsSyncMigrator.Engine.Tests
             EngineConfiguration ec = EngineConfiguration.GetDefault();
             Assert.IsNotNull(ec);
             Assert.IsNotNull(ec.Source);
-            Assert.AreEqual(ec.Source.Name, "DemoProjs");
+            Assert.AreEqual(ec.Source.Project, "DemoProjs");
         }
     }
 }

--- a/src/VstsSyncMigrator.Core/Configuration/EngineConfiguration.cs
+++ b/src/VstsSyncMigrator.Core/Configuration/EngineConfiguration.cs
@@ -29,7 +29,7 @@ namespace VstsSyncMigrator.Engine.Configuration
             AddTestPlansMigrationDefault(ec);
             ec.Processors.Add(new ImportProfilePictureConfig() { Enabled = false });
             ec.Processors.Add(new ExportProfilePictureFromADConfig() { Enabled = false });
-            ec.Processors.Add(new FixGitCommitLinksConfig() { Enabled = false, TargetRepository = ec.Target.Name });
+            ec.Processors.Add(new FixGitCommitLinksConfig() { Enabled = false, TargetRepository = ec.Target.Project });
             ec.Processors.Add(new WorkItemUpdateConfig() { Enabled = false, QueryBit = @"AND [TfsMigrationTool.ReflectedWorkItemId] = '' AND  [Microsoft.VSTS.Common.ClosedDate] = '' AND [System.WorkItemType] IN ('Shared Steps', 'Shared Parameter', 'Test Case', 'Requirement', 'Task', 'User Story', 'Bug')" });
             ec.Processors.Add(new WorkItemPostProcessingConfig() { Enabled = false, QueryBit = "AND [TfsMigrationTool.ReflectedWorkItemId] = '' ", WorkItemIDs = new List<int> { 1, 2, 3 } });
             ec.Processors.Add(new WorkItemDeleteConfig() { Enabled = false });
@@ -71,8 +71,8 @@ namespace VstsSyncMigrator.Engine.Configuration
             EngineConfiguration ec = new EngineConfiguration();
             ec.TelemetryEnableTrace = false;
             ec.Version = System.Reflection.Assembly.GetExecutingAssembly().GetName().Version.ToString(2);
-            ec.Source = new TeamProjectConfig() { Name = "DemoProjs", Collection = new Uri("https://dev.azure.com/psd45"), ReflectedWorkItemIDFieldName = "TfsMigrationTool.ReflectedWorkItemId" };
-            ec.Target = new TeamProjectConfig() { Name = "DemoProjt", Collection = new Uri("https://dev.azure.com/psd46"), ReflectedWorkItemIDFieldName = "ProcessName.ReflectedWorkItemId" };
+            ec.Source = new TeamProjectConfig() { Project = "DemoProjs", AllowCrossProjectLinking = false, Collection = new Uri("https://dev.azure.com/psd45"), ReflectedWorkItemIDFieldName = "TfsMigrationTool.ReflectedWorkItemId" };
+            ec.Target = new TeamProjectConfig() { Project = "DemoProjt", AllowCrossProjectLinking = false, Collection = new Uri("https://dev.azure.com/psd46"), ReflectedWorkItemIDFieldName = "ProcessName.ReflectedWorkItemId" };
             ec.FieldMaps = new List<IFieldMapConfig>();
             ec.WorkItemTypeDefinition = new Dictionary<string, string> {
                     { "sourceWorkItemTypeName", "targetWorkItemTypeName" }

--- a/src/VstsSyncMigrator.Core/Configuration/TeamProjectConfig.cs
+++ b/src/VstsSyncMigrator.Core/Configuration/TeamProjectConfig.cs
@@ -9,7 +9,8 @@ namespace VstsSyncMigrator.Engine.Configuration
     public class TeamProjectConfig
     {
         public Uri Collection { get; set; }
-        public string Name { get; set; }
+        public string Project { get; set; }
         public string ReflectedWorkItemIDFieldName { get; set; }
+        public bool AllowCrossProjectLinking { get; set; }
     }
 }

--- a/src/VstsSyncMigrator.Core/Execution/ComponentContext/TeamProjectContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/ComponentContext/TeamProjectContext.cs
@@ -50,8 +50,8 @@ namespace VstsSyncMigrator.Engine
             {
                 Telemetry.Current.TrackEvent("TeamProjectContext.Connect",
                     new Dictionary<string, string> {
-                          { "Name", Config.Name},
-                          { "Target Project", Config.Name},
+                          { "Name", Config.Project},
+                          { "Target Project", Config.Project},
                           { "Target Collection",Config.Collection.ToString() },
                            { "ReflectedWorkItemID Field Name",Config.ReflectedWorkItemIDFieldName }
                     });
@@ -79,7 +79,7 @@ namespace VstsSyncMigrator.Engine
                     Telemetry.Current.TrackException(ex,
                        new Dictionary<string, string> {
                             { "CollectionUrl", Config.Collection.ToString() },
-                            { "TeamProjectName",  Config.Name}
+                            { "TeamProjectName",  Config.Project}
                        },
                        new Dictionary<string, double> {
                             { "ConnectionTimer", connectionTimer.ElapsedMilliseconds }

--- a/src/VstsSyncMigrator.Core/Execution/ComponentContext/TestManagementContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/ComponentContext/TestManagementContext.cs
@@ -19,7 +19,7 @@ namespace VstsSyncMigrator.Engine.ComponentContext
             this.testPlanQueryBit = testPlanQueryBit;
             this.source = source;
             tms = (ITestManagementService)source.Collection.GetService(typeof(ITestManagementService));
-            Project = tms.GetTeamProject(source.Config.Name);
+            Project = tms.GetTeamProject(source.Config.Project);
         }
 
         internal ITestPlanCollection GetTestPlans()

--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/FakeProcessor.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/FakeProcessor.cs
@@ -33,7 +33,7 @@ namespace VstsSyncMigrator.Engine
 			//////////////////////////////////////////////////
 			WorkItemStoreContext sourceStore = new WorkItemStoreContext(me.Source, WorkItemStoreFlags.None);
             TfsQueryContext tfsqc = new TfsQueryContext(sourceStore);
-            tfsqc.AddParameter("TeamProject", me.Source.Config.Name);
+            tfsqc.AddParameter("TeamProject", me.Source.Config.Project);
             tfsqc.Query = @"SELECT [System.Id] FROM WorkItems WHERE  [System.TeamProject] = @TeamProject ";// AND [System.Id] = 188708 ";
             WorkItemCollection sourceWIS = tfsqc.Execute();
             Trace.WriteLine(string.Format("Migrate {0} work items?", sourceWIS.Count));

--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/MigrationContextBase.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/MigrationContextBase.cs
@@ -46,9 +46,9 @@ namespace VstsSyncMigrator.Engine
                     new Dictionary<string, string>
                     {
                         {"Name", Name},
-                        {"Target Project", me.Target.Config.Name},
+                        {"Target Project", me.Target.Config.Project},
                         {"Target Collection", me.Target.Collection.Name},
-                        {"Source Project", me.Source.Config.Name},
+                        {"Source Project", me.Source.Config.Project},
                         {"Source Collection", me.Source.Collection.Name},
                         {"Status", Status.ToString()}
                     },
@@ -70,7 +70,7 @@ namespace VstsSyncMigrator.Engine
         internal string NodeStructreSourceToTarget(string input)
         {
             //input = [sourceTeamProject]\[AreaPath]
-            return string.Format("{0}\\{1}", me.Target.Config.Name, input);
+            return string.Format("{0}\\{1}", me.Target.Config.Project, input);
 
 
             //Regex r = new Regex(source.Name, RegexOptions.IgnoreCase);
@@ -89,9 +89,9 @@ namespace VstsSyncMigrator.Engine
         internal string ReplaceFirstInstanceOf(string input)
         {
             //input = [sourceTeamProject]\[AreaPath]
-            var r = new Regex(me.Source.Config.Name, RegexOptions.IgnoreCase);
+            var r = new Regex(me.Source.Config.Project, RegexOptions.IgnoreCase);
             //// Output = [targetTeamProject]\[sourceTeamProject]\[AreaPath]
-            return r.Replace(input, me.Target.Config.Name, 1);
+            return r.Replace(input, me.Target.Config.Project, 1);
         }
 
         internal static void AddParameter(string name, IDictionary<string, string> store, string value)

--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/NodeStructuresMigrationContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/NodeStructuresMigrationContext.cs
@@ -29,7 +29,7 @@ namespace VstsSyncMigrator.Engine
         {
             //////////////////////////////////////////////////
             ICommonStructureService sourceCss = (ICommonStructureService)me.Source.Collection.GetService(typeof(ICommonStructureService));
-            ProjectInfo sourceProjectInfo = sourceCss.GetProjectFromName(me.Source.Config.Name);
+            ProjectInfo sourceProjectInfo = sourceCss.GetProjectFromName(me.Source.Config.Project);
             NodeInfo[] sourceNodes = sourceCss.ListStructures(sourceProjectInfo.Uri);
             //////////////////////////////////////////////////
             ICommonStructureService targetCss = (ICommonStructureService)me.Target.Collection.GetService(typeof(ICommonStructureService4));
@@ -45,10 +45,10 @@ namespace VstsSyncMigrator.Engine
         {
             NodeInfo sourceNode = (from n in sourceNodes where n.Path.Contains(treeType) select n).Single();
             XmlElement sourceTree = sourceCss.GetNodesXml(new string[] { sourceNode.Uri }, true);
-            NodeInfo structureParent = targetCss.GetNodeFromPath(string.Format("\\{0}\\{1}", me.Target.Config.Name, treeType));
+            NodeInfo structureParent = targetCss.GetNodeFromPath(string.Format("\\{0}\\{1}", me.Target.Config.Project, treeType));
             if (config.PrefixProjectToNodes)
             {
-                structureParent = CreateNode(targetCss, me.Source.Config.Name, structureParent);
+                structureParent = CreateNode(targetCss, me.Source.Config.Project, structureParent);
             }
             if (sourceTree.ChildNodes[0].HasChildNodes)
             {

--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/TeamMigrationContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/TeamMigrationContext.cs
@@ -39,7 +39,7 @@ namespace VstsSyncMigrator.Engine
             //////////////////////////////////////////////////
             WorkItemStoreContext sourceStore = new WorkItemStoreContext(me.Source, WorkItemStoreFlags.BypassRules);
             TfsTeamService sourceTS = me.Source.Collection.GetService<TfsTeamService>();
-            List<TeamFoundationTeam> sourceTL = sourceTS.QueryTeams(me.Source.Config.Name).ToList();
+            List<TeamFoundationTeam> sourceTL = sourceTS.QueryTeams(me.Source.Config.Project).ToList();
             Trace.WriteLine(string.Format("Found {0} teams in Source?", sourceTL.Count));
             var sourceTSCS = me.Source.Collection.GetService<TeamSettingsConfigurationService>();
             //////////////////////////////////////////////////
@@ -47,7 +47,7 @@ namespace VstsSyncMigrator.Engine
             Project targetProject = targetStore.GetProject();
             Trace.WriteLine(string.Format("Found target project as {0}", targetProject.Name));
             TfsTeamService targetTS = me.Target.Collection.GetService<TfsTeamService>();
-            List<TeamFoundationTeam> targetTL = targetTS.QueryTeams(me.Target.Config.Name).ToList();
+            List<TeamFoundationTeam> targetTL = targetTS.QueryTeams(me.Target.Config.Project).ToList();
             Trace.WriteLine(string.Format("Found {0} teams in Target?", targetTL.Count));
             var targetTSCS = me.Target.Collection.GetService<TeamSettingsConfigurationService>();
             //////////////////////////////////////////////////
@@ -87,15 +87,15 @@ namespace VstsSyncMigrator.Engine
                             if (_config.PrefixProjectToNodes)
                             {
                                 targetConfig.TeamSettings.BacklogIterationPath = 
-                                    string.Format("{0}\\{1}", me.Source.Config.Name, sourceConfig.TeamSettings.BacklogIterationPath);
+                                    string.Format("{0}\\{1}", me.Source.Config.Project, sourceConfig.TeamSettings.BacklogIterationPath);
                                 targetConfig.TeamSettings.IterationPaths = sourceConfig.TeamSettings.IterationPaths
-                                    .Select(path => string.Format("{0}\\{1}", me.Source.Config.Name, path))
+                                    .Select(path => string.Format("{0}\\{1}", me.Source.Config.Project, path))
                                     .ToArray();
                                 targetConfig.TeamSettings.TeamFieldValues = sourceConfig.TeamSettings.TeamFieldValues
                                     .Select(field => new TeamFieldValue
                                     {
                                         IncludeChildren = field.IncludeChildren,
-                                        Value = string.Format("{0}\\{1}", me.Source.Config.Name, field.Value)
+                                        Value = string.Format("{0}\\{1}", me.Source.Config.Project, field.Value)
                                     })
                                     .ToArray();
                             }
@@ -164,11 +164,11 @@ namespace VstsSyncMigrator.Engine
         {
             ///////////////////////////////////////////////////
             TeamSettings newTeamSettings = sourceTCfU.TeamSettings;
-            newTeamSettings.BacklogIterationPath = newTeamSettings.BacklogIterationPath.Replace(me.Source.Config.Name, me.Target.Config.Name);
+            newTeamSettings.BacklogIterationPath = newTeamSettings.BacklogIterationPath.Replace(me.Source.Config.Project, me.Target.Config.Project);
             List<string> newIterationPaths = new List<string>();
             foreach (var ip in newTeamSettings.IterationPaths)
             {
-                newIterationPaths.Add(ip.Replace(me.Source.Config.Name, me.Target.Config.Name));
+                newIterationPaths.Add(ip.Replace(me.Source.Config.Project, me.Target.Config.Project));
             }
             newTeamSettings.IterationPaths = newIterationPaths.ToArray();
 

--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/TestConfigurationsMigrationContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/TestConfigurationsMigrationContext.cs
@@ -45,7 +45,7 @@ namespace VstsSyncMigrator.Engine
                 {
                     Trace.WriteLine($"{sourceTestConf.Name} - Create new", Name);
                     targetTc = targetTmc.Project.TestConfigurations.Create();
-                    targetTc.AreaPath = sourceTestConf.AreaPath.Replace(me.Source.Config.Name, me.Target.Config.Name);
+                    targetTc.AreaPath = sourceTestConf.AreaPath.Replace(me.Source.Config.Project, me.Target.Config.Project);
                     targetTc.Description = sourceTestConf.Description;
                     targetTc.IsDefault = sourceTestConf.IsDefault;
                     targetTc.Name = sourceTestConf.Name;

--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/TestPlansAndSuitesMigrationContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/TestPlansAndSuitesMigrationContext.cs
@@ -280,14 +280,14 @@ namespace VstsSyncMigrator.Engine
 
             if (config.PrefixProjectToNodes)
             {
-                targetWI.AreaPath = string.Format(@"{0}\{1}", engine.Target.Config.Name, sourceWI.AreaPath);
-                targetWI.IterationPath = string.Format(@"{0}\{1}", engine.Target.Config.Name, sourceWI.IterationPath);
+                targetWI.AreaPath = string.Format(@"{0}\{1}", engine.Target.Config.Project, sourceWI.AreaPath);
+                targetWI.IterationPath = string.Format(@"{0}\{1}", engine.Target.Config.Project, sourceWI.IterationPath);
             }
             else
             {
-                var regex = new Regex(Regex.Escape(engine.Source.Config.Name));
-                targetWI.AreaPath = regex.Replace(sourceWI.AreaPath, engine.Target.Config.Name, 1);
-                targetWI.IterationPath = regex.Replace(sourceWI.IterationPath, engine.Target.Config.Name, 1);
+                var regex = new Regex(Regex.Escape(engine.Source.Config.Project));
+                targetWI.AreaPath = regex.Replace(sourceWI.AreaPath, engine.Target.Config.Project, 1);
+                targetWI.IterationPath = regex.Replace(sourceWI.IterationPath, engine.Target.Config.Project, 1);
             }
 
             me.ApplyFieldMappings(sourceWI, targetWI);
@@ -884,9 +884,9 @@ AddParameter("PlanId", parameters, targetPlan.Id.ToString());
                 Telemetry.Current.TrackException(ex,
                       new Dictionary<string, string> {
                           { "Name", Name},
-                          { "Target Project", me.Target.Config.Name},
+                          { "Target Project", me.Target.Config.Project},
                           { "Target Collection", me.Target.Collection.Name },
-                          { "Source Project", me.Source.Config.Name},
+                          { "Source Project", me.Source.Config.Project},
                           { "Source Collection", me.Source.Collection.Name },
                           { "Status", Status.ToString() },
                           { "Task", "SaveNewTestSuitToPlan" },
@@ -937,8 +937,8 @@ AddParameter("PlanId", parameters, targetPlan.Id.ToString());
 
             // Set area and iteration to root of the target project. 
             // We will set the correct values later, when we actually have a work item available
-            targetPlan.Iteration = engine.Target.Config.Name;
-            targetPlan.AreaPath = engine.Target.Config.Name;
+            targetPlan.Iteration = engine.Target.Config.Project;
+            targetPlan.AreaPath = engine.Target.Config.Project;
 
             // Remove testsettings reference because VSTS Sync doesn't support migrating these artifacts
             if (targetPlan.ManualTestSettingsId != 0)

--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemMigrationContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemMigrationContext.cs
@@ -88,7 +88,7 @@ namespace VstsSyncMigrator.Engine
             //////////////////////////////////////////////////
             var sourceStore = new WorkItemStoreContext(me.Source, WorkItemStoreFlags.BypassRules);
             var tfsqc = new TfsQueryContext(sourceStore);
-            tfsqc.AddParameter("TeamProject", me.Source.Config.Name);
+            tfsqc.AddParameter("TeamProject", me.Source.Config.Project);
             tfsqc.Query =
                 string.Format(
                     @"SELECT [System.Id], [System.Tags] FROM WorkItems WHERE [System.TeamProject] = @TeamProject {0} ORDER BY {1}",
@@ -492,7 +492,7 @@ namespace VstsSyncMigrator.Engine
         private List<WorkItem> FilterWorkItemsThatAlreadyExistInTarget(List<WorkItem> sourceWorkItems, WorkItemStoreContext targetStore)
         {
             var targetQuery = new TfsQueryContext(targetStore);
-            targetQuery.AddParameter("TeamProject", me.Target.Config.Name);
+            targetQuery.AddParameter("TeamProject", me.Target.Config.Project);
             targetQuery.Query =
                 string.Format(
                     @"SELECT [System.Id], [{0}] FROM WorkItems WHERE [System.TeamProject] = @TeamProject {1} ORDER BY {2}",
@@ -646,7 +646,7 @@ namespace VstsSyncMigrator.Engine
         private void ConfigValidation()
         {
             //Make sure that the ReflectedWorkItemId field name specified in the config exists in the target process, preferably on each work item type
-            var fields = _witClient.GetFieldsAsync(me.Target.Config.Name).Result;
+            var fields = _witClient.GetFieldsAsync(me.Target.Config.Project).Result;
             bool rwiidFieldExists = fields.Any(x => x.ReferenceName == me.Target.Config.ReflectedWorkItemIDFieldName || x.Name == me.Target.Config.ReflectedWorkItemIDFieldName);
             Debug.WriteLine($"Found {fields.Count.ToString("n0")} work item fields.");
             if (rwiidFieldExists)

--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemPostProcessingContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemPostProcessingContext.cs
@@ -54,7 +54,7 @@ namespace VstsSyncMigrator.Engine
 			//////////////////////////////////////////////////
 			WorkItemStoreContext sourceStore = new WorkItemStoreContext(me.Source, WorkItemStoreFlags.None);
             TfsQueryContext tfsqc = new TfsQueryContext(sourceStore);
-            tfsqc.AddParameter("TeamProject", me.Source.Config.Name);
+            tfsqc.AddParameter("TeamProject", me.Source.Config.Project);
 
             //Builds the constraint part of the query
             string constraints = BuildQueryBitConstraints();

--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemQueryMigrationContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemQueryMigrationContext.cs
@@ -64,8 +64,8 @@ namespace VstsSyncMigrator.Engine
 			var sourceStore = new WorkItemStoreContext(me.Source, WorkItemStoreFlags.None);
             var targetStore = new WorkItemStoreContext(me.Target, WorkItemStoreFlags.None);
 
-            var sourceQueryHierarchy = sourceStore.Store.Projects[me.Source.Config.Name].QueryHierarchy;
-            var targetQueryHierarchy = targetStore.Store.Projects[me.Target.Config.Name].QueryHierarchy;
+            var sourceQueryHierarchy = sourceStore.Store.Projects[me.Source.Config.Project].QueryHierarchy;
+            var targetQueryHierarchy = targetStore.Store.Projects[me.Target.Config.Project].QueryHierarchy;
 
             Trace.WriteLine(string.Format("Found {0} root level child WIQ folders", sourceQueryHierarchy.Count));
             //////////////////////////////////////////////////
@@ -99,13 +99,13 @@ namespace VstsSyncMigrator.Engine
                 this.totalFoldersAttempted++;
 
                 // we need to replace the team project name in folder names as it included in query paths
-                var requiredPath = sourceFolder.Path.Replace($"{me.Source.Config.Name}/", $"{me.Target.Config.Name}/");
+                var requiredPath = sourceFolder.Path.Replace($"{me.Source.Config.Project}/", $"{me.Target.Config.Project}/");
 
                 // Is the project name to be used in the migration as an extra folder level?
                 if (config.PrefixProjectToNodes == true)
                 {
                     // we need to inject the team name as a folder in the structure
-                    requiredPath = requiredPath.Replace(config.SharedFolderName, $"{config.SharedFolderName}/{me.Source.Config.Name}");
+                    requiredPath = requiredPath.Replace(config.SharedFolderName, $"{config.SharedFolderName}/{me.Source.Config.Project}");
 
                     // If on the root level we need to check that the extra folder has already been added
                     if (sourceFolder.Path.Count(f => f == '/') == 1)
@@ -115,8 +115,8 @@ namespace VstsSyncMigrator.Engine
                         if (extraFolder == null)
                         {
                             // we are at the root level on the first pass and need to create the extra folder for the team name
-                            Trace.WriteLine($"Adding a folder '{me.Source.Config.Name}'");
-                            extraFolder = new QueryFolder(me.Source.Config.Name);
+                            Trace.WriteLine($"Adding a folder '{me.Source.Config.Project}'");
+                            extraFolder = new QueryFolder(me.Source.Config.Project);
                             targetSharedFolderRoot.Add(extraFolder);
                             targetHierarchy.Save(); // moved the save here a more immediate and relavent error message
                         }
@@ -172,12 +172,12 @@ namespace VstsSyncMigrator.Engine
             else
             {
                 // Sort out any path issues in the quertText
-                var fixedQueryText = query.QueryText.Replace($"'{me.Source.Config.Name}", $"'{me.Target.Config.Name}"); // the ' should only items at the start of areapath etc.
+                var fixedQueryText = query.QueryText.Replace($"'{me.Source.Config.Project}", $"'{me.Target.Config.Project}"); // the ' should only items at the start of areapath etc.
 
                 if (config.PrefixProjectToNodes)
                 {
                     // we need to inject the team name as a folder in the structure too
-                    fixedQueryText = fixedQueryText.Replace($"{me.Target.Config.Name}\\", $"{me.Target.Config.Name}\\{me.Source.Config.Name}\\");
+                    fixedQueryText = fixedQueryText.Replace($"{me.Target.Config.Project}\\", $"{me.Target.Config.Project}\\{me.Source.Config.Project}\\");
                 }
 
                 // you cannot just add an item from one store to another, we need to create a new object

--- a/src/VstsSyncMigrator.Core/Execution/OMatics/RepoOMatic.cs
+++ b/src/VstsSyncMigrator.Core/Execution/OMatics/RepoOMatic.cs
@@ -26,10 +26,10 @@ namespace VstsSyncMigrator.Core.Execution.OMatics
         {
             migrationEngine = me;
             sourceRepoService = me.Source.Collection.GetService<GitRepositoryService>();
-            sourceRepos = sourceRepoService.QueryRepositories(me.Source.Config.Name);
+            sourceRepos = sourceRepoService.QueryRepositories(me.Source.Config.Project);
             //////////////////////////////////////////////////
             targetRepoService = me.Target.Collection.GetService<GitRepositoryService>();
-            targetRepos = targetRepoService.QueryRepositories(me.Target.Config.Name);
+            targetRepos = targetRepoService.QueryRepositories(me.Target.Config.Project);
             gitWits = new List<string>
                 {
                     "Branch",
@@ -56,7 +56,7 @@ namespace VstsSyncMigrator.Core.Execution.OMatics
                         
                         string targetRepoName = GetTargetRepoName(migrationEngine.GitRepoMappings, sourceRepoInfo);
                         string sourceProjectName = sourceRepoInfo.GitRepo.ProjectReference.Name;
-                        string targetProjectName = migrationEngine.Target.Config.Name;
+                        string targetProjectName = migrationEngine.Target.Config.Project;
 
                         GitRepositoryInfo targetRepoInfo = GitRepositoryInfo.Create(targetRepoName, sourceRepoInfo, migrationEngine, targetRepos);
                
@@ -218,12 +218,12 @@ namespace VstsSyncMigrator.Core.Execution.OMatics
         {
             GitRepository gitRepo;
             // Source and Target project names match
-            if (migrationEngine.Source.Config.Name == migrationEngine.Target.Config.Name)
+            if (migrationEngine.Source.Config.Project == migrationEngine.Target.Config.Project)
             {
                 gitRepo = (from g in targetRepos
                               where
                               g.Name == targetRepoName &&
-                              g.ProjectReference.Name == migrationEngine.Source.Config.Name
+                              g.ProjectReference.Name == migrationEngine.Source.Config.Project
                               select g).SingleOrDefault();
             }
             // Source and Target project names do not match
@@ -232,7 +232,7 @@ namespace VstsSyncMigrator.Core.Execution.OMatics
                 gitRepo = (from g in targetRepos
                               where
                               g.Name == targetRepoName &&
-                              g.ProjectReference.Name != migrationEngine.Source.Config.Name
+                              g.ProjectReference.Name != migrationEngine.Source.Config.Project
                               select g).SingleOrDefault();
             }
             return new GitRepositoryInfo(sourceRepoInfo.CommitID, gitRepo.Id.ToString(), gitRepo);

--- a/src/VstsSyncMigrator.Core/Execution/ProcessingContext/CreateTeamFolders.cs
+++ b/src/VstsSyncMigrator.Core/Execution/ProcessingContext/CreateTeamFolders.cs
@@ -38,8 +38,8 @@ namespace VstsSyncMigrator.Engine
             TfsQueryContext tfsqc = new TfsQueryContext(targetStore);
 
             TfsTeamService teamService = me.Target.Collection.GetService<TfsTeamService>();
-            QueryHierarchy qh = targetStore.Store.Projects[me.Target.Config.Name].QueryHierarchy;
-            List<TeamFoundationTeam> teamList = teamService.QueryTeams(me.Target.Config.Name).ToList();
+            QueryHierarchy qh = targetStore.Store.Projects[me.Target.Config.Project].QueryHierarchy;
+            List<TeamFoundationTeam> teamList = teamService.QueryTeams(me.Target.Config.Project).ToList();
 
             Trace.WriteLine(string.Format("Found {0} teams?", teamList.Count));
             //////////////////////////////////////////////////

--- a/src/VstsSyncMigrator.Core/Execution/ProcessingContext/ExportTeamList.cs
+++ b/src/VstsSyncMigrator.Core/Execution/ProcessingContext/ExportTeamList.cs
@@ -37,7 +37,7 @@ namespace VstsSyncMigrator.Engine
 			//////////////////////////////////////////////////
 			// Retrieve the project URI. Needed to enumerate teams.     
 			var css4 = me.Target.Collection.GetService<ICommonStructureService4>();
-            ProjectInfo projectInfo = css4.GetProjectFromName(me.Target.Config.Name);
+            ProjectInfo projectInfo = css4.GetProjectFromName(me.Target.Config.Project);
             // Retrieve a list of all teams on the project.     
             TfsTeamService teamService = me.Target.Collection.GetService<TfsTeamService>();
 

--- a/src/VstsSyncMigrator.Core/Execution/ProcessingContext/FixGitCommitLinks.cs
+++ b/src/VstsSyncMigrator.Core/Execution/ProcessingContext/FixGitCommitLinks.cs
@@ -38,7 +38,7 @@ namespace VstsSyncMigrator.Engine
 			//////////////////////////////////////////////////
             WorkItemStoreContext targetStore = new WorkItemStoreContext(me.Target, WorkItemStoreFlags.BypassRules);
             var targetQuery = new TfsQueryContext(targetStore);
-            targetQuery.AddParameter("TeamProject", me.Target.Config.Name);
+            targetQuery.AddParameter("TeamProject", me.Target.Config.Project);
             targetQuery.Query =
                 string.Format(
                     @"SELECT [System.Id] FROM WorkItems WHERE [System.TeamProject] = @TeamProject {0} ORDER BY {1}",

--- a/src/VstsSyncMigrator.Core/Execution/ProcessingContext/ProcessingContextBase.cs
+++ b/src/VstsSyncMigrator.Core/Execution/ProcessingContext/ProcessingContextBase.cs
@@ -47,7 +47,7 @@ namespace VstsSyncMigrator.Engine
                 Telemetry.Current.TrackEvent("ProcessingContextComplete",
                     new Dictionary<string, string> {
                         { "Name", Name},
-                        { "Target Project", me.Target.Config.Name},
+                        { "Target Project", me.Target.Config.Project},
                         { "Target Collection", me.Target.Collection.Name },
                         { "Status", Status.ToString() }
                     },
@@ -63,7 +63,7 @@ namespace VstsSyncMigrator.Engine
                 Telemetry.Current.TrackException(ex,
                       new Dictionary<string, string> {
                           { "Name", Name},
-                          { "Target Project", me.Target.Config.Name},
+                          { "Target Project", me.Target.Config.Project},
                           { "Target Collection", me.Target.Collection.Name },
                           { "Status", Status.ToString() }
                       },

--- a/src/VstsSyncMigrator.Core/Execution/ProcessingContext/WorkItemDelete.cs
+++ b/src/VstsSyncMigrator.Core/Execution/ProcessingContext/WorkItemDelete.cs
@@ -34,8 +34,8 @@ namespace VstsSyncMigrator.Engine
 			//////////////////////////////////////////////////
 			WorkItemStoreContext targetStore = new WorkItemStoreContext(me.Target, WorkItemStoreFlags.BypassRules);
             TfsQueryContext tfsqc = new TfsQueryContext(targetStore);
-            tfsqc.AddParameter("TeamProject", me.Target.Config.Name);
-            tfsqc.Query = string.Format(@"SELECT [System.Id] FROM WorkItems WHERE  [System.TeamProject] = @TeamProject  AND [System.AreaPath] UNDER '{0}\_DeleteMe'", me.Target.Config.Name);
+            tfsqc.AddParameter("TeamProject", me.Target.Config.Project);
+            tfsqc.Query = string.Format(@"SELECT [System.Id] FROM WorkItems WHERE  [System.TeamProject] = @TeamProject  AND [System.AreaPath] UNDER '{0}\_DeleteMe'", me.Target.Config.Project);
             WorkItemCollection  workitems = tfsqc.Execute();
             Trace.WriteLine(string.Format("Update {0} work items?", workitems.Count));
             //////////////////////////////////////////////////

--- a/src/VstsSyncMigrator.Core/Execution/ProcessingContext/WorkItemUpdate.cs
+++ b/src/VstsSyncMigrator.Core/Execution/ProcessingContext/WorkItemUpdate.cs
@@ -37,7 +37,7 @@ namespace VstsSyncMigrator.Engine
 			WorkItemStoreContext targetStore = new WorkItemStoreContext(me.Target, WorkItemStoreFlags.BypassRules);
 
             TfsQueryContext tfsqc = new TfsQueryContext(targetStore);
-            tfsqc.AddParameter("TeamProject", me.Target.Config.Name);
+            tfsqc.AddParameter("TeamProject", me.Target.Config.Project);
             tfsqc.Query = string.Format(@"SELECT [System.Id], [System.Tags] FROM WorkItems WHERE [System.TeamProject] = @TeamProject {0} ORDER BY [System.ChangedDate] desc", _config.QueryBit);
             WorkItemCollection  workitems = tfsqc.Execute();
             Trace.WriteLine(string.Format("Update {0} work items?", workitems.Count));

--- a/src/VstsSyncMigrator.Core/Execution/ProcessingContext/WorkItemUpdateAreasAsTagsContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/ProcessingContext/WorkItemUpdateAreasAsTagsContext.cs
@@ -36,7 +36,7 @@ namespace VstsSyncMigrator.Engine
 			WorkItemStoreContext targetStore = new WorkItemStoreContext(me.Target, WorkItemStoreFlags.BypassRules);
 
             TfsQueryContext tfsqc = new TfsQueryContext(targetStore);
-            tfsqc.AddParameter("TeamProject", me.Target.Config.Name);
+            tfsqc.AddParameter("TeamProject", me.Target.Config.Project);
             tfsqc.AddParameter("AreaPath", config.AreaIterationPath);
             tfsqc.Query = @"SELECT [System.Id], [System.Tags] FROM WorkItems WHERE  [System.TeamProject] = @TeamProject and [System.AreaPath] under @AreaPath";
             WorkItemCollection  workitems = tfsqc.Execute();


### PR DESCRIPTION
Added the ability to enable cross-project work item linking as per #354. This is slightly dangerous as you may have left over trial migrations with the RelectedWorkItemID set and this will find them. +semver: minor 

WARNING: Make sure you delete all prior runs or blank the RelectedWorkItemID field.