### PR TITLE
Fixed links to workitems based on ReflectedWorkItemId 

### DIFF
--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/TestPlansAndSuitesMigrationContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/TestPlansAndSuitesMigrationContext.cs
@@ -537,7 +537,7 @@ AddParameter("PlanId", parameters, targetPlan.Id.ToString());
                     return;
 
                 TraceWriteLine(source, string.Format("    Processing {0} : {1} - {2} ", sourceTestCaseEntry.EntryType.ToString(), sourceTestCaseEntry.Id, sourceTestCaseEntry.Title),15);
-                WorkItem wi = targetWitStore.FindReflectedWorkItem(sourceTestCaseEntry.TestCase.WorkItem, false);
+                WorkItem wi = targetWitStore.FindReflectedWorkItem(sourceTestCaseEntry.TestCase.WorkItem, false, me.Source.Config.ReflectedWorkItemIDFieldName);
                 if (wi == null)
                 {
                     TraceWriteLine(source, string.Format("    Can't find work item for Test Case. Has it been migrated? {0} : {1} - {2} ", sourceTestCaseEntry.EntryType.ToString(), sourceTestCaseEntry.Id, sourceTestCaseEntry.Title), 15);

--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemMigrationContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemMigrationContext.cs
@@ -195,7 +195,7 @@ namespace VstsSyncMigrator.Engine
                         {
                             ProcessWorkItemAttachments(sourceWorkItem, targetWorkItem, false);
                             ProcessWorkItemLinks(sourceStore, targetStore, sourceWorkItem, targetWorkItem);
-                            TraceWriteLine(sourceWorkItem, "Skipping as work item exists and no revisions to sync detected", ConsoleColor.Yellow);
+                            TraceWriteLine(LogEventLevel.Information, "Skipping as work item exists and no revisions to sync detected");
                             processWorkItemMetrics.Add("Revisions", 0);
                         }
                         else

--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemMigrationContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemMigrationContext.cs
@@ -38,7 +38,7 @@ namespace VstsSyncMigrator.Engine
         private AttachmentOMatic attachmentOMatic;
         private RepoOMatic repoOMatic;
         private ILogger contextLog;
-       private ILogger workItemLog;
+        private ILogger workItemLog;
         EmbededImagesRepairOMatic embededImagesRepairOMatic = new EmbededImagesRepairOMatic();
         static int _current = 0;
         static int _count = 0;
@@ -149,12 +149,12 @@ namespace VstsSyncMigrator.Engine
                             break;
                         }
                     }
-                }               
+                }
             }
             //////////////////////////////////////////////////
             stopwatch.Stop();
 
-            contextLog.Information("DONE in {Elapsed:%h} hours {Elapsed:%m} minutes {Elapsed:s/:fff} seconds",  stopwatch.Elapsed);
+            contextLog.Information("DONE in {Elapsed:%h} hours {Elapsed:%m} minutes {Elapsed:s/:fff} seconds", stopwatch.Elapsed);
         }
 
 
@@ -195,7 +195,7 @@ namespace VstsSyncMigrator.Engine
                         {
                             ProcessWorkItemAttachments(sourceWorkItem, targetWorkItem, false);
                             ProcessWorkItemLinks(sourceStore, targetStore, sourceWorkItem, targetWorkItem);
-                            TraceWriteLine(LogEventLevel.Information, "Skipping as work item exists and no revisions to sync detected");
+                            TraceWriteLine(sourceWorkItem, "Skipping as work item exists and no revisions to sync detected", ConsoleColor.Yellow);
                             processWorkItemMetrics.Add("Revisions", 0);
                         }
                         else
@@ -230,7 +230,7 @@ namespace VstsSyncMigrator.Engine
                 }
                 else
                 {
-                    TraceWriteLine(LogEventLevel.Warning, "SKIP: Unable to migrate {sourceWorkItemTypeName}/{sourceWorkItemId}. Use the TestPlansAndSuitesMigrationContext after you have migrated all Test Cases. ", sourceWorkItem.Type.Name,sourceWorkItem.Id);
+                    TraceWriteLine(LogEventLevel.Warning, "SKIP: Unable to migrate {sourceWorkItemTypeName}/{sourceWorkItemId}. Use the TestPlansAndSuitesMigrationContext after you have migrated all Test Cases. ", sourceWorkItem.Type.Name, sourceWorkItem.Id);
                 }
             }
             catch (WebException ex)
@@ -366,7 +366,7 @@ namespace VstsSyncMigrator.Engine
 
                     revisionsToMigrate = revisionsToMigrate.GetRange(revisionsToMigrate.Count - 1, 1);
 
-                    TraceWriteLine( LogEventLevel.Information, " Attached a consolidated set of {RevisionCount} revisions.", data.Count());
+                    TraceWriteLine(LogEventLevel.Information, " Attached a consolidated set of {RevisionCount} revisions.", data.Count());
                 }
 
                 foreach (var revision in revisionsToMigrate)
@@ -422,7 +422,7 @@ namespace VstsSyncMigrator.Engine
 
                     foreach (Field f in fails)
                     {
-                        TraceWriteLine( LogEventLevel.Information,
+                        TraceWriteLine(LogEventLevel.Information,
                             "{Current} - Invalid: {CurrentRevisionWorkItemId}-{CurrentRevisionWorkItemTypeName}-{FieldReferenceName}-{SourceWorkItemTitle} Value: {FieldValue}",
                             current,
                             currentRevisionWorkItem.Id,
@@ -438,10 +438,10 @@ namespace VstsSyncMigrator.Engine
                     //}
 
                     targetWorkItem.Save();
-                    TraceWriteLine( LogEventLevel.Information,
-                        " Saved TargetWorkItem {TargetWorkItemId}. Replayed revision {RevisionNumber} of {RevisionsToMigrateCount}", 
-                        targetWorkItem.Id, 
-                        revision.Number, 
+                    TraceWriteLine(LogEventLevel.Information,
+                        " Saved TargetWorkItem {TargetWorkItemId}. Replayed revision {RevisionNumber} of {RevisionsToMigrateCount}",
+                        targetWorkItem.Id,
+                        revision.Number,
                         revisionsToMigrate.Count);
 
                 }
@@ -463,7 +463,7 @@ namespace VstsSyncMigrator.Engine
                     SaveWorkItem(targetWorkItem);
 
                     attachmentOMatic.CleanUpAfterSave(targetWorkItem);
-                    TraceWriteLine (LogEventLevel.Information, "...Saved as {TargetWorkItemId}", targetWorkItem.Id);
+                    TraceWriteLine(LogEventLevel.Information, "...Saved as {TargetWorkItemId}", targetWorkItem.Id);
                 }
             }
             catch (Exception ex)
@@ -524,9 +524,8 @@ namespace VstsSyncMigrator.Engine
                 }
             }
 
-            newwit.AreaPath = GetNewNodeName(oldWi.AreaPath, oldWi.Project.Name, newwit.Project.Name, newwit.Store, me.Target.Config.LanguageMaps.AreaPath);
-            newwit.IterationPath = GetNewNodeName(oldWi.IterationPath, oldWi.Project.Name, newwit.Project.Name, newwit.Store, me.Target.Config.LanguageMaps.IterationPath);
-
+            newwit.AreaPath = GetNewNodeName(oldWi.AreaPath, oldWi.Project.Name, newwit.Project.Name, newwit.Store, "Area");
+            newwit.IterationPath = GetNewNodeName(oldWi.IterationPath, oldWi.Project.Name, newwit.Project.Name, newwit.Store, "Iteration");
             switch (destType)
             {
                 case "Test Case":
@@ -552,7 +551,7 @@ namespace VstsSyncMigrator.Engine
 
         internal void TraceWriteLine(LogEventLevel level, string message = "", params object[] propertyValues)
         {
-            workItemLog.Write(level, workItemLogTeamplate + message,propertyValues);
+            workItemLog.Write(level, workItemLogTeamplate + message, propertyValues);
         }
 
         private List<WorkItem> FilterWorkItemsThatAlreadyExistInTarget(List<WorkItem> sourceWorkItems, WorkItemStoreContext targetStore)
@@ -688,8 +687,8 @@ namespace VstsSyncMigrator.Engine
         {
             if (targetWorkItem != null && _config.LinkMigration && sourceWorkItem.Links.Count > 0)
             {
-                TraceWriteLine(LogEventLevel.Information, "Links {SourceWorkItemLinkCount} | LinkMigrator:{LinkMigration}", sourceWorkItem.Links.Count,_config.LinkMigration);
-                workItemLinkOMatic.MigrateLinks(sourceWorkItem, sourceStore, targetWorkItem, targetStore, _config.LinkMigrationSaveEachAsAdded);
+                TraceWriteLine(LogEventLevel.Information, "Links {SourceWorkItemLinkCount} | LinkMigrator:{LinkMigration}", sourceWorkItem.Links.Count, _config.LinkMigration);
+                workItemLinkOMatic.MigrateLinks(sourceWorkItem, sourceStore, targetWorkItem, targetStore, _config.LinkMigrationSaveEachAsAdded, me.Source.Config.ReflectedWorkItemIDFieldName);
                 AddMetric("RelatedLinkCount", processWorkItemMetrics, targetWorkItem.Links.Count);
                 int fixedLinkCount = repoOMatic.FixExternalLinks(targetWorkItem, targetStore, sourceWorkItem, _config.LinkMigrationSaveEachAsAdded);
                 AddMetric("FixedGitLinkCount", processWorkItemMetrics, fixedLinkCount);

--- a/src/VstsSyncMigrator.Core/Execution/OMatics/WorkItemLinkOMatic.cs
+++ b/src/VstsSyncMigrator.Core/Execution/OMatics/WorkItemLinkOMatic.cs
@@ -9,7 +9,7 @@ namespace VstsSyncMigrator.Core.Execution.OMatics
 {
     public class WorkItemLinkOMatic
     {
-        public void MigrateLinks(WorkItem sourceWorkItemLinkStart, WorkItemStoreContext sourceWorkItemStore, WorkItem targetWorkItemLinkStart, WorkItemStoreContext targetWorkItemStore, bool save = true)
+        public void MigrateLinks(WorkItem sourceWorkItemLinkStart, WorkItemStoreContext sourceWorkItemStore, WorkItem targetWorkItemLinkStart, WorkItemStoreContext targetWorkItemStore, bool save = true, string sourceReflectedWIIdField = null)
         {
             if (targetWorkItemLinkStart.Links.Count == sourceWorkItemLinkStart.Links.Count)
             {
@@ -31,7 +31,7 @@ namespace VstsSyncMigrator.Core.Execution.OMatics
                         else if (IsRelatedLink(item))
                         {
                             RelatedLink rl = (RelatedLink)item;
-                            CreateRelatedLink(sourceWorkItemLinkStart, rl, targetWorkItemLinkStart, sourceWorkItemStore, targetWorkItemStore, save);
+                            CreateRelatedLink(sourceWorkItemLinkStart, rl, targetWorkItemLinkStart, sourceWorkItemStore, targetWorkItemStore, save, sourceReflectedWIIdField);
                         }
                         else if (IsExternalLink(item))
                         {
@@ -141,7 +141,7 @@ namespace VstsSyncMigrator.Core.Execution.OMatics
                    link.LinkedArtifactUri.StartsWith("vstfs:///Build/Build/", StringComparison.InvariantCultureIgnoreCase);
         }
 
-        private void CreateRelatedLink(WorkItem wiSourceL, RelatedLink item, WorkItem wiTargetL, WorkItemStoreContext sourceStore, WorkItemStoreContext targetStore, bool save )
+        private void CreateRelatedLink(WorkItem wiSourceL, RelatedLink item, WorkItem wiTargetL, WorkItemStoreContext sourceStore, WorkItemStoreContext targetStore, bool save, string sourceReflectedWIIdField)
         {
             RelatedLink rl = (RelatedLink)item;
             WorkItem wiSourceR = null;
@@ -158,7 +158,7 @@ namespace VstsSyncMigrator.Core.Execution.OMatics
             }
             try
             {
-                wiTargetR = GetRightHandSideTargitWi(wiSourceL, wiSourceR, wiTargetL, targetStore);
+                wiTargetR = GetRightHandSideTargetWi(wiSourceL, wiSourceR, wiTargetL, targetStore, sourceStore, sourceReflectedWIIdField);
             }
             catch (Exception ex)
             {
@@ -234,7 +234,7 @@ namespace VstsSyncMigrator.Core.Execution.OMatics
             }
         }
 
-        private WorkItem GetRightHandSideTargitWi(WorkItem wiSourceL, WorkItem wiSourceR, WorkItem wiTargetL, WorkItemStoreContext targetStore)
+        private WorkItem GetRightHandSideTargetWi(WorkItem wiSourceL, WorkItem wiSourceR, WorkItem wiTargetL, WorkItemStoreContext targetStore, WorkItemStoreContext sourceStore, string sourceReflectedWIIdField)
         {
             WorkItem wiTargetR;
             if (!(wiTargetL == null)
@@ -247,7 +247,7 @@ namespace VstsSyncMigrator.Core.Execution.OMatics
             else
             {
                 // Moving to Other Team Project from Source
-                wiTargetR = targetStore.FindReflectedWorkItem(wiSourceR, true);
+                wiTargetR = targetStore.FindReflectedWorkItem(wiSourceR, true, sourceReflectedWIIdField);
                 if (wiTargetR == null) // Assume source only (other team project)
                 {
                     wiTargetR = wiSourceR;


### PR DESCRIPTION
Fixes issue #526.
When migrating links, Right-hand work items can now be found on the target system based on the ReflectedWorkItemId field on the source system.
Now updated to resolve merge conflicts.