### PR TITLE
fixed target project selection for work item migration

### DIFF
--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemMigrationContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemMigrationContext.cs
@@ -125,7 +125,7 @@ namespace VstsSyncMigrator.Engine
             var sourceWorkItems = Engine.Source.WorkItems.GetWorkItems(sourceQuery);
             contextLog.Information("Replay all revisions of {sourceWorkItemsCount} work items?", sourceWorkItems.Count);
             //////////////////////////////////////////////////
-            var destProject = Engine.Source.WorkItems.GetProject();
+            var destProject = Engine.Target.WorkItems.GetProject();
             contextLog.Information("Found target project as {@destProject}", destProject.Name);
             //////////////////////////////////////////////////////////FilterCompletedByQuery
             if (_config.FilterWorkItemsThatAlreadyExistInTarget)


### PR DESCRIPTION
changed the destination/target project in the work item migration context, as it should be possible to migrate from one devops project to another, this was broken in recent changes