### PR TITLE
Bugfix: Ignore unknown repo types (i.e. Git/PullRequestId) to process further links

### DIFF
--- a/src/VstsSyncMigrator.Core/Execution/OMatics/RepoOMatic.cs
+++ b/src/VstsSyncMigrator.Core/Execution/OMatics/RepoOMatic.cs
@@ -55,6 +55,13 @@ namespace VstsSyncMigrator.Core.Execution.OMatics
                     ExternalLink el = (ExternalLink)l;
 
                     GitRepositoryInfo sourceRepoInfo = GitRepositoryInfo.Create(el, sourceRepos, migrationEngine, sourceWorkItem?.Project?.Name);
+                    
+                    // if sourceRepo is null ignore this link and keep processing further links
+                    if (sourceRepoInfo == null) 
+                    {
+                        continue;
+                    }
+
                     // if repo was not found in source project, try to find it by repoId in the whole project collection
                     if (sourceRepoInfo.GitRepo == null)
                     {


### PR DESCRIPTION
**Error:** When migrating work items with git PR links, these links throw errors and further (commit) links for this work item won't be processed.

**Solution:** Ignore and keep unknown links without throwing an error to process further links.

**Further information:** In DetermineFromLink a PR ("Git/PullRequestId") set RepistoryType to unknown (only allows "git/commit"). Unknown can't be processed by GitRepositoryInfo.Create (currently evaluates only Git and TFVC) and returns a null. sourceRepoInfo is set to null which breaks the loop.

**Error message:**
```
Cannot determine repository type from external link: vstfs:///Git/PullRequestId/053f67f5-24ab-4d51-b15e-49b2c62d1a2b%2ffab2c49f-af08-491a-866f-85e7ed774611%2f21
[Product Backlog Item][Complete:1/2][sid:3095  |Rev:5  ][tid:null   | ...FAILED to Save
...
[Product Backlog Item][Complete:1/2][sid:3095  |Rev:5  ][tid:null   | System.NullReferenceException: Object reference not set to an instance of an object.
   at VstsSyncMigrator.Core.Execution.OMatics.RepoOMatic.FixExternalLinks(WorkItem targetWorkItem, WorkItemStoreContexttargetStore, WorkItem sourceWorkItem, Boolean save) in D:\a\1\s\src\VstsSyncMigrator.Core\Execution\OMatics\RepoOMatic.cs:line 57
   at VstsSyncMigrator.Engine.WorkItemMigrationContext.ProcessWorkItemLinks(WorkItemStoreContext sourceStore, WorkItemStoreContext targetStore, WorkItem sourceWorkItem, WorkItem targetWorkItem, Boolean save) in D:\a\1\s\src\VstsSyncMigrator.Core\Execution\MigrationContext\WorkItemMigrationContext.cs:line 628
   at VstsSyncMigrator.Engine.WorkItemMigrationContext.ReplayRevisions(List`1 revisionsToMigrate, WorkItem sourceWorkItem, WorkItem targetWorkItem, Project destProject, WorkItemStoreContext sourceStore, Int32 current, WorkItemStoreContext targetStore) in D:\a\1\s\src\VstsSyncMigrator.Core\Execution\MigrationContext\WorkItemMigrationContext.cs:line 362
[Product Backlog Item][Complete:1/2][sid:3095  |Rev:5  ][tid:null   | Average time of 2:243 seconds per work item and 0 hours 0 minutes 4:486 seconds estimated to completion
```