### PR TITLE
'SkipToFinalRevisedWorkItemType' feature added to handle scenario when changing Work Item Type in revisions

### DIFF
--- a/docs/Processors/WorkItemMigrationConfig.md
+++ b/docs/Processors/WorkItemMigrationConfig.md
@@ -35,5 +35,5 @@ It will migrate work items using a tip or replay migrator as well as Attachments
 | _{NEW}_ `FilterWorkItemsThatAlreadyExistInTarget` | Boolean | Instad of using the `UpdateSoureReflectedId` setting this load all of the work items already saved to the Target and removes them from the Source work item list prior to commensing the run. While this may take some time in large data sets it reduces the time of the overall migration significantly if you need to restart. | true |
 | `QueryBit`                           | string  | A work item query to select only important work items. To migrate all leave this empty. |                                          |
 | `OrderBit` | string | A work item query to affect the order in which the work items are migrated. Don't leave this empty. | [System.ChangedDate] desc
-| `SkipToFinalRevisedWorkItemType` | Boolean | If enabled, when a revision is found that changes the work item type it will use the most recent revision work item type when migrating the initial work item. | false
+| `SkipToFinalRevisedWorkItemType` | Boolean | If enabled, when a revision is found that changes the work item type it will use the most recent revision work item type when migrating the initial work item. This should only be enabled for migrations from Azure DevOps Service to Azure DevOps Server. | false
 

--- a/docs/Processors/WorkItemMigrationConfig.md
+++ b/docs/Processors/WorkItemMigrationConfig.md
@@ -35,4 +35,5 @@ It will migrate work items using a tip or replay migrator as well as Attachments
 | _{NEW}_ `FilterWorkItemsThatAlreadyExistInTarget` | Boolean | Instad of using the `UpdateSoureReflectedId` setting this load all of the work items already saved to the Target and removes them from the Source work item list prior to commensing the run. While this may take some time in large data sets it reduces the time of the overall migration significantly if you need to restart. | true |
 | `QueryBit`                           | string  | A work item query to select only important work items. To migrate all leave this empty. |                                          |
 | `OrderBit` | string | A work item query to affect the order in which the work items are migrated. Don't leave this empty. | [System.ChangedDate] desc
+| `SkipToFinalRevisedWorkItemType` | Boolean | If enabled, when a revision is found that changes the work item type it will use the most recent revision work item type when migrating the initial work item. | false
 

--- a/src/VstsSyncMigrator.Core/Configuration/Processing/WorkItemMigrationConfig.cs
+++ b/src/VstsSyncMigrator.Core/Configuration/Processing/WorkItemMigrationConfig.cs
@@ -27,6 +27,8 @@ namespace VstsSyncMigrator.Engine.Configuration.Processing
 
         public bool FixHtmlAttachmentLinks { get; set; }
 
+        public bool SkipToFinalRevisedWorkItemType { get; set; }
+
         public int WorkItemCreateRetryLimit { get; set; }
 
         public bool FilterWorkItemsThatAlreadyExistInTarget { get; set; }


### PR DESCRIPTION
**Issue:**
When migrating work items from Azure DevOps Services to Azure DevOps Server that contain revisions that changed the work item type you receive the following error:
```
TF401326: Invalid field status 'InvalidNotOldValue' for field 'System.WorkItemType'"
```
This is described here.
https://twitter.com/fokkoveegens/status/1206610220790820866

I've adjusted it so that it uses the latest revision's Work Item Type when creating it's initial shell work item, I think that's likely the work item type that is where you want to land anyway.