### PR TITLE
History/Footer only appended when configured, same for ChangedBy

### DIFF
--- a/src/VstsSyncMigrator.Core/Configuration/Processing/TestPlansAndSuitesMigrationConfig.cs
+++ b/src/VstsSyncMigrator.Core/Configuration/Processing/TestPlansAndSuitesMigrationConfig.cs
@@ -10,6 +10,8 @@ namespace VstsSyncMigrator.Engine.Configuration.Processing
         public string OnlyElementsWithTag { get; set; }
         public string TestPlanQueryBit { get; set; }
 
+        public bool UpdateChangedByToMigration { get; set; }
+
         public Type Processor
         {
             get { return typeof(TestPlandsAndSuitesMigrationContext); }
@@ -28,6 +30,7 @@ namespace VstsSyncMigrator.Engine.Configuration.Processing
 
         public TestPlansAndSuitesMigrationConfig()
         {
+            UpdateChangedByToMigration = true;
         }
     }
 }

--- a/src/VstsSyncMigrator.Core/Configuration/Processing/WorkItemMigrationConfig.cs
+++ b/src/VstsSyncMigrator.Core/Configuration/Processing/WorkItemMigrationConfig.cs
@@ -11,6 +11,7 @@ namespace VstsSyncMigrator.Engine.Configuration.Processing
         public bool PrefixProjectToNodes { get; set; }
         public bool UpdateCreatedDate { get; set; }
         public bool UpdateCreatedBy { get; set; }
+        public bool UpdateChangedByToMigration { get; set; }
         public bool BuildFieldTable { get; set; }
         public bool AppendMigrationToolSignatureFooter { get; set; }
         public string QueryBit { get; set; }
@@ -48,6 +49,8 @@ namespace VstsSyncMigrator.Engine.Configuration.Processing
         public WorkItemMigrationConfig()
         {
             Enabled = false;
+            AppendMigrationToolSignatureFooter = true;
+            UpdateChangedByToMigration = true;
             WorkItemCreateRetryLimit = 5;
             FilterWorkItemsThatAlreadyExistInTarget = true;
             ReplayRevisions = true;

--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/MigrationContextBase.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/MigrationContextBase.cs
@@ -80,9 +80,12 @@ namespace VstsSyncMigrator.Engine
             //return r.Replace(input, target.Name, 1);
         }
 
-        internal static void SaveWorkItem(WorkItem workItem)
+        internal static void SaveWorkItem(WorkItem workItem, WorkItemMigrationConfig workItemMigrationConfig)
         {
-            workItem.Fields["System.ChangedBy"].Value = "Migration";
+            if (workItemMigrationConfig.UpdateChangedByToMigration)
+            {
+                workItem.Fields["System.ChangedBy"].Value = "Migration";
+            }
             workItem.Save();
         }
 

--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/MigrationContextBase.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/MigrationContextBase.cs
@@ -80,9 +80,9 @@ namespace VstsSyncMigrator.Engine
             //return r.Replace(input, target.Name, 1);
         }
 
-        internal static void SaveWorkItem(WorkItem workItem, WorkItemMigrationConfig workItemMigrationConfig)
+        internal static void SaveWorkItem(WorkItem workItem, bool updateChangedByToMigration = true)
         {
-            if (workItemMigrationConfig.UpdateChangedByToMigration)
+            if (updateChangedByToMigration)
             {
                 workItem.Fields["System.ChangedBy"].Value = "Migration";
             }

--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/TestPlansAndSuitesMigrationContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/TestPlansAndSuitesMigrationContext.cs
@@ -139,7 +139,7 @@ namespace VstsSyncMigrator.Engine
                 if (CanSkipElementBecauseOfTags(sourcePlan.Id))
                     continue;
 
-                ProcessTestPlan( sourcePlan);
+                ProcessTestPlan(sourcePlan);
                
             }
             _currentPlan = 0;
@@ -317,7 +317,7 @@ namespace VstsSyncMigrator.Engine
         {
             var targetPlanWorkItem = targetWitStore.Store.GetWorkItem(workItemId);
             targetPlanWorkItem.Tags = targetPlanWorkItem.Tags + ";migrated";
-            SaveWorkItem(targetPlanWorkItem);
+            SaveWorkItem(targetPlanWorkItem, config.UpdateChangedByToMigration);
         }
 
         private bool TargetPlanContansTag(int workItemId)

--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemMigrationContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemMigrationContext.cs
@@ -178,7 +178,7 @@ namespace VstsSyncMigrator.Engine
                     {
                         if (revisionsToMigrate.Count == 0)
                         {
-                            ProcessWorkItemAttachments(sourceWorkItem, targetWorkItem, false);
+                            ProcessWorkItemAttachments(sourceWorkItem, targetWorkItem, workItemMigrationConfig, false);
                             ProcessWorkItemLinks(sourceStore, targetStore, sourceWorkItem, targetWorkItem);
                             TraceWriteLine(sourceWorkItem, "Skipping as work item exists and no revisions to sync detected", ConsoleColor.Yellow);
                             processWorkItemMetrics.Add("Revisions", 0);
@@ -202,7 +202,7 @@ namespace VstsSyncMigrator.Engine
                     ///////////////////////////////////////////////////////
                     if (targetWorkItem != null && targetWorkItem.IsDirty)
                     {
-                        SaveWorkItem(targetWorkItem);
+                        SaveWorkItem(targetWorkItem, workItemMigrationConfig);
                     }
                     if (targetWorkItem != null)
                     {
@@ -424,7 +424,7 @@ namespace VstsSyncMigrator.Engine
 
                 if (targetWorkItem != null)
                 {
-                    ProcessWorkItemAttachments(sourceWorkItem, targetWorkItem, false);
+                    ProcessWorkItemAttachments(sourceWorkItem, targetWorkItem, workItemMigrationConfig, false);
                     ProcessWorkItemLinks(sourceStore, targetStore, sourceWorkItem, targetWorkItem);
                     string reflectedUri = sourceStore.CreateReflectedWorkItemId(sourceWorkItem);
                     if (targetWorkItem.Fields.Contains(me.Target.Config.ReflectedWorkItemIDFieldName))
@@ -439,7 +439,7 @@ namespace VstsSyncMigrator.Engine
                             $"This work item was migrated from a different project or organization. You can find the old version at <a href=\"{reflectedUri}\">{reflectedUri}</a>.");
                         targetWorkItem.History = history.ToString();
                     }
-                    SaveWorkItem(targetWorkItem);
+                    SaveWorkItem(targetWorkItem, workItemMigrationConfig);
 
                     attachmentOMatic.CleanUpAfterSave(targetWorkItem);
                     TraceWriteLine(sourceWorkItem, $"...Saved as {targetWorkItem.Id}");
@@ -697,12 +697,12 @@ namespace VstsSyncMigrator.Engine
             }
         }
 
-        private void ProcessWorkItemAttachments(WorkItem sourceWorkItem, WorkItem targetWorkItem, bool save = true)
+        private void ProcessWorkItemAttachments(WorkItem sourceWorkItem, WorkItem targetWorkItem, WorkItemMigrationConfig workItemMigrationConfig, bool save = true)
         {
             if (targetWorkItem != null && _config.AttachmentMigration && sourceWorkItem.Attachments.Count > 0)
             {
                 TraceWriteLine(sourceWorkItem, $"Attachemnts {sourceWorkItem.Attachments.Count} | LinkMigrator:{_config.AttachmentMigration}");
-                attachmentOMatic.ProcessAttachemnts(sourceWorkItem, targetWorkItem, save);
+                attachmentOMatic.ProcessAttachemnts(sourceWorkItem, targetWorkItem, workItemMigrationConfig, save);
                 AddMetric("Attachments", processWorkItemMetrics, targetWorkItem.AttachedFileCount);
             }
         }

--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemMigrationContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemMigrationContext.cs
@@ -202,7 +202,7 @@ namespace VstsSyncMigrator.Engine
                     ///////////////////////////////////////////////////////
                     if (targetWorkItem != null && targetWorkItem.IsDirty)
                     {
-                        SaveWorkItem(targetWorkItem, workItemMigrationConfig);
+                        SaveWorkItem(targetWorkItem, workItemMigrationConfig.UpdateChangedByToMigration);
                     }
                     if (targetWorkItem != null)
                     {
@@ -439,7 +439,7 @@ namespace VstsSyncMigrator.Engine
                             $"This work item was migrated from a different project or organization. You can find the old version at <a href=\"{reflectedUri}\">{reflectedUri}</a>.");
                         targetWorkItem.History = history.ToString();
                     }
-                    SaveWorkItem(targetWorkItem, workItemMigrationConfig);
+                    SaveWorkItem(targetWorkItem, workItemMigrationConfig.UpdateChangedByToMigration);
 
                     attachmentOMatic.CleanUpAfterSave(targetWorkItem);
                     TraceWriteLine(sourceWorkItem, $"...Saved as {targetWorkItem.Id}");

--- a/src/VstsSyncMigrator.Core/Execution/OMatics/AttachmentOMatic.cs
+++ b/src/VstsSyncMigrator.Core/Execution/OMatics/AttachmentOMatic.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using VstsSyncMigrator.Engine;
+using VstsSyncMigrator.Engine.Configuration.Processing;
 
 namespace VstsSyncMigrator.Core.Execution.OMatics
 {
@@ -26,7 +27,7 @@ namespace VstsSyncMigrator.Core.Execution.OMatics
             _maxAttachmentSize = maxAttachmentSize;
         }
 
-        public void ProcessAttachemnts(WorkItem sourceWorkItem, WorkItem targetWorkItem, bool save = true)
+        public void ProcessAttachemnts(WorkItem sourceWorkItem, WorkItem targetWorkItem, WorkItemMigrationConfig workItemMigrationConfig, bool save = true)
         {
             _exportWiPath = Path.Combine(_exportBasePath, sourceWorkItem.Id.ToString());
             if (System.IO.Directory.Exists(_exportWiPath))
@@ -55,7 +56,7 @@ namespace VstsSyncMigrator.Core.Execution.OMatics
             }
             if (save)
             {
-                WorkItemMigrationContext.SaveWorkItem(targetWorkItem);
+                WorkItemMigrationContext.SaveWorkItem(targetWorkItem, workItemMigrationConfig);
                 WorkItemMigrationContext.TraceWriteLine(sourceWorkItem, $" Work iTem now has {sourceWorkItem.Attachments.Count} attachemnts");
                 CleanUpAfterSave(targetWorkItem);
             }           

--- a/src/VstsSyncMigrator.Core/Execution/OMatics/AttachmentOMatic.cs
+++ b/src/VstsSyncMigrator.Core/Execution/OMatics/AttachmentOMatic.cs
@@ -56,7 +56,7 @@ namespace VstsSyncMigrator.Core.Execution.OMatics
             }
             if (save)
             {
-                WorkItemMigrationContext.SaveWorkItem(targetWorkItem, workItemMigrationConfig);
+                WorkItemMigrationContext.SaveWorkItem(targetWorkItem, workItemMigrationConfig.UpdateChangedByToMigration);
                 WorkItemMigrationContext.TraceWriteLine(sourceWorkItem, $" Work iTem now has {sourceWorkItem.Attachments.Count} attachemnts");
                 CleanUpAfterSave(targetWorkItem);
             }           


### PR DESCRIPTION
Things fixed:
1. WorkItemMigrationConfig.AppendMigrationToolSignatureFooter configuration is now respected

Things added:
1. A new WorkItemMigrationConfig option 'UpdateChangedByToMigration' that enables/disables the hard-coded  `workItem.Fields["System.ChangedBy"].Value = "Migration";` currently to be optional as well.

Both changes remain unchanged by default (config creation).


Not sure why AppendMigrationToolSignatureFooter was available but not used previously, but it is working now as the documentation reads.