### PR TITLE
Fix field blank map

### DIFF
--- a/src/VstsSyncMigrator.Core/Configuration/FieldMap/FieldBlankMapConfig.cs
+++ b/src/VstsSyncMigrator.Core/Configuration/FieldMap/FieldBlankMapConfig.cs
@@ -1,13 +1,9 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using VstsSyncMigrator.Engine.ComponentContext;
 
 namespace VstsSyncMigrator.Engine.Configuration.FieldMap
 {
-   public class FieldBlankMapConfig : IFieldMapConfig
+    public class FieldBlankMapConfig : IFieldMapConfig
     {
         public string WorkItemTypeName { get; set; }
         public string targetField { get; set; }

--- a/src/VstsSyncMigrator.Core/Execution/FieldMaps/FieldBlankMap.cs
+++ b/src/VstsSyncMigrator.Core/Execution/FieldMaps/FieldBlankMap.cs
@@ -17,8 +17,7 @@ namespace VstsSyncMigrator.Engine.ComponentContext
 
         internal override void InternalExecute(WorkItem source, WorkItem target)
         {
-            var targetField = target.Fields[config.targetField];
-            if (targetField != null)
+            if (target.Fields.Contains(config.targetField))
             {
                 target.Fields[config.targetField].Value = null;
                 Trace.WriteLine(string.Format("  [UPDATE] field mapped {0}:{1} to {2} blanked", source.Id, target.Id, this.config.targetField));

--- a/src/VstsSyncMigrator.Core/Execution/FieldMaps/FieldBlankMap.cs
+++ b/src/VstsSyncMigrator.Core/Execution/FieldMaps/FieldBlankMap.cs
@@ -1,10 +1,4 @@
-﻿//New COmment
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.TeamFoundation.WorkItemTracking.Client;
+﻿using Microsoft.TeamFoundation.WorkItemTracking.Client;
 using System.Diagnostics;
 using VstsSyncMigrator.Engine.Configuration.FieldMap;
 
@@ -23,9 +17,10 @@ namespace VstsSyncMigrator.Engine.ComponentContext
 
         internal override void InternalExecute(WorkItem source, WorkItem target)
         {
-            if (target.Fields.Contains(config.targetField))
-            { 
-                target.Fields[config.targetField].Value = "";
+            var targetField = target.Fields[config.targetField];
+            if (targetField != null)
+            {
+                target.Fields[config.targetField].Value = null;
                 Trace.WriteLine(string.Format("  [UPDATE] field mapped {0}:{1} to {2} blanked", source.Id, target.Id, this.config.targetField));
             }
         }


### PR DESCRIPTION
I had trouble blanking out the Microsoft.VSTS.Common.ActivatedDate field, using `""` would throw an error. Setting the value to null instead seems to work.