### PR TITLE
Bugfix/logging

### DIFF
--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemMigrationContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemMigrationContext.cs
@@ -2,32 +2,27 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
+using System.IO;
 using System.Linq;
+using System.Net;
 using System.Text;
 using System.Text.RegularExpressions;
+using Microsoft.ApplicationInsights.DataContracts;
 using Microsoft.TeamFoundation.Server;
 using Microsoft.TeamFoundation.WorkItemTracking.Client;
+using Microsoft.TeamFoundation.WorkItemTracking.Proxy;
 using Microsoft.TeamFoundation.WorkItemTracking.WebApi;
 using Microsoft.VisualStudio.Services.Client;
-using Microsoft.VisualStudio.Services.Common;
-using Microsoft.VisualStudio.Services.WebApi;
-using MigrationTools.Core.Configuration.Processing;
 using Microsoft.VisualStudio.Services.WebApi.Patch.Json;
-using System.Collections;
-using VstsSyncMigrator.Core.Execution.OMatics;
-using Microsoft.TeamFoundation.WorkItemTracking.Proxy;
-using System.Net;
-using System.ServiceModel.Channels;
-using System.IO;
-using Newtonsoft.Json;
-using VstsSyncMigrator.Core;
-using Serilog;
-using Serilog.Events;
-using Serilog.Context;
-using Microsoft.ApplicationInsights.DataContracts;
 using MigrationTools;
-using Microsoft.Extensions.Hosting;
 using MigrationTools.Core.Configuration;
+using MigrationTools.Core.Configuration.Processing;
+using Newtonsoft.Json;
+using Serilog;
+using Serilog.Context;
+using Serilog.Events;
+using VstsSyncMigrator.Core;
+using VstsSyncMigrator.Core.Execution.OMatics;
 
 namespace VstsSyncMigrator.Engine
 {
@@ -55,14 +50,14 @@ namespace VstsSyncMigrator.Engine
         public WorkItemMigrationContext(IServiceProvider services, ITelemetryLogger telemetry)
             : base(services, telemetry)
         {
-            contextLog = Log.ForContext<WorkItemMigrationContext>( );
+            contextLog = Log.ForContext<WorkItemMigrationContext>();
             Telemetry = telemetry;
         }
-        
+
         public override void Configure(ITfsProcessingConfig config)
         {
             _config = (WorkItemMigrationConfig)config;
-           
+
         }
 
         private void PopulateIgnoreList()
@@ -192,7 +187,7 @@ namespace VstsSyncMigrator.Engine
                 {
                     var targetWorkItem = targetStore.FindReflectedWorkItem(sourceWorkItem, false);
                     ///////////////////////////////////////////////
-                    TraceWriteLine(LogEventLevel.Information, "Work Item has {sourceWorkItemRev} revisions and revision migration is set to {ReplayRevisions}", 
+                    TraceWriteLine(LogEventLevel.Information, "Work Item has {sourceWorkItemRev} revisions and revision migration is set to {ReplayRevisions}",
                         new Dictionary<string, object>(){
                             { "sourceWorkItemRev", sourceWorkItem.Rev },
                             { "ReplayRevisions", _config.ReplayRevisions }}
@@ -262,7 +257,7 @@ namespace VstsSyncMigrator.Engine
                     TraceWriteLine(LogEventLevel.Warning, "WebException: Will retry in {retrys}s ",
                         new Dictionary<string, object>() {
                             {"retrys", retrys }
-                        }); 
+                        });
                     System.Threading.Thread.Sleep(new TimeSpan(0, 0, retrys));
                     retrys++;
                     TraceWriteLine(LogEventLevel.Warning, "RETRY {Retrys}/{RetryLimit} ",
@@ -345,7 +340,7 @@ namespace VstsSyncMigrator.Engine
                 new Dictionary<string, object>() {
                     {"RevisionsCount", sortedRevisions.Count},
                     {"sourceWorkItemId", sourceWorkItem.Id}
-                } );
+                });
             return sortedRevisions;
         }
 
@@ -463,7 +458,7 @@ namespace VstsSyncMigrator.Engine
                     {
                         TraceWriteLine(LogEventLevel.Information,
                             "{Current} - Invalid: {CurrentRevisionWorkItemId}-{CurrentRevisionWorkItemTypeName}-{FieldReferenceName}-{SourceWorkItemTitle} Value: {FieldValue}",
-                           new Dictionary<string, object>() { 
+                           new Dictionary<string, object>() {
                                {"Current", current },
                                {"CurrentRevisionWorkItemId", currentRevisionWorkItem.Id },
                                {"CurrentRevisionWorkItemTypeName",  currentRevisionWorkItem.Type.Name},
@@ -485,7 +480,7 @@ namespace VstsSyncMigrator.Engine
                                {"TargetWorkItemId", targetWorkItem.Id },
                                {"RevisionNumber", revision.Number },
                                {"RevisionsToMigrateCount",  revisionsToMigrate.Count}
-                           }); 
+                           });
 
                 }
 
@@ -506,7 +501,7 @@ namespace VstsSyncMigrator.Engine
                     this.SaveWorkItem(targetWorkItem);
 
                     attachmentOMatic.CleanUpAfterSave(targetWorkItem);
-                    TraceWriteLine(LogEventLevel.Information, "...Saved as {TargetWorkItemId}", new Dictionary<string, object> { {"TargetWorkItemId" , targetWorkItem.Id } } );
+                    TraceWriteLine(LogEventLevel.Information, "...Saved as {TargetWorkItemId}", new Dictionary<string, object> { { "TargetWorkItemId", targetWorkItem.Id } });
                 }
             }
             catch (Exception ex)
@@ -516,7 +511,7 @@ namespace VstsSyncMigrator.Engine
                 if (targetWorkItem != null)
                 {
                     foreach (Field f in targetWorkItem.Fields)
-                        TraceWriteLine(LogEventLevel.Information, "{FieldReferenceName} ({FieldName}) | {FieldValue}", new Dictionary<string, object>() { { "FieldReferenceName", f.ReferenceName }, { "FieldName", f.Name } ,{ "FieldValue", f.Value } } );
+                        TraceWriteLine(LogEventLevel.Information, "{FieldReferenceName} ({FieldName}) | {FieldValue}", new Dictionary<string, object>() { { "FieldReferenceName", f.ReferenceName }, { "FieldName", f.Name }, { "FieldValue", f.Value } });
                 }
                 Log.Error(ex.ToString(), ex);
             }
@@ -740,7 +735,7 @@ namespace VstsSyncMigrator.Engine
         {
             if (targetWorkItem != null && _config.LinkMigration && sourceWorkItem.Links.Count > 0)
             {
-                TraceWriteLine(LogEventLevel.Information, "Links {SourceWorkItemLinkCount} | LinkMigrator:{LinkMigration}", new Dictionary<string, object>() { { "SourceWorkItemLinkCount", sourceWorkItem.Links.Count } ,{ "LinkMigration", _config.LinkMigration } });
+                TraceWriteLine(LogEventLevel.Information, "Links {SourceWorkItemLinkCount} | LinkMigrator:{LinkMigration}", new Dictionary<string, object>() { { "SourceWorkItemLinkCount", sourceWorkItem.Links.Count }, { "LinkMigration", _config.LinkMigration } });
                 workItemLinkOMatic.MigrateLinks(sourceWorkItem, sourceStore, targetWorkItem, targetStore, _config.LinkMigrationSaveEachAsAdded, me.Source.Config.ReflectedWorkItemIDFieldName);
                 AddMetric("RelatedLinkCount", processWorkItemMetrics, targetWorkItem.Links.Count);
                 int fixedLinkCount = repoOMatic.FixExternalLinks(targetWorkItem, targetStore, sourceWorkItem, _config.LinkMigrationSaveEachAsAdded);
@@ -779,7 +774,7 @@ namespace VstsSyncMigrator.Engine
             }
         }
 
-  
+
     }
 
 

--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemMigrationContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemMigrationContext.cs
@@ -286,7 +286,7 @@ namespace VstsSyncMigrator.Engine
             var average = new TimeSpan(0, 0, 0, 0, (int)(_elapsedms / _current));
             var remaining = new TimeSpan(0, 0, 0, 0, (int)(average.TotalMilliseconds * _count));
             TraceWriteLine(LogEventLevel.Information,
-                "Average time of {average:s/:fff} per work item and {remaining:%h} hours {remaining:%m} minutes {remaining:s/:fff} seconds estimated to completion",
+                "Average time of {average:%s}.{average:%fff} per work item and {remaining:%h} hours {remaining:%m} minutes {remaining:%s}.{remaining:%fff} seconds estimated to completion",
                 new Dictionary<string, object>() {
                     {"average", average},
                     {"remaining", remaining}

--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemMigrationContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemMigrationContext.cs
@@ -587,17 +587,14 @@ namespace VstsSyncMigrator.Engine
             //    $"FieldMapOnNewWorkItem: {newWorkItemstartTime} - {fieldMappingTimer.Elapsed.ToString("c")}", Name);
         }
 
-        internal void TraceWriteLine(LogEventLevel level, string message = "", Dictionary<string, object> properties = null)
+        internal void TraceWriteLine(LogEventLevel level, string message, Dictionary<string, object> properties = null)
         {
-            try /// Temp fix to eat error and unblock folks
+            if(properties != null)
             {
                 foreach (var item in properties)
                 {
                     workItemLog = workItemLog.ForContext(item.Key, item.Value);
                 }
-            }
-            catch (Exception)
-            {
             }
             workItemLog.Write(level, workItemLogTeamplate + message);
         }


### PR DESCRIPTION
Seems like some log statements that worked in trace.log does not work in Serilog.
Also fixed a null ref

This is how my logs look like now, so it does line up so should it close #567 and close #568 ? The last one was because of the earlier change from param objects to Dictionary<string,object> and null default parameter. Some calls to this method did not include a dictionary, then this blows up.

23:00:41 INF] [Product Backlog Item][Complete:     6/12][sid:    23|Rev:  2][tid:  null |  Saved TargetWorkItem 34. Replayed revision 2 of 2
[23:00:41 INF] [Product Backlog Item][Complete:     6/12][sid:    23|Rev:  2][tid:  null | ...Saved as 34
[23:00:41 INF] [Product Backlog Item][Complete:     6/12][sid:    23|Rev:  2][tid:  null | Average time of 1.115 per work item and 0 hours 0 minutes 8.008 seconds estimated to completion
TfsQueryContext: TfsQueryContext: TeamProjectCollection: https://dev.azure.com
TfsQueryContext: TfsQueryContext: TeamProject: 
TfsQueryContext: TfsQueryContext: idToFind: https://dev.azure.com//_workitems/edit/18
[23:00:41 INF] [             Feature][Complete:     7/12][sid:    18|Rev:  2][tid:  null | Work Item has 2 revisions and revision migration is set to True
[23:00:41 INF] [             Feature][Complete:     7/12][sid:    18|Rev:  2][tid:  null | Found 0 revisions to migrate on  Work item:18
[23:00:41 INF] [             Feature][Complete:     7/12][sid:    18|Rev:  2][tid:  null | Links 1 | LinkMigrator:True
[23:00:41 INF] [SKIP] Source and Target have same number of links  18 - Microsoft.TeamFoundation.WorkItemTracking.Client.WorkItemType
[23:00:41 INF] [             Feature][Complete:     7/12][sid:    18|Rev:  2][tid:  null | Skipping as work item exists and no revisions to sync detected
[23:00:41 INF] [             Feature][Complete:     7/12][sid:    18|Rev:  2][tid:  null | Average time of 1.004 per work item and 0 hours 0 minutes 6.225 seconds estimated to completion
TfsQueryContext: TfsQueryContext: TeamProjectCollection: https://dev.azure.com/
TfsQueryContext: TfsQueryContext: TeamProject: 
TfsQueryContext: TfsQueryContext: idToFind: https://dev.azure.com//_workitems/edit/17
[23:00:41 INF] [                Task][Complete:     8/12][sid:    17|Rev:  1][tid:  null | Work Item has 1 revisions and revision migration is set to True
[23:00:41 INF] [                Task][Complete:     8/12][sid:    17|Rev:  1][tid:  null | Found 0 revisions to migrate on  Work item:17
[23:00:41 INF] [                Task][Complete:     8/12][sid:    17|Rev:  1][tid:  null | Links 1 | LinkMigrator:True
[23:00:42 INF] [SKIP] Source and Target have same number of links  17 - Microsoft.TeamFoundation.WorkItemTracking.Client.WorkItemType
[23:00:42 INF] [                Task][Complete:     8/12][sid:    17|Rev:  1][tid:  null | Skipping as work item exists and no revisions to sync detected
[23:00:42 INF] [                Task][Complete:     8/12][sid:    17|Rev:  1][tid:  null | Average time of 0.996 per work item and 0 hours 0 minutes 4.881 seconds estimated to completion
TfsQueryContext: TfsQueryContext: TeamProjectCollection: https://dev.azure.com/
TfsQueryContext: TfsQueryContext: TeamProject: 
TfsQueryContext: TfsQueryContext: idToFind: https://dev.azure.com//_workitems/edit/13
[23:00:42 INF] [                 Bug][Complete:     9/12][sid:    13|Rev:  2][tid:  null | Work Item has 2 revisions and revision migration is set to True
[23:00:42 INF] [                 Bug][Complete:     9/12][sid:    13|Rev:  2][tid:  null | Found 0 revisions to migrate on  Work item:13
[23:00:42 INF] [                 Bug][Complete:     9/12][sid:    13|Rev:  2][tid:  null | Attachemnts 12 | LinkMigrator:True