### PR TITLE
fixed release link

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,5 +59,5 @@ The Azure DevOps Migration Tools allow you to bulk edit and migrate data between
 | Maintainability | [![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=vsts-sync-migrator%3Amaster&metric=sqale_rating)](https://sonarcloud.io/dashboard?id=vsts-sync-migrator%3Amaster) |
 | Security Rating | [![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=vsts-sync-migrator%3Amaster&metric=security_rating)](https://sonarcloud.io/dashboard?id=vsts-sync-migrator%3Amaster) |
 | Vulnerabilities | [![Vulnerabilities](https://sonarcloud.io/api/project_badges/measure?project=vsts-sync-migrator%3Amaster&metric=vulnerabilities)](https://sonarcloud.io/dashboard?id=vsts-sync-migrator%3Amaster) |
-| Release |![GitHub release](https://img.shields.io/github/release/nkdAgility/vsts-sync-migration.svg)| Release |[![GitHub release](https://img.shields.io/github/release/nkdAgility/vsts-sync-migration.svg)](https://github.com/nkdAgility/azure-devops-migration-tools/releases)|
+| Release | [![GitHub release](https://img.shields.io/github/release/nkdAgility/vsts-sync-migration.svg)](https://github.com/nkdAgility/azure-devops-migration-tools/releases) |
 | Chocolatey |[![Chocolatey](https://img.shields.io/chocolatey/v/vsts-sync-migrator.svg)](https://chocolatey.org/packages/vsts-sync-migrator/)|

--- a/docs/index.md
+++ b/docs/index.md
@@ -179,7 +179,7 @@ naked Agility Limited & our contibutors creates and maintains the "Azure DevOps 
 | Maintainability | [![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=vsts-sync-migrator%3Amaster&metric=sqale_rating)](https://sonarcloud.io/dashboard?id=vsts-sync-migrator%3Amaster) |
 | Security Rating | [![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=vsts-sync-migrator%3Amaster&metric=security_rating)](https://sonarcloud.io/dashboard?id=vsts-sync-migrator%3Amaster) |
 | Vulnerabilities | [![Vulnerabilities](https://sonarcloud.io/api/project_badges/measure?project=vsts-sync-migrator%3Amaster&metric=vulnerabilities)](https://sonarcloud.io/dashboard?id=vsts-sync-migrator%3Amaster) |
-| Release |![GitHub release](https://img.shields.io/github/release/nkdAgility/vsts-sync-migration.svg)| Release |[![GitHub release](https://img.shields.io/github/release/nkdAgility/vsts-sync-migration.svg)](https://github.com/nkdAgility/azure-devops-migration-tools/releases)|
+| Release | [![GitHub release](https://img.shields.io/github/release/nkdAgility/vsts-sync-migration.svg)](https://github.com/nkdAgility/azure-devops-migration-tools/releases)|
 | Chocolatey |[![Chocolatey](https://img.shields.io/chocolatey/v/vsts-sync-migrator.svg)](https://chocolatey.org/packages/vsts-sync-migrator/)|
 
 


### PR DESCRIPTION
I copied the markdown from the readme.md previously which is still working now [there](https://github.com/nkdAgility/azure-devops-migration-tools)
![image](https://user-images.githubusercontent.com/5680199/94254623-55696780-ff27-11ea-99f1-850b40829668.png)
but for the docs was causing extra columns, realized that the release columns are duplicated
![image](https://user-images.githubusercontent.com/5680199/94254699-6f0aaf00-ff27-11ea-97fc-45844a5edbff.png)
[reference](https://nkdagility.github.io/azure-devops-migration-tools/)