### PR TITLE
Change how we process parent/child links when LinkMigrationSaveEachAsAdded = true

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,4 +5,9 @@ end_of_line = crlf
 indent_style = space
 
 [*.cs]
+dotnet_sort_system_directives_first = true
 indent_style = space
+indent_size = 4
+insert_final_newline = false
+trim_trailing_whitespace = true
+charset = utf-8-bom

--- a/src/VstsSyncMigrator.Console/Properties/launchSettings.json
+++ b/src/VstsSyncMigrator.Console/Properties/launchSettings.json
@@ -1,8 +1,7 @@
 {
   "profiles": {
     "VstsSyncMigrator.Console": {
-      "commandName": "Project",
-      "commandLineArgs": "execute --config \"migrate-testplans.json\""
+      "commandName": "Project"
     }
   }
 }

--- a/src/VstsSyncMigrator.Console/Properties/launchSettings.json
+++ b/src/VstsSyncMigrator.Console/Properties/launchSettings.json
@@ -1,7 +1,8 @@
 {
   "profiles": {
     "VstsSyncMigrator.Console": {
-      "commandName": "Project"
+      "commandName": "Project",
+      "commandLineArgs": "execute --config \"migrate-testplans.json\""
     }
   }
 }

--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemMigrationContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemMigrationContext.cs
@@ -734,7 +734,7 @@ namespace VstsSyncMigrator.Engine
             if (targetWorkItem != null && _config.LinkMigration && sourceWorkItem.Links.Count > 0)
             {
                 TraceWriteLine(LogEventLevel.Information, "Links {SourceWorkItemLinkCount} | LinkMigrator:{LinkMigration}", new Dictionary<string, object>() { { "SourceWorkItemLinkCount", sourceWorkItem.Links.Count }, { "LinkMigration", _config.LinkMigration } });
-                workItemLinkOMatic.MigrateLinks(sourceWorkItem, sourceStore, targetWorkItem, targetStore, _config.LinkMigrationSaveEachAsAdded, me.Source.Config.ReflectedWorkItemIDFieldName);
+                workItemLinkOMatic.MigrateLinks(sourceWorkItem, sourceStore, targetWorkItem, targetStore, _config.LinkMigrationSaveEachAsAdded, _config.FilterWorkItemsThatAlreadyExistInTarget, me.Source.Config.ReflectedWorkItemIDFieldName);
                 AddMetric("RelatedLinkCount", processWorkItemMetrics, targetWorkItem.Links.Count);
                 int fixedLinkCount = repoOMatic.FixExternalLinks(targetWorkItem, targetStore, sourceWorkItem, _config.LinkMigrationSaveEachAsAdded);
                 AddMetric("FixedGitLinkCount", processWorkItemMetrics, fixedLinkCount);

--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemMigrationContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemMigrationContext.cs
@@ -68,6 +68,7 @@ namespace VstsSyncMigrator.Engine
                 "System.AreaId",
                 "System.IterationId",
                 "System.Id",
+                "System.Parent",
                 "System.RevisedDate",
                 "System.AuthorizedAs",
                 "System.AttachedFileCount",
@@ -589,7 +590,7 @@ namespace VstsSyncMigrator.Engine
 
         internal void TraceWriteLine(LogEventLevel level, string message, Dictionary<string, object> properties = null)
         {
-            if(properties != null)
+            if (properties != null)
             {
                 foreach (var item in properties)
                 {

--- a/src/VstsSyncMigrator.Core/Execution/OMatics/WorkItemLinkOMatic.cs
+++ b/src/VstsSyncMigrator.Core/Execution/OMatics/WorkItemLinkOMatic.cs
@@ -201,6 +201,18 @@ namespace VstsSyncMigrator.Core.Execution.OMatics
                         }
                         else
                         {
+                            if (linkTypeEnd.ImmutableName == "System.LinkTypes.Hierarchy-Reverse")
+                            {
+                                var potentialParentConflictLink = ( // TF201065: You can not add a Parent link to this work item because a work item can have only one link of this type.
+                                    from Link l in wiTargetL.Links
+                                    where l is RelatedLink
+                                        && ((RelatedLink)l).LinkTypeEnd.ImmutableName == "System.LinkTypes.Hierarchy-Reverse"
+                                    select (RelatedLink)l).SingleOrDefault();
+                                if (potentialParentConflictLink != null)
+                                {
+                                    wiTargetL.Links.Remove(potentialParentConflictLink);
+                                }
+                            }
                             wiTargetL.Links.Add(newRl);
                             if (save)
                             {


### PR DESCRIPTION
Fixes an error with linking parents when replaying a work items revisions and it's parent has changed. Should Resolve #452 which references the same thing. 

The Pr contains the changes from #580 as I was working in the same branch when I discovered the error. I can nuke the branch and get just the changes in it's own if there is issues with the way 580 was done.