### PR TITLE
Changing PrefixProjectToNodes to false

### DIFF
--- a/src/VstsSyncMigrator.Core/Configuration/Processing/TestPlansAndSuitesMigrationConfig.cs
+++ b/src/VstsSyncMigrator.Core/Configuration/Processing/TestPlansAndSuitesMigrationConfig.cs
@@ -28,7 +28,6 @@ namespace VstsSyncMigrator.Engine.Configuration.Processing
 
         public TestPlansAndSuitesMigrationConfig()
         {
-            PrefixProjectToNodes = true;
         }
     }
 }


### PR DESCRIPTION
PrefixProjectToNodes is supposed to be false by default according to the documentation (https://github.com/nkdAgility/azure-devops-migration-tools/blob/master/docs/Processors/TestPlansAndSuitesMigrationConfig.md).