### PR TITLE
LanguageMap should be LanguageMaps in config doc

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -28,9 +28,9 @@ The global configuration created by the `init` command look like this:
     "Project": "DemoProjs",
     "ReflectedWorkItemIDFieldName": "TfsMigrationTool.ReflectedWorkItemId",
     "AllowCrossProjectLinking": false,
-    "LanguageMap": {
+    "LanguageMaps": {
         "AreaPath": "Area",
-        "AreaPath": "Iteration",
+        "IterationPath": "Iteration"
 	}
   },
   "Target": {
@@ -38,9 +38,9 @@ The global configuration created by the `init` command look like this:
     "Project": "DemoProjt",
     "ReflectedWorkItemIDFieldName": "ProcessName.ReflectedWorkItemId",
     "AllowCrossProjectLinking": false,
-    "LanguageMap": {
+    "LanguageMaps": {
         "AreaPath": "Area",
-        "AreaPath": "Iteration",
+        "IterationPath": "Iteration"
 	}
   },
   "FieldMaps": [],


### PR DESCRIPTION
A Null Reference is thrown if the example is pasted into a configuration file - missing trailing 's'.  AreaPath is duplicated, renamed 2nd entry to IterationPath