### PR TITLE
Shared Queries migration with field map #527

### DIFF
--- a/src/VstsSyncMigrator.Core/Configuration/EngineConfiguration.cs
+++ b/src/VstsSyncMigrator.Core/Configuration/EngineConfiguration.cs
@@ -33,7 +33,7 @@ namespace VstsSyncMigrator.Engine.Configuration
             ec.Processors.Add(new WorkItemUpdateConfig());
             ec.Processors.Add(new WorkItemPostProcessingConfig() { WorkItemIDs = new List<int> { 1, 2, 3 } });
             ec.Processors.Add(new WorkItemDeleteConfig());
-            ec.Processors.Add(new WorkItemQueryMigrationConfig());
+            ec.Processors.Add(new WorkItemQueryMigrationConfig() { SourceToTargetFieldMappings = new Dictionary<string, string>() { {"SourceFieldRef", "TargetFieldRef" } } });
             ec.Processors.Add(new TeamMigrationConfig());
             return ec;
         }

--- a/src/VstsSyncMigrator.Core/Configuration/Processing/WorkItemQueryMigrationConfig.cs
+++ b/src/VstsSyncMigrator.Core/Configuration/Processing/WorkItemQueryMigrationConfig.cs
@@ -24,6 +24,8 @@ namespace VstsSyncMigrator.Engine.Configuration.Processing
             set { sharedFolderName = value; }
         }
 
+        public Dictionary<string, string> SourceToTargetFieldMappings { get; set; }
+
         /// <inheritdoc />
         public bool Enabled { get; set; }
 

--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemQueryMigrationContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemQueryMigrationContext.cs
@@ -180,6 +180,14 @@ namespace VstsSyncMigrator.Engine
                     fixedQueryText = fixedQueryText.Replace($"{me.Target.Config.Project}\\", $"{me.Target.Config.Project}\\{me.Source.Config.Project}\\");
                 }
 
+                if (config.SourceToTargetFieldMappings != null)
+                {
+                    foreach (var sourceField in config.SourceToTargetFieldMappings.Keys)
+                    {
+                        fixedQueryText = query.QueryText.Replace($"{sourceField}", $"'{config.SourceToTargetFieldMappings[sourceField]}");
+                    }
+                }
+
                 // you cannot just add an item from one store to another, we need to create a new object
                 var queryCopy = new QueryDefinition(query.Name, fixedQueryText);
                 this.totalQueriesAttempted++;


### PR DESCRIPTION
This feature will close #527 and add the ability to have a field mapping to the `WorkItemQueryMigrationConfig`. Add a `SourceToTargetFieldMappings` variable with:

```
"SourceToTargetFieldMappings": {
"Siemens.Importance": "Custom.SiemensImportance",
"Siemens.Objective.Type": "Custom.SiemensObjectiveType"
```
