### PR TITLE
Fixed typo blocking FieldToTagMap from working?

### DIFF
--- a/src/VstsSyncMigrator.Core/Execution/FieldMaps/FieldToTagFieldMap.cs
+++ b/src/VstsSyncMigrator.Core/Execution/FieldMaps/FieldToTagFieldMap.cs
@@ -36,7 +36,7 @@ namespace VstsSyncMigrator.Engine
                 if (source.Fields[this.config.sourceField].Value != null)
                 {
                     string value = source.Fields[this.config.sourceField].Value.ToString();
-                    if (string.IsNullOrEmpty(value))
+                    if (!string.IsNullOrEmpty(value))
                     {
                         if (string.IsNullOrEmpty(config.formatExpression))
                         {


### PR DESCRIPTION
Couldn't seem to get FieldToTagMap working. After looking at commit history I think this was a typo? It should only do the mapping if there is a source.Fields[this.config.soruceField].Value to work with.