### PR TITLE
Fixed links to workitems based on ReflectedWorkItemId

### DIFF
--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/TestPlansAndSuitesMigrationContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/TestPlansAndSuitesMigrationContext.cs
@@ -537,7 +537,7 @@ AddParameter("PlanId", parameters, targetPlan.Id.ToString());
                     return;
 
                 TraceWriteLine(source, string.Format("    Processing {0} : {1} - {2} ", sourceTestCaseEntry.EntryType.ToString(), sourceTestCaseEntry.Id, sourceTestCaseEntry.Title),15);
-                WorkItem wi = targetWitStore.FindReflectedWorkItem(sourceTestCaseEntry.TestCase.WorkItem, false);
+                WorkItem wi = targetWitStore.FindReflectedWorkItem(sourceTestCaseEntry.TestCase.WorkItem, false, me.Source.Config.ReflectedWorkItemIDFieldName);
                 if (wi == null)
                 {
                     TraceWriteLine(source, string.Format("    Can't find work item for Test Case. Has it been migrated? {0} : {1} - {2} ", sourceTestCaseEntry.EntryType.ToString(), sourceTestCaseEntry.Id, sourceTestCaseEntry.Title), 15);

--- a/src/VstsSyncMigrator.Core/Execution/OMatics/WorkItemLinkOMatic.cs
+++ b/src/VstsSyncMigrator.Core/Execution/OMatics/WorkItemLinkOMatic.cs
@@ -9,7 +9,7 @@ namespace VstsSyncMigrator.Core.Execution.OMatics
 {
     public class WorkItemLinkOMatic
     {
-        public void MigrateLinks(WorkItem sourceWorkItemLinkStart, WorkItemStoreContext sourceWorkItemStore, WorkItem targetWorkItemLinkStart, WorkItemStoreContext targetWorkItemStore, bool save = true)
+        public void MigrateLinks(WorkItem sourceWorkItemLinkStart, WorkItemStoreContext sourceWorkItemStore, WorkItem targetWorkItemLinkStart, WorkItemStoreContext targetWorkItemStore, bool save = true, string sourceReflectedWIIdField = null)
         {
             if (targetWorkItemLinkStart.Links.Count == sourceWorkItemLinkStart.Links.Count)
             {
@@ -31,7 +31,7 @@ namespace VstsSyncMigrator.Core.Execution.OMatics
                         else if (IsRelatedLink(item))
                         {
                             RelatedLink rl = (RelatedLink)item;
-                            CreateRelatedLink(sourceWorkItemLinkStart, rl, targetWorkItemLinkStart, sourceWorkItemStore, targetWorkItemStore, save);
+                            CreateRelatedLink(sourceWorkItemLinkStart, rl, targetWorkItemLinkStart, sourceWorkItemStore, targetWorkItemStore, save, sourceReflectedWIIdField);
                         }
                         else if (IsExternalLink(item))
                         {
@@ -141,7 +141,7 @@ namespace VstsSyncMigrator.Core.Execution.OMatics
                    link.LinkedArtifactUri.StartsWith("vstfs:///Build/Build/", StringComparison.InvariantCultureIgnoreCase);
         }
 
-        private void CreateRelatedLink(WorkItem wiSourceL, RelatedLink item, WorkItem wiTargetL, WorkItemStoreContext sourceStore, WorkItemStoreContext targetStore, bool save )
+        private void CreateRelatedLink(WorkItem wiSourceL, RelatedLink item, WorkItem wiTargetL, WorkItemStoreContext sourceStore, WorkItemStoreContext targetStore, bool save, string sourceReflectedWIIdField)
         {
             RelatedLink rl = (RelatedLink)item;
             WorkItem wiSourceR = null;
@@ -158,7 +158,7 @@ namespace VstsSyncMigrator.Core.Execution.OMatics
             }
             try
             {
-                wiTargetR = GetRightHandSideTargitWi(wiSourceL, wiSourceR, wiTargetL, targetStore);
+                wiTargetR = GetRightHandSideTargetWi(wiSourceL, wiSourceR, wiTargetL, targetStore, sourceStore, sourceReflectedWIIdField);
             }
             catch (Exception ex)
             {
@@ -234,7 +234,7 @@ namespace VstsSyncMigrator.Core.Execution.OMatics
             }
         }
 
-        private WorkItem GetRightHandSideTargitWi(WorkItem wiSourceL, WorkItem wiSourceR, WorkItem wiTargetL, WorkItemStoreContext targetStore)
+        private WorkItem GetRightHandSideTargetWi(WorkItem wiSourceL, WorkItem wiSourceR, WorkItem wiTargetL, WorkItemStoreContext targetStore, WorkItemStoreContext sourceStore, string sourceReflectedWIIdField)
         {
             WorkItem wiTargetR;
             if (!(wiTargetL == null)
@@ -247,7 +247,7 @@ namespace VstsSyncMigrator.Core.Execution.OMatics
             else
             {
                 // Moving to Other Team Project from Source
-                wiTargetR = targetStore.FindReflectedWorkItem(wiSourceR, true);
+                wiTargetR = targetStore.FindReflectedWorkItem(wiSourceR, true, sourceReflectedWIIdField);
                 if (wiTargetR == null) // Assume source only (other team project)
                 {
                     wiTargetR = wiSourceR;


### PR DESCRIPTION
Fixes issue #526.
When migrating links, Right-hand work items can now be found on the target system based on the ReflectedWorkItemId field on the source system.