### PR TITLE
Links from workItem to repo in different projects

### DIFF
--- a/src/VstsSyncMigrator.Core/Execution/ComponentContext/WorkItemStoreContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/ComponentContext/WorkItemStoreContext.cs
@@ -149,7 +149,7 @@ namespace VstsSyncMigrator.Engine
             StringBuilder s = new StringBuilder();
             s.Append("SELECT [System.Id] FROM WorkItems");
             s.Append(" WHERE ");
-            if (teamProjectContext.Config.AllowCrossProjectLinking)
+            if (!teamProjectContext.Config.AllowCrossProjectLinking)
             {
                 s.Append("[System.TeamProject]=@TeamProject AND ");
                 query.AddParameter("TeamProject", this.teamProjectContext.Config.Project);

--- a/src/VstsSyncMigrator.Core/Execution/OMatics/RepoOMatic.cs
+++ b/src/VstsSyncMigrator.Core/Execution/OMatics/RepoOMatic.cs
@@ -18,6 +18,7 @@ namespace VstsSyncMigrator.Core.Execution.OMatics
         MigrationEngine migrationEngine;
         GitRepositoryService sourceRepoService;
         IList<GitRepository> sourceRepos;
+        IList<GitRepository> allSourceRepos;
         GitRepositoryService targetRepoService;
         IList<GitRepository> targetRepos;
         List<string> gitWits;
@@ -27,6 +28,7 @@ namespace VstsSyncMigrator.Core.Execution.OMatics
             migrationEngine = me;
             sourceRepoService = me.Source.Collection.GetService<GitRepositoryService>();
             sourceRepos = sourceRepoService.QueryRepositories(me.Source.Config.Project);
+            allSourceRepos = sourceRepoService.QueryRepositories("");
             //////////////////////////////////////////////////
             targetRepoService = me.Target.Collection.GetService<GitRepositoryService>();
             targetRepos = targetRepoService.QueryRepositories(me.Target.Config.Project);
@@ -113,7 +115,8 @@ namespace VstsSyncMigrator.Core.Execution.OMatics
                     }
                     else
                     {
-                        Trace.WriteLine($"FAIL could not find source git repo");
+                        GitRepositoryInfo anyProjectSourceRepoInfo = GitRepositoryInfo.Create(el, allSourceRepos);
+                        Trace.WriteLine($"FAIL could not find source git repo - repo referenced: {anyProjectSourceRepoInfo?.GitRepo?.ProjectReference?.Name}/{anyProjectSourceRepoInfo?.GitRepo?.Name}");
                     }
                 }
             }


### PR DESCRIPTION
I've converted projects (on premise DevOps Server 2019 update1) with LinkMigration=true.

Source project workItems were linked to repos in different projects from the same source collection. In my first scenario all destination repos were in the same target project.

Next for different scenario, some of target repos were located in the same target collection in different project so I have added the second commit. In that commit I also simplified method
RepoOMatic.Create(string targetRepoName, GitRepositoryInfo sourceRepoInfo , MigrationEngine migrationEngine, IList<GitRepository> targetRepos)
cause I believe there were some now unused code remnants.

Please note that for both scenarios (source as well as target) I've added a condition: external repo link is migrated only if linked repo is listed in GitRepoMappings. I wished to prevent unwanted/too automatic behaviour and didn't want to add another configuration option.

With these changes I've successfully accomplished my migration task.