### PR TITLE
Removed class fullname from config

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ The Azure DevOps Migration Tools allow you to bulk edit and migrate data between
 
 ## Change Log
 
+- v10.1 - Changed config design to have only the Name and not FullName of the class. Remove `MigrationTools.Core.Configuration.FieldMap.` and `MigrationTools.Core.Configuration.Processing.` from the config leaving only the Name of the class in ObjectName.
+- v10.0 - Start of the greate refactor over to .NET Core and the REST API as the Object Model has been retired.
 - v9.0 - Added support for migration between other language versions of Azure DevOps. Developed for German -> English
 - v8.9 - Added 'Collapse Revisions' feature to collapse and attache revisions instead of replaying them
 - v8.8 - 'SkipToFinalRevisedWorkItemType' feature added to handle scenario when changing Work Item Type

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The Azure DevOps Migration Tools allow you to bulk edit and migrate data between
 
 ## Change Log
 
-- v10.1 - Changed config design to have only the Name and not FullName of the class. Remove `MigrationTools.Core.Configuration.FieldMap.` and `MigrationTools.Core.Configuration.Processing.` from the config leaving only the Name of the class in ObjectName.
+- v10.1 - Changed config design to have only the Name and not FullName of the class. Remove `MigrationTools.Core.Configuration.FieldMap.` and `MigrationTools.Core.Configuration.Processing.` from the config leaving only the Name of the class in ObjectType field.
 - v10.0 - Start of the greate refactor over to .NET Core and the REST API as the Object Model has been retired.
 - v9.0 - Added support for migration between other language versions of Azure DevOps. Developed for German -> English
 - v8.9 - Added 'Collapse Revisions' feature to collapse and attache revisions instead of replaying them

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -28,29 +28,123 @@ You can now customise the configuration depending on what you need to do. Howeve
 
 ```
 {
-  "Version": "8.4",
+  "Version": "0.0",
   "TelemetryEnableTrace": false,
   "workaroundForQuerySOAPBugEnabled": false,
   "Source": {
-    "Collection": "https://dev.azure.com/psd45",
-    "Project": "DemoProjs",
-    "ReflectedWorkItemIDFieldName": "TfsMigrationTool.ReflectedWorkItemId",
-    "AllowCrossProjectLinking": false
+    "Collection": "https://dev.azure.com/nkdagility-preview/",
+    "Project": "migrationSource1",
+    "ReflectedWorkItemIDFieldName": "Custom.ReflectedWorkItemId",
+    "AllowCrossProjectLinking": false,
+    "PersonalAccessToken": "",
+    "LanguageMaps": {
+      "AreaPath": "Area",
+      "IterationPath": "Iteration"
+    }
   },
   "Target": {
-    "Collection": "https://dev.azure.com/psd46",
-    "Project": "DemoProjt",
-    "ReflectedWorkItemIDFieldName": "ProcessName.ReflectedWorkItemId",
-    "AllowCrossProjectLinking": false
+    "Collection": "https://dev.azure.com/nkdagility-preview/",
+    "Project": "migrationTarget1",
+    "ReflectedWorkItemIDFieldName": "Custom.ReflectedWorkItemId",
+    "AllowCrossProjectLinking": false,
+    "PersonalAccessToken": "",
+    "LanguageMaps": {
+      "AreaPath": "Area",
+      "IterationPath": "Iteration"
+    }
   },
-  "FieldMaps": [],
+  "FieldMaps": [
+    {
+      "ObjectType": "MultiValueConditionalMapConfig",
+      "WorkItemTypeName": "*",
+      "sourceFieldsAndValues": {
+        "Field1": "Value1",
+        "Field2": "Value2"
+      },
+      "targetFieldsAndValues": {
+        "Field1": "Value1",
+        "Field2": "Value2"
+      }
+    },
+    {
+      "ObjectType": "FieldBlankMapConfig",
+      "WorkItemTypeName": "*",
+      "targetField": "TfsMigrationTool.ReflectedWorkItemId"
+    },
+    {
+      "ObjectType": "FieldValueMapConfig",
+      "WorkItemTypeName": "*",
+      "sourceField": "System.State",
+      "targetField": "System.State",
+      "defaultValue": "New",
+      "valueMapping": {
+        "Approved": "New",
+        "New": "New",
+        "Committed": "Active",
+        "In Progress": "Active",
+        "To Do": "New",
+        "Done": "Closed",
+        "Removed": "Removed"
+      }
+    },
+    {
+      "ObjectType": "FieldtoFieldMapConfig",
+      "WorkItemTypeName": "*",
+      "sourceField": "Microsoft.VSTS.Common.BacklogPriority",
+      "targetField": "Microsoft.VSTS.Common.StackRank"
+    },
+    {
+      "ObjectType": "FieldtoFieldMultiMapConfig",
+      "WorkItemTypeName": "*",
+      "SourceToTargetMappings": {
+        "SourceField1": "TargetField1",
+        "SourceField2": "TargetField2"
+      }
+    },
+    {
+      "ObjectType": "FieldtoTagMapConfig",
+      "WorkItemTypeName": "*",
+      "sourceField": "System.State",
+      "formatExpression": "ScrumState:{0}"
+    },
+    {
+      "ObjectType": "FieldMergeMapConfig",
+      "WorkItemTypeName": "*",
+      "sourceField1": "System.Description",
+      "sourceField2": "Microsoft.VSTS.Common.AcceptanceCriteria",
+      "targetField": "System.Description",
+      "formatExpression": "{0} <br/><br/><h3>Acceptance Criteria</h3>{1}",
+      "doneMatch": "##DONE##"
+    },
+    {
+      "ObjectType": "RegexFieldMapConfig",
+      "WorkItemTypeName": "*",
+      "sourceField": "COMPANY.PRODUCT.Release",
+      "targetField": "COMPANY.DEVISION.MinorReleaseVersion",
+      "pattern": "PRODUCT \\d{4}.(\\d{1})",
+      "replacement": "$1"
+    },
+    {
+      "ObjectType": "FieldValuetoTagMapConfig",
+      "WorkItemTypeName": "*",
+      "sourceField": "Microsoft.VSTS.CMMI.Blocked",
+      "pattern": "Yes",
+      "formatExpression": "{0}"
+    },
+    {
+      "ObjectType": "TreeToTagMapConfig",
+      "WorkItemTypeName": "*",
+      "toSkip": 3,
+      "timeTravel": 1
+    }
+  ],
   "WorkItemTypeDefinition": {
     "sourceWorkItemTypeName": "targetWorkItemTypeName"
   },
   "GitRepoMapping": null,
   "Processors": [
     {
-      "ObjectType": "VstsSyncMigrator.Engine.Configuration.Processing.NodeStructuresMigrationConfig",
+      "ObjectType": "NodeStructuresMigrationConfig",
       "PrefixProjectToNodes": false,
       "Enabled": false,
       "BasePaths": [
@@ -59,7 +153,7 @@ You can now customise the configuration depending on what you need to do. Howeve
       ]
     },
     {
-      "ObjectType": "VstsSyncMigrator.Engine.Configuration.Processing.WorkItemMigrationConfig",
+      "ObjectType": "WorkItemMigrationConfig",
       "ReplayRevisions": true,
       "PrefixProjectToNodes": false,
       "UpdateCreatedDate": true,
@@ -73,12 +167,17 @@ You can now customise the configuration depending on what you need to do. Howeve
       "AttachmentMigration": true,
       "AttachmentWorkingPath": "c:\\temp\\WorkItemAttachmentWorkingFolder\\",
       "FixHtmlAttachmentLinks": false,
+      "SkipToFinalRevisedWorkItemType": false,
       "WorkItemCreateRetryLimit": 5,
       "FilterWorkItemsThatAlreadyExistInTarget": true,
-      "PauseAfterEachWorkItem": false
+      "PauseAfterEachWorkItem": false,
+      "AttachmentMazSize": 480000000,
+      "CollapseRevisions": false,
+      "LinkMigrationSaveEachAsAdded": false
     }
   ]
 }
+
 ```
 
 Here we are performing the following operations:

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,8 +17,10 @@ _NOTICE: Both paied and community support is avilable through our [recommneded c
 - Migrate from one Language version of TFS / Azure Devops to another (*new v9.0*)
 
 ## Change Log
+
+- v10.1 - Changed config design to have only the Name and not FullName of the class. Remove `MigrationTools.Core.Configuration.FieldMap.` and `MigrationTools.Core.Configuration.Processing.` from the config leaving only the Name of the class in ObjectName.
+- v10.0 - Start of the greate refactor over to .NET Core and the REST API as the Object Model has been retired.
 - v9.0 - Added support for migration between other language versions of Azure DevOps. Developed for German -> English
-- v8.10 - Added `LinkMigrationSaveEachAsAdded` to help mitigate `TF26194: unable to change the value of the 'Parent' field` error. Remvoved `UpdateSourceReflectedId`
 - v8.9 - Added 'Collapse Revisions' feature to collapse and attache revisions instead of replaying them
 - v8.8 - 'SkipToFinalRevisedWorkItemType' feature added to handle scenario when changing Work Item Type
 - v8.7 - Support for inline images using a Personal Access Token added to the Source Project

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,7 +18,7 @@ _NOTICE: Both paied and community support is avilable through our [recommneded c
 
 ## Change Log
 
-- v10.1 - Changed config design to have only the Name and not FullName of the class. Remove `MigrationTools.Core.Configuration.FieldMap.` and `MigrationTools.Core.Configuration.Processing.` from the config leaving only the Name of the class in ObjectName.
+- v10.1 - Changed config design to have only the Name and not FullName of the class. Remove `MigrationTools.Core.Configuration.FieldMap.` and `MigrationTools.Core.Configuration.Processing.` from the config leaving only the Name of the class in ObjectType field.
 - v10.0 - Start of the greate refactor over to .NET Core and the REST API as the Object Model has been retired.
 - v9.0 - Added support for migration between other language versions of Azure DevOps. Developed for German -> English
 - v8.9 - Added 'Collapse Revisions' feature to collapse and attache revisions instead of replaying them

--- a/src/MigrationTools/Core/Configuration/FieldMapConfigJsonConverter.cs
+++ b/src/MigrationTools/Core/Configuration/FieldMapConfigJsonConverter.cs
@@ -14,7 +14,10 @@ namespace MigrationTools.Core.Configuration
             if (FieldExists("ObjectType", jObject))
             {
                 string typename = jObject.GetValue("ObjectType").ToString();
-                Type type = Type.GetType(typename, true);
+                Type type = AppDomain.CurrentDomain.GetAssemblies()
+                   .Where(a => !a.IsDynamic)
+                   .SelectMany(a => a.GetTypes())
+                   .FirstOrDefault(t => t.Name.Equals(typename) || t.FullName.Equals(typename));
                 return (IFieldMapConfig)Activator.CreateInstance(type);
             }
             else

--- a/src/MigrationTools/Core/Configuration/JsonCreationConverter.cs
+++ b/src/MigrationTools/Core/Configuration/JsonCreationConverter.cs
@@ -54,7 +54,7 @@ namespace MigrationTools.Core.Configuration
             else
             {
                 JObject o = (JObject)jt;
-                o.AddFirst(new JProperty("ObjectType", value.GetType().FullName));
+                o.AddFirst(new JProperty("ObjectType", value.GetType().Name));
                 o.WriteTo(writer);
             }
         }

--- a/src/MigrationTools/Core/Configuration/ProcessorConfigJsonConverter.cs
+++ b/src/MigrationTools/Core/Configuration/ProcessorConfigJsonConverter.cs
@@ -15,7 +15,10 @@ namespace MigrationTools.Core.Configuration
             if (FieldExists("ObjectType", jObject))
             {
                 string typename = jObject.GetValue("ObjectType").ToString();
-                Type type = Type.GetType(typename, true);
+                Type type = AppDomain.CurrentDomain.GetAssemblies()
+                  .Where(a => !a.IsDynamic)
+                  .SelectMany(a => a.GetTypes())
+                  .FirstOrDefault(t => t.Name.Equals(typename) || t.FullName.Equals(typename));
                 return (ITfsProcessingConfig)Activator.CreateInstance(type);
             }
             else

--- a/src/VstsSyncMigrator.Extension/README.md
+++ b/src/VstsSyncMigrator.Extension/README.md
@@ -23,8 +23,9 @@ The Azure DevOps Migration Tools allow you to bulk edit and migrate data between
 
 ## Change Log
 
+- v10.1 - Changed config design to have only the Name and not FullName of the class. Remove `MigrationTools.Core.Configuration.FieldMap.` and `MigrationTools.Core.Configuration.Processing.` from the config leaving only the Name of the class in ObjectName.
+- v10.0 - Start of the greate refactor over to .NET Core and the REST API as the Object Model has been retired.
 - v9.0 - Added support for migration between other language versions of Azure DevOps. Developed for German -> English
-- v8.10 - Added `LinkMigrationSaveEachAsAdded` to help mitigate `TF26194: unable to change the value of the 'Parent' field` error. Remvoved `UpdateSourceReflectedId`
 - v8.9 - Added 'Collapse Revisions' feature to collapse and attache revisions instead of replaying them
 - v8.8 - 'SkipToFinalRevisedWorkItemType' feature added to handle scenario when changing Work Item Type
 - v8.7 - Support for inline images using a Personal Access Token added to the Source Project

--- a/src/VstsSyncMigrator.Extension/README.md
+++ b/src/VstsSyncMigrator.Extension/README.md
@@ -23,7 +23,7 @@ The Azure DevOps Migration Tools allow you to bulk edit and migrate data between
 
 ## Change Log
 
-- v10.1 - Changed config design to have only the Name and not FullName of the class. Remove `MigrationTools.Core.Configuration.FieldMap.` and `MigrationTools.Core.Configuration.Processing.` from the config leaving only the Name of the class in ObjectName.
+- v10.1 - Changed config design to have only the Name and not FullName of the class. Remove `MigrationTools.Core.Configuration.FieldMap.` and `MigrationTools.Core.Configuration.Processing.` from the config leaving only the Name of the class in ObjectType field.
 - v10.0 - Start of the greate refactor over to .NET Core and the REST API as the Object Model has been retired.
 - v9.0 - Added support for migration between other language versions of Azure DevOps. Developed for German -> English
 - v8.9 - Added 'Collapse Revisions' feature to collapse and attache revisions instead of replaying them


### PR DESCRIPTION
There are error when moving Config around due to the class full name being used. This has been removed so that future refactors don't cause problems.