### PR TITLE
Allow mapping of literal values

### DIFF
--- a/src/MigrationTools/Core/Configuration/FieldMap/FieldLiteralMapConfig.cs
+++ b/src/MigrationTools/Core/Configuration/FieldMap/FieldLiteralMapConfig.cs
@@ -1,0 +1,13 @@
+﻿namespace MigrationTools.Core.Configuration.FieldMap
+{
+    public class FieldLiteralMapConfig : IFieldMapConfig
+    {
+        public string FieldMap => "FieldLiteralMap";
+        
+        public string WorkItemTypeName { get; set; }
+
+        public string targetField { get; set; }
+        
+        public string value { get; set; }
+    }
+}

--- a/src/MigrationTools/Core/Configuration/FieldMap/FieldtoFieldMapConfig.cs
+++ b/src/MigrationTools/Core/Configuration/FieldMap/FieldtoFieldMapConfig.cs
@@ -12,6 +12,7 @@ namespace MigrationTools.Core.Configuration.FieldMap
         public string WorkItemTypeName { get; set; }
         public string sourceField { get; set; }
         public string targetField { get; set; }
+        public string defaultValue { get; set; }
         public string FieldMap
         {
             get

--- a/src/VstsSyncMigrator.Core/Execution/FieldMaps/FieldLiteralMap.cs
+++ b/src/VstsSyncMigrator.Core/Execution/FieldMaps/FieldLiteralMap.cs
@@ -1,0 +1,28 @@
+﻿using MigrationTools.Core.Configuration.FieldMap;
+using Microsoft.TeamFoundation.WorkItemTracking.Client;
+using VstsSyncMigrator.Engine.ComponentContext;
+using System;
+
+namespace VstsSyncMigrator.Engine.ComponentContext
+{
+    class FieldLiteralMap : FieldMapBase
+    {
+        private FieldLiteralMapConfig config;
+
+        public FieldLiteralMap(FieldLiteralMapConfig config)
+        {
+            this.config = config;
+            if (config.targetField == null)
+            {
+                throw new ArgumentNullException($"The target field `{config.targetField}` must be specified. Please use diferent fields.");
+            }
+        }
+
+        public override string MappingDisplayName => $"{config.value} -> {config.targetField}";
+
+        internal override void InternalExecute(WorkItem source, WorkItem target)
+        {
+            target.Fields[config.targetField].Value = config.value;
+        }
+    }
+}

--- a/src/VstsSyncMigrator.Core/Execution/FieldMaps/FieldLiteralMap.cs
+++ b/src/VstsSyncMigrator.Core/Execution/FieldMaps/FieldLiteralMap.cs
@@ -1,11 +1,10 @@
 ﻿using MigrationTools.Core.Configuration.FieldMap;
 using Microsoft.TeamFoundation.WorkItemTracking.Client;
-using VstsSyncMigrator.Engine.ComponentContext;
 using System;
 
 namespace VstsSyncMigrator.Engine.ComponentContext
 {
-    class FieldLiteralMap : FieldMapBase
+    public class FieldLiteralMap : FieldMapBase
     {
         private FieldLiteralMapConfig config;
 

--- a/src/VstsSyncMigrator.Core/Execution/FieldMaps/FieldToFieldMap.cs
+++ b/src/VstsSyncMigrator.Core/Execution/FieldMaps/FieldToFieldMap.cs
@@ -24,7 +24,12 @@ namespace VstsSyncMigrator.Engine.ComponentContext
         {
             if (source.Fields.Contains(config.sourceField) && target.Fields.Contains(config.targetField))
             {
-                target.Fields[config.targetField].Value = source.Fields[config.sourceField].Value;
+                var value = source.Fields[config.sourceField].Value;
+                if ((value as string is null || value as string == "") && config.defaultValue != null)
+                {
+                    value = config.defaultValue;
+                }
+                target.Fields[config.targetField].Value = value;
                 Trace.WriteLine(string.Format("  [UPDATE] field mapped {0}:{1} to {2}:{3}", source.Id, config.sourceField, target.Id, config.targetField));
             }
         }

--- a/src/VstsSyncMigrator.Core/VstsSyncMigrator.Core.csproj
+++ b/src/VstsSyncMigrator.Core/VstsSyncMigrator.Core.csproj
@@ -355,6 +355,7 @@
     <Compile Include="AzureAD\Constants.cs" />
     <Compile Include="Commands\ExportADGroupsCommand.cs" />
     <Compile Include="Execution\Exceptions\UnknownLinkTypeException.cs" />
+    <Compile Include="Execution\FieldMaps\FieldLiteralMap.cs" />
     <Compile Include="Execution\FieldMaps\FieldMapBase.cs" />
     <Compile Include="Execution\FieldMaps\FieldMergeMap.cs" />
     <Compile Include="Execution\FieldMaps\FieldBlankMap.cs" />


### PR DESCRIPTION
Add a new mapping type to allow fields in the target to be populated with literal values.

Allow the standard field mapping type to enter a literal value as a fall-back, so that fields required in the target but not source can be populated with valid data.