### PR TITLE
Log the project name rather than the entire project object structure

### DIFF
--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemMigrationContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemMigrationContext.cs
@@ -114,7 +114,7 @@ namespace VstsSyncMigrator.Engine
             //////////////////////////////////////////////////
             var targetStore = new WorkItemStoreContext(me.Target, WorkItemStoreFlags.BypassRules);
             var destProject = targetStore.GetProject();
-            contextLog.Information("Found target project as {@destProject}", destProject);
+            contextLog.Information("Found target project as {@destProject}", destProject.Name);
             //////////////////////////////////////////////////////////FilterCompletedByQuery
             if (_config.FilterWorkItemsThatAlreadyExistInTarget)
             {


### PR DESCRIPTION
While the process would run successfully, it would pause at this point when logging, use up lots of memory, error, and proceed with the rest of its logic.