### PR TITLE
Refactor/logging levels

### DIFF
--- a/configuration.json
+++ b/configuration.json
@@ -116,7 +116,7 @@
   "Processors": [
     {
       "ObjectType": "WorkItemDeleteConfig",
-      "Enabled": true,
+      "Enabled": false,
       "QueryBit": "AND [System.WorkItemType] NOT IN ('Test Suite', 'Test Plan')",
       "OrderBit": "[System.ChangedDate] desc"
     },

--- a/configuration.json
+++ b/configuration.json
@@ -1,6 +1,6 @@
 {
   "Version": "0.0",
-  "TelemetryEnableTrace": false,
+  "LogLevel": "Verbose",
   "workaroundForQuerySOAPBugEnabled": false,
   "Source": {
     "Collection": "https://dev.azure.com/nkdagility-preview/",

--- a/src/MigrationTools.Clients.AzureDevops.ObjectModel/Clients/MigrationClient.cs
+++ b/src/MigrationTools.Clients.AzureDevops.ObjectModel/Clients/MigrationClient.cs
@@ -82,7 +82,7 @@ namespace MigrationTools.Clients.AzureDevops.ObjectModel.Clients
         {
             if (_collection == null)
             {
-                _Telemetry.TrackEvent("TeamProjectContext.Connect",
+                _Telemetry.TrackEvent("TeamProjectContext.EnsureCollection",
                     new Dictionary<string, string> {
                           { "Name", Config.Project},
                           { "Target Project", Config.Project},
@@ -91,21 +91,21 @@ namespace MigrationTools.Clients.AzureDevops.ObjectModel.Clients
                     }, null);
                 Stopwatch connectionTimer = Stopwatch.StartNew();
                 DateTime start = DateTime.Now;
-                Log.Information("Connecting to {@Config}", Config);
+                Log.Information("MigrationClient: Connecting to {Project} on {Collection}", Config.Project, Config.Collection);
+                Log.Verbose("MigrationClient: Connecting to {@Config}", Config);
 
                 if (_credentials == null)
                     _collection = new TfsTeamProjectCollection(Config.Collection);
                 else
                     _collection = new TfsTeamProjectCollection(Config.Collection, new VssCredentials(new Microsoft.VisualStudio.Services.Common.WindowsCredential(_credentials)));
-
                 try
                 {
-                    Log.Debug("Connected to {CollectionUrl} ", _collection.Uri.ToString());
-                    Log.Debug("validating security for {@AuthorizedIdentity} ", _collection.AuthorizedIdentity);
+                    Log.Debug("MigrationClient: Connected to {CollectionUrl} ", _collection.Uri.ToString());
+                    Log.Debug("MigrationClient: validating security for {@AuthorizedIdentity} ", _collection.AuthorizedIdentity);
                     _collection.EnsureAuthenticated();
                     connectionTimer.Stop();
                     _Telemetry.TrackDependency(new DependencyTelemetry("TeamService", "EnsureAuthenticated", start, connectionTimer.Elapsed, true));
-                    Log.Information(" Access granted ");
+                    Log.Information("MigrationClient: Access granted ");
                 }
                 catch (TeamFoundationServiceUnavailableException ex)
                 {
@@ -118,12 +118,12 @@ namespace MigrationTools.Clients.AzureDevops.ObjectModel.Clients
                        new Dictionary<string, double> {
                             { "ConnectionTimer", connectionTimer.ElapsedMilliseconds }
                        });
-                    Log.Error(ex, "Unable to connect to {@Config}", Config);
+                    Log.Error(ex, "MigrationClient: Unable to connect to {@Config}", Config);
                     throw;
                 }
             }
         }
-
+ 
         public T GetService<T>()
         {
             EnsureCollection();

--- a/src/MigrationTools.Clients.AzureDevops.ObjectModel/Clients/WorkItemMigrationClient.cs
+++ b/src/MigrationTools.Clients.AzureDevops.ObjectModel/Clients/WorkItemMigrationClient.cs
@@ -80,16 +80,20 @@ namespace MigrationTools.Clients.AzureDevops.ObjectModel.Clients
         }
         public override int GetReflectedWorkItemId(WorkItemData workItem)
         {
+            Log.Verbose("GetReflectedWorkItemId: START");
             var local = workItem.ToWorkItem();
             if (!local.Fields.Contains(Config.ReflectedWorkItemIDFieldName))
             {
+                Log.Verbose("GetReflectedWorkItemId: END - no reflected work item id on work item");
                 return 0;
             }
             string rwiid = local.Fields[Config.ReflectedWorkItemIDFieldName].Value.ToString();
             if (Regex.IsMatch(rwiid, @"(http(s)?://)?([\w-]+\.)+[\w-]+(/[\w- ;,./?%&=]*)?"))
             {
+                Log.Verbose("GetReflectedWorkItemId: END - Has ReflectedWorkItemIdField and has value");
                 return int.Parse(rwiid.Substring(rwiid.LastIndexOf(@"/") + 1));
             }
+            Log.Verbose("GetReflectedWorkItemId: END - Has ReflectedWorkItemIdField but has no value");
             return 0;
         }
 

--- a/src/MigrationTools.Clients.AzureDevops.ObjectModel/Clients/WorkItemMigrationClient.cs
+++ b/src/MigrationTools.Clients.AzureDevops.ObjectModel/Clients/WorkItemMigrationClient.cs
@@ -80,20 +80,20 @@ namespace MigrationTools.Clients.AzureDevops.ObjectModel.Clients
         }
         public override int GetReflectedWorkItemId(WorkItemData workItem)
         {
-            Log.Verbose("GetReflectedWorkItemId: START");
+            Log.Debug("GetReflectedWorkItemId: START");
             var local = workItem.ToWorkItem();
             if (!local.Fields.Contains(Config.ReflectedWorkItemIDFieldName))
             {
-                Log.Verbose("GetReflectedWorkItemId: END - no reflected work item id on work item");
+                Log.Debug("GetReflectedWorkItemId: END - no reflected work item id on work item");
                 return 0;
             }
             string rwiid = local.Fields[Config.ReflectedWorkItemIDFieldName].Value.ToString();
             if (Regex.IsMatch(rwiid, @"(http(s)?://)?([\w-]+\.)+[\w-]+(/[\w- ;,./?%&=]*)?"))
             {
-                Log.Verbose("GetReflectedWorkItemId: END - Has ReflectedWorkItemIdField and has value");
+                Log.Debug("GetReflectedWorkItemId: END - Has ReflectedWorkItemIdField and has value");
                 return int.Parse(rwiid.Substring(rwiid.LastIndexOf(@"/") + 1));
             }
-            Log.Verbose("GetReflectedWorkItemId: END - Has ReflectedWorkItemIdField but has no value");
+            Log.Debug("GetReflectedWorkItemId: END - Has ReflectedWorkItemIdField but has no value");
             return 0;
         }
 

--- a/src/MigrationTools.Clients.AzureDevops.ObjectModel/Clients/WorkItemQuery.cs
+++ b/src/MigrationTools.Clients.AzureDevops.ObjectModel/Clients/WorkItemQuery.cs
@@ -19,23 +19,25 @@ namespace MigrationTools.Clients.AzureDevops.ObjectModel.Clients
 
         public override List<WorkItemData> GetWorkItems()
         {
+            Log.Verbose("WorkItemQuery: ===========GetWorkItems=============");
             var wiClient = (WorkItemMigrationClient)MigrationClient.WorkItems;
             Telemetry.TrackEvent("WorkItemQuery.Execute", Parameters, null);
-            Log.Information("WorkItemQuery: TeamProjectCollection: {QueryTarget}",  wiClient.Store.TeamProjectCollection.Uri.ToString());
-            Log.Information("WorkItemQuery: Query: {QueryText}",  Query);
-            Log.Information("WorkItemQuery: Paramiters: {@QueryParams}",  Parameters);
+            Log.Verbose("WorkItemQuery: TeamProjectCollection: {QueryTarget}",  wiClient.Store.TeamProjectCollection.Uri.ToString());
+            Log.Verbose("WorkItemQuery: Query: {QueryText}",  Query);
+            Log.Verbose("WorkItemQuery: Paramiters: {@QueryParams}",  Parameters);
 
             WorkItemCollection wc;
             var startTime = DateTime.UtcNow;
             Stopwatch queryTimer = new Stopwatch();
             foreach (var item in Parameters)
             {
-                Debug.WriteLine(string.Format("TfsQueryContext: {0}: {1}", item.Key, item.Value), "TfsQueryContext");
+                Log.Verbose("WorkItemQuery: {0}: {1}", item.Key, item.Value);
             }
 
             queryTimer.Start();
             try
             {
+                Log.Information("WorkItemQuery: Running query...");
                 wc = wiClient.Store.Query(Query); //, parameters);
                 queryTimer.Stop();
                 Telemetry.TrackDependency(new DependencyTelemetry("TeamService", "Query", startTime, queryTimer.Elapsed, true));
@@ -48,7 +50,7 @@ namespace MigrationTools.Clients.AzureDevops.ObjectModel.Clients
                             { "QueryTime", queryTimer.ElapsedMilliseconds },
                           { "QueryCount", wc.Count }
                       });
-                Log.Debug("Query Complete: found {WorkItemCount} work items in {QueryTimer}ms ", wc.Count, queryTimer.ElapsedMilliseconds);
+                Log.Information("WorkItemQuery: Query found {WorkItemCount} work items in {QueryTimer}ms ", wc.Count, queryTimer.ElapsedMilliseconds);
 
             }
             catch (Exception ex)
@@ -62,7 +64,7 @@ namespace MigrationTools.Clients.AzureDevops.ObjectModel.Clients
                        new Dictionary<string, double> {
                             { "QueryTime",queryTimer.ElapsedMilliseconds }
                        });
-                Trace.TraceWarning($"  [EXCEPTION] {ex}");
+                Log.Error(ex, " Error running query");
                 throw;
             }
             return wc.ToWorkItemDataList();

--- a/src/MigrationTools.Clients.AzureDevops.ObjectModel/Clients/WorkItemQuery.cs
+++ b/src/MigrationTools.Clients.AzureDevops.ObjectModel/Clients/WorkItemQuery.cs
@@ -22,9 +22,9 @@ namespace MigrationTools.Clients.AzureDevops.ObjectModel.Clients
             Log.Verbose("WorkItemQuery: ===========GetWorkItems=============");
             var wiClient = (WorkItemMigrationClient)MigrationClient.WorkItems;
             Telemetry.TrackEvent("WorkItemQuery.Execute", Parameters, null);
-            Log.Verbose("WorkItemQuery: TeamProjectCollection: {QueryTarget}",  wiClient.Store.TeamProjectCollection.Uri.ToString());
-            Log.Verbose("WorkItemQuery: Query: {QueryText}",  Query);
-            Log.Verbose("WorkItemQuery: Paramiters: {@QueryParams}",  Parameters);
+            Log.Debug("WorkItemQuery: TeamProjectCollection: {QueryTarget}",  wiClient.Store.TeamProjectCollection.Uri.ToString());
+            Log.Debug("WorkItemQuery: Query: {QueryText}",  Query);
+            Log.Debug("WorkItemQuery: Paramiters: {@QueryParams}",  Parameters);
 
             WorkItemCollection wc;
             var startTime = DateTime.UtcNow;

--- a/src/MigrationTools.Clients.AzureDevops.ObjectModel/Clients/WorkItemQuery.cs
+++ b/src/MigrationTools.Clients.AzureDevops.ObjectModel/Clients/WorkItemQuery.cs
@@ -19,7 +19,7 @@ namespace MigrationTools.Clients.AzureDevops.ObjectModel.Clients
 
         public override List<WorkItemData> GetWorkItems()
         {
-            Log.Verbose("WorkItemQuery: ===========GetWorkItems=============");
+            Log.Debug("WorkItemQuery: ===========GetWorkItems=============");
             var wiClient = (WorkItemMigrationClient)MigrationClient.WorkItems;
             Telemetry.TrackEvent("WorkItemQuery.Execute", Parameters, null);
             Log.Debug("WorkItemQuery: TeamProjectCollection: {QueryTarget}",  wiClient.Store.TeamProjectCollection.Uri.ToString());
@@ -31,7 +31,7 @@ namespace MigrationTools.Clients.AzureDevops.ObjectModel.Clients
             Stopwatch queryTimer = new Stopwatch();
             foreach (var item in Parameters)
             {
-                Log.Verbose("WorkItemQuery: {0}: {1}", item.Key, item.Value);
+                Log.Debug("WorkItemQuery: {0}: {1}", item.Key, item.Value);
             }
 
             queryTimer.Start();

--- a/src/MigrationTools.Clients.AzureDevops.ObjectModel/Enrichers/GitRepositoryInfo.cs
+++ b/src/MigrationTools.Clients.AzureDevops.ObjectModel/Enrichers/GitRepositoryInfo.cs
@@ -1,0 +1,129 @@
+﻿using Microsoft.TeamFoundation.SourceControl.WebApi;
+using Microsoft.TeamFoundation.WorkItemTracking.Client;
+using Serilog;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace MigrationTools.Clients.AzureDevops.ObjectModel.Enrichers
+{
+    public class GitRepositoryInfo
+    {
+        public string CommitID { get; }
+        public string RepoID { get; }
+        public GitRepository GitRepo { get; }
+
+        public GitRepositoryInfo(string CommitID, string RepoID, GitRepository GitRepo)
+        {
+            this.CommitID = CommitID;
+            this.RepoID = RepoID;
+            this.GitRepo = GitRepo;
+        }
+
+        public static GitRepositoryInfo Create(ExternalLink gitExternalLink, IList<GitRepository> possibleRepos, IMigrationEngine migrationEngine, string workItemSourceProjectName)
+        {
+            var repoType = DetermineFromLink(gitExternalLink.LinkedArtifactUri);
+            switch (repoType)
+            {
+                case RepistoryType.Git:
+                    return CreateFromGit(gitExternalLink, possibleRepos);
+
+                case RepistoryType.TFVC:
+                    return CreateFromTFVC(gitExternalLink, possibleRepos, migrationEngine.ChangeSetMapps.Items, migrationEngine.Source.Config.Project, workItemSourceProjectName);
+            }
+
+            return null;
+        }
+
+        private static GitRepositoryInfo CreateFromTFVC(ExternalLink gitExternalLink, IList<GitRepository> possibleRepos, ReadOnlyDictionary<int, string> changesetMapping, string sourceProjectName, string workItemSourceProjectName)
+        {
+            string commitID;
+            string repoID;
+            GitRepository gitRepo;
+
+            //vstfs:///VersionControl/Changeset/{id}
+            var changeSetIdPart = gitExternalLink.LinkedArtifactUri.Substring(gitExternalLink.LinkedArtifactUri.LastIndexOf('/') + 1);
+            if (!int.TryParse(changeSetIdPart, out int changeSetId))
+            {
+                return null;
+            }
+
+            var commitIDKvPair = changesetMapping.FirstOrDefault(item => item.Key == changeSetId);
+            if (string.IsNullOrEmpty(commitIDKvPair.Value))
+            {
+                Log.Debug("GitRepositoryInfo: Commit Id not found from Changeset Id {changeSetIdPart}.");
+                return null;
+            }
+
+            //assume the GitRepository source name is the work items project name, which changeset links needs to be fixed
+            return new GitRepositoryInfo(commitIDKvPair.Value, null, new GitRepository() { Name = workItemSourceProjectName });
+        }
+
+        private enum RepistoryType
+        {
+            Unknown,
+            TFVC,
+            Git
+        }
+
+        private static RepistoryType DetermineFromLink(string link)
+        {
+            if (string.IsNullOrEmpty(link))
+                throw new ArgumentNullException("link");
+
+            //vstfs:///Git/Commit/25f94570-e3e7-4b79-ad19-4b434787fd5a%2f50477259-3058-4dff-ba4c-e8c179ec5327%2f41dd2754058348d72a6417c0615c2543b9b55535
+            //vstfs:///Git/PullRequestId/
+            //ToDo: check only for "git" ?
+            if (link.ToLowerInvariant().Contains("git/commit")
+                || link.ToLowerInvariant().Contains("git/pullrequestid")
+                || link.ToLowerInvariant().Contains("git/ref"))
+                return RepistoryType.Git;
+
+            //vstfs:///VersionControl/Changeset/{id}
+            if (link.ToLowerInvariant().Contains("versioncontrol/changeset"))
+                return RepistoryType.TFVC;
+
+            Log.Debug("GitRepositoryInfo: Cannot determine repository type from external link: {link}");
+
+            return RepistoryType.Unknown;
+        }
+
+        public static GitRepositoryInfo CreateFromGit(ExternalLink gitExternalLink, IList<GitRepository> possibleRepos)
+        {
+            string commitID;
+            string repoID;
+            GitRepository gitRepo;
+            //vstfs:///Git/Commit/25f94570-e3e7-4b79-ad19-4b434787fd5a%2f50477259-3058-4dff-ba4c-e8c179ec5327%2f41dd2754058348d72a6417c0615c2543b9b55535
+            string guidbits = gitExternalLink.LinkedArtifactUri.Substring(gitExternalLink.LinkedArtifactUri.LastIndexOf('/') + 1);
+            string[] bits = Regex.Split(guidbits, "%2f", RegexOptions.IgnoreCase);
+            repoID = bits[1];
+            if (bits.Count() >= 3)
+            {
+                commitID = $"{bits[2]}";
+                for (int i = 3; i < bits.Count(); i++)
+                {
+                    commitID += $"%2f{bits[i]}";
+                }
+            }
+            else
+            {
+                commitID = bits[2];
+            }
+            gitRepo =
+                (from g in possibleRepos where g.Id.ToString() == repoID select g)
+                .SingleOrDefault();
+            return new GitRepositoryInfo(commitID, repoID, gitRepo);
+        }
+
+        internal static GitRepositoryInfo Create(string targetRepoName, GitRepositoryInfo sourceRepoInfo, IList<GitRepository> targetRepos)
+        {
+            var gitRepo = (from g in targetRepos
+                           where
+                               g.Name == targetRepoName
+                           select g).SingleOrDefault();
+            return new GitRepositoryInfo(sourceRepoInfo.CommitID, gitRepo?.Id.ToString(), gitRepo);
+        }
+    }
+}

--- a/src/MigrationTools.Clients.AzureDevops.ObjectModel/Enrichers/NodeStructureEnricher.cs
+++ b/src/MigrationTools.Clients.AzureDevops.ObjectModel/Enrichers/NodeStructureEnricher.cs
@@ -155,7 +155,7 @@ namespace MigrationTools.Clients.AzureDevops.ObjectModel.Enrichers
 
                 if (!_nodeBasePaths.Any(p => path.StartsWith(p, StringComparison.InvariantCultureIgnoreCase)))
                 {
-                    Trace.WriteLine(string.Format("--IgnoreNode: {0}", nodePath));
+                    Log.Verbose("--IgnoreNode: {0}", nodePath);
                     return false;
                 }
             }
@@ -168,28 +168,27 @@ namespace MigrationTools.Clients.AzureDevops.ObjectModel.Enrichers
             string nodePath = string.Format(@"{0}\{1}", parent.Path, name);
             NodeInfo node = null;
 
-            Trace.Write(string.Format("--CreateNode: {0}", nodePath));
+            Log.Verbose("--CreateNode: {0}", nodePath);
             try
             {
                 node = _targetCommonStructureService.GetNodeFromPath(nodePath);
-                Trace.Write("...found");
+                Log.Verbose("...found");
             }
             catch (CommonStructureSubsystemException ex)
             {
                 try
                 {
                     string newPathUri = _targetCommonStructureService.CreateNode(name, parent.Uri);
-                    Trace.Write("...created");
+                    Log.Verbose("...created");
                     node = _targetCommonStructureService.GetNode(newPathUri);
                 }
                 catch
                 {
                     Log.Error(ex, "Creating Node");
-                    Trace.Write("...missing");
+                    Log.Verbose("...missing");
                     throw;
                 }
             }
-
             Trace.WriteLine(String.Empty);
             return node;
         }
@@ -198,18 +197,18 @@ namespace MigrationTools.Clients.AzureDevops.ObjectModel.Enrichers
         {
             string nodePath = string.Format(@"{0}\{1}", parent.Path, name);
             NodeInfo node = null;
-            Trace.Write(string.Format("--CreateNode: {0}, start date: {1}, finish date: {2}", nodePath, startDate, finishDate));
+            Log.Verbose("--CreateNode: {0}, start date: {1}, finish date: {2}", nodePath, startDate, finishDate);
             try
             {
                 node = _targetCommonStructureService.GetNodeFromPath(nodePath);
-                Trace.Write("...found");
+                Log.Verbose("...found");
             }
             catch (CommonStructureSubsystemException ex)
             {
                 try
                 {
                     string newPathUri = _targetCommonStructureService.CreateNode(name, parent.Uri);
-                    Log.Information("...created");
+                    Log.Verbose("...created");
                     node = _targetCommonStructureService.GetNode(newPathUri);
                 }
                 catch
@@ -222,14 +221,14 @@ namespace MigrationTools.Clients.AzureDevops.ObjectModel.Enrichers
             try
             {
                 ((ICommonStructureService4)_targetCommonStructureService).SetIterationDates(node.Uri, startDate, finishDate);
-                Trace.Write("...dates assigned");
+                Log.Verbose("...dates assigned");
             }
             catch (CommonStructureSubsystemException ex)
             {
                 Log.Warning(ex, "Dates not set ");
             }
 
-            Trace.WriteLine(String.Empty);
+            Log.Verbose(String.Empty);
             return node;
         }
 

--- a/src/MigrationTools.Clients.AzureDevops.ObjectModel/Enrichers/NodeStructureEnricher.cs
+++ b/src/MigrationTools.Clients.AzureDevops.ObjectModel/Enrichers/NodeStructureEnricher.cs
@@ -155,7 +155,7 @@ namespace MigrationTools.Clients.AzureDevops.ObjectModel.Enrichers
 
                 if (!_nodeBasePaths.Any(p => path.StartsWith(p, StringComparison.InvariantCultureIgnoreCase)))
                 {
-                    Log.Verbose("--IgnoreNode: {0}", nodePath);
+                    Log.Debug("--IgnoreNode: {0}", nodePath);
                     return false;
                 }
             }
@@ -168,24 +168,24 @@ namespace MigrationTools.Clients.AzureDevops.ObjectModel.Enrichers
             string nodePath = string.Format(@"{0}\{1}", parent.Path, name);
             NodeInfo node = null;
 
-            Log.Verbose("--CreateNode: {0}", nodePath);
+            Log.Debug("--CreateNode: {0}", nodePath);
             try
             {
                 node = _targetCommonStructureService.GetNodeFromPath(nodePath);
-                Log.Verbose("...found");
+                Log.Debug("...found");
             }
             catch (CommonStructureSubsystemException ex)
             {
                 try
                 {
                     string newPathUri = _targetCommonStructureService.CreateNode(name, parent.Uri);
-                    Log.Verbose("...created");
+                    Log.Debug("...created");
                     node = _targetCommonStructureService.GetNode(newPathUri);
                 }
                 catch
                 {
                     Log.Error(ex, "Creating Node");
-                    Log.Verbose("...missing");
+                    Log.Debug("...missing");
                     throw;
                 }
             }
@@ -197,18 +197,18 @@ namespace MigrationTools.Clients.AzureDevops.ObjectModel.Enrichers
         {
             string nodePath = string.Format(@"{0}\{1}", parent.Path, name);
             NodeInfo node = null;
-            Log.Verbose("--CreateNode: {0}, start date: {1}, finish date: {2}", nodePath, startDate, finishDate);
+            Log.Debug("--CreateNode: {0}, start date: {1}, finish date: {2}", nodePath, startDate, finishDate);
             try
             {
                 node = _targetCommonStructureService.GetNodeFromPath(nodePath);
-                Log.Verbose("...found");
+                Log.Debug("...found");
             }
             catch (CommonStructureSubsystemException ex)
             {
                 try
                 {
                     string newPathUri = _targetCommonStructureService.CreateNode(name, parent.Uri);
-                    Log.Verbose("...created");
+                    Log.Debug("...created");
                     node = _targetCommonStructureService.GetNode(newPathUri);
                 }
                 catch
@@ -221,14 +221,14 @@ namespace MigrationTools.Clients.AzureDevops.ObjectModel.Enrichers
             try
             {
                 ((ICommonStructureService4)_targetCommonStructureService).SetIterationDates(node.Uri, startDate, finishDate);
-                Log.Verbose("...dates assigned");
+                Log.Debug("...dates assigned");
             }
             catch (CommonStructureSubsystemException ex)
             {
                 Log.Warning(ex, "Dates not set ");
             }
 
-            Log.Verbose(String.Empty);
+            Log.Debug(String.Empty);
             return node;
         }
 

--- a/src/MigrationTools.Clients.AzureDevops.ObjectModel/Enrichers/NodeStructureEnricher.cs
+++ b/src/MigrationTools.Clients.AzureDevops.ObjectModel/Enrichers/NodeStructureEnricher.cs
@@ -2,6 +2,7 @@
 using System.Diagnostics;
 using System.Linq;
 using System.Xml;
+using Microsoft.Extensions.Logging;
 using Microsoft.TeamFoundation.Server;
 using MigrationTools;
 using MigrationTools.Configuration;
@@ -13,7 +14,7 @@ using Serilog;
 
 namespace MigrationTools.Clients.AzureDevops.ObjectModel.Enrichers
 {
-    public class NodeStructureEnricher : IWorkItemEnricher
+    public class NodeStructureEnricher : WorkItemEnricher
     {
         private bool _prefixProjectToNodes = false;
         private ICommonStructureService _sourceCommonStructureService;
@@ -22,21 +23,19 @@ namespace MigrationTools.Clients.AzureDevops.ObjectModel.Enrichers
         private NodeInfo[] _sourceRootNodes;
         private string[] _nodeBasePaths;
 
-        public IMigrationEngine Engine { get; }
-
-        public void Configure(bool save = true, bool filterWorkItemsThatAlreadyExistInTarget = true)
+        public override void Configure(bool save = true, bool filterWorkItemsThatAlreadyExistInTarget = true)
         {
             
         }
 
-        public void Enrich(WorkItemData sourceWorkItem, WorkItemData targetWorkItem)
+        public override int Enrich(WorkItemData sourceWorkItem, WorkItemData targetWorkItem)
         {
-   
+            throw new NotImplementedException();
+            return 0;
         }
 
-        public NodeStructureEnricher(IMigrationEngine engine)
+        public NodeStructureEnricher(IMigrationEngine engine, ILogger<NodeStructureEnricher> logger) : base(engine, logger)
         {
-            Engine = engine;
             _sourceCommonStructureService = (ICommonStructureService)Engine.Source.GetService<ICommonStructureService>();
             _targetCommonStructureService = (ICommonStructureService)Engine.Target.GetService<ICommonStructureService4>();
             _sourceProjectInfo = _sourceCommonStructureService.GetProjectFromName(Engine.Source.Config.Project);
@@ -60,7 +59,7 @@ namespace MigrationTools.Clients.AzureDevops.ObjectModel.Enrichers
             if (sourceNode == null) // May run into language problems!!! This is to try and detect that
             {
                 Exception ex = new Exception(string.Format("Unable to load Common Structure for Source. This is usually due to diferent language versions. Validate that '{0}' is the correct name in your version. ", treeTypeSource));
-                Log.Error(ex, "Unable to load Common Structure for Source.");
+                Log.LogError(ex, "Unable to load Common Structure for Source.");
                 throw ex;
             }
             XmlElement sourceTree = _sourceCommonStructureService.GetNodesXml(new string[] { sourceNode.Uri }, true);
@@ -72,7 +71,7 @@ namespace MigrationTools.Clients.AzureDevops.ObjectModel.Enrichers
             catch (Exception ex)
             {
                 Exception ex2 = new Exception(string.Format("Unable to load Common Structure for Target.This is usually due to diferent language versions. Validate that '{0}' is the correct name in your version. ", treeTypeTarget), ex);
-                Log.Error(ex2, "Unable to load Common Structure for Target.");
+                Log.LogError(ex2, "Unable to load Common Structure for Target.");
                 throw ex2;
             }
             if (_prefixProjectToNodes)
@@ -155,7 +154,7 @@ namespace MigrationTools.Clients.AzureDevops.ObjectModel.Enrichers
 
                 if (!_nodeBasePaths.Any(p => path.StartsWith(p, StringComparison.InvariantCultureIgnoreCase)))
                 {
-                    Log.Debug("--IgnoreNode: {0}", nodePath);
+                    Log.LogDebug("--IgnoreNode: {0}", nodePath);
                     return false;
                 }
             }
@@ -168,24 +167,24 @@ namespace MigrationTools.Clients.AzureDevops.ObjectModel.Enrichers
             string nodePath = string.Format(@"{0}\{1}", parent.Path, name);
             NodeInfo node = null;
 
-            Log.Debug("--CreateNode: {0}", nodePath);
+            Log.LogDebug("--CreateNode: {0}", nodePath);
             try
             {
                 node = _targetCommonStructureService.GetNodeFromPath(nodePath);
-                Log.Debug("...found");
+                Log.LogDebug("...found");
             }
             catch (CommonStructureSubsystemException ex)
             {
                 try
                 {
                     string newPathUri = _targetCommonStructureService.CreateNode(name, parent.Uri);
-                    Log.Debug("...created");
+                    Log.LogDebug("...created");
                     node = _targetCommonStructureService.GetNode(newPathUri);
                 }
                 catch
                 {
-                    Log.Error(ex, "Creating Node");
-                    Log.Debug("...missing");
+                    Log.LogError(ex, "Creating Node");
+                    Log.LogDebug("...missing");
                     throw;
                 }
             }
@@ -197,23 +196,23 @@ namespace MigrationTools.Clients.AzureDevops.ObjectModel.Enrichers
         {
             string nodePath = string.Format(@"{0}\{1}", parent.Path, name);
             NodeInfo node = null;
-            Log.Debug("--CreateNode: {0}, start date: {1}, finish date: {2}", nodePath, startDate, finishDate);
+            Log.LogDebug("--CreateNode: {0}, start date: {1}, finish date: {2}", nodePath, startDate, finishDate);
             try
             {
                 node = _targetCommonStructureService.GetNodeFromPath(nodePath);
-                Log.Debug("...found");
+                Log.LogDebug("...found");
             }
             catch (CommonStructureSubsystemException ex)
             {
                 try
                 {
                     string newPathUri = _targetCommonStructureService.CreateNode(name, parent.Uri);
-                    Log.Debug("...created");
+                    Log.LogDebug("...created");
                     node = _targetCommonStructureService.GetNode(newPathUri);
                 }
                 catch
                 {
-                    Log.Warning(ex, "Missing ");
+                    Log.LogWarning(ex, "Missing ");
                     throw;
                 }
             }
@@ -221,14 +220,14 @@ namespace MigrationTools.Clients.AzureDevops.ObjectModel.Enrichers
             try
             {
                 ((ICommonStructureService4)_targetCommonStructureService).SetIterationDates(node.Uri, startDate, finishDate);
-                Log.Debug("...dates assigned");
+                Log.LogDebug("...dates assigned");
             }
             catch (CommonStructureSubsystemException ex)
             {
-                Log.Warning(ex, "Dates not set ");
+                Log.LogWarning(ex, "Dates not set ");
             }
 
-            Log.Debug(String.Empty);
+            Log.LogDebug(String.Empty);
             return node;
         }
 

--- a/src/MigrationTools.Clients.AzureDevops.Rest/Enrichers/EmbededImagesRepairEnricher.cs
+++ b/src/MigrationTools.Clients.AzureDevops.Rest/Enrichers/EmbededImagesRepairEnricher.cs
@@ -9,6 +9,7 @@ using System.Net.Http.Headers;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using MigrationTools.Configuration.Processing;
 using MigrationTools.DataContracts;
 using MigrationTools.Enrichers;
@@ -18,10 +19,23 @@ namespace MigrationTools.Clients.AzureDevops.Rest.Enrichers
     public class EmbededImagesRepairEnricher : EmbededImagesRepairEnricherBase
     {
 
-        public override void FixEmbededImages(WorkItemData wi, string oldTfsurl, string newTfsurl, string sourcePersonalAccessToken = "")
+        public EmbededImagesRepairEnricher(IMigrationEngine engine, ILogger<EmbededImagesRepairEnricher> logger) :base(engine, logger)
+        {
+
+        }
+        public override void Configure(bool save = true, bool filter = true)
         {
             throw new NotImplementedException();
         }
 
+        public override int Enrich(WorkItemData sourceWorkItem, WorkItemData targetWorkItem)
+        {
+            throw new NotImplementedException();
+        }
+
+        protected override void FixEmbededImages(WorkItemData wi, string oldTfsurl, string newTfsurl, string sourcePersonalAccessToken = "")
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/MigrationTools.Clients.AzureDevops.Rest/FieldMaps/FieldBlankMap.cs
+++ b/src/MigrationTools.Clients.AzureDevops.Rest/FieldMaps/FieldBlankMap.cs
@@ -20,11 +20,6 @@ namespace MigrationTools.Clients.AzureDevops.Rest.FieldMaps
         internal override void InternalExecute(WorkItem source, WorkItem target)
         {
             throw new NotImplementedException();
-            //if (target.Fields.ContainsKey(Config.targetField))
-            //{ 
-            //    (target.Fields[Config.targetField]).Value = "";
-            //    Trace.WriteLine(string.Format("  [UPDATE] field mapped {0}:{1} to {2} blanked", source.Id, target.Id, this.Config.targetField));
-            //}
         }
     }
 }

--- a/src/MigrationTools.Clients.AzureDevops.Rest/FieldMaps/FieldMergeMap.cs
+++ b/src/MigrationTools.Clients.AzureDevops.Rest/FieldMaps/FieldMergeMap.cs
@@ -29,24 +29,6 @@ namespace MigrationTools.Clients.AzureDevops.Rest.FieldMaps
         internal override void InternalExecute(WorkItem source, WorkItem target)
         {
             throw new NotImplementedException();
-            //if (source.Fields.ContainsKey(Config.sourceField1) && source.Fields.ContainsKey(Config.sourceField2))
-            //{
-            //    var val1 = source.Fields[Config.sourceField1].Value != null ? source.Fields[Config.sourceField1].Value.ToString() : string.Empty;
-            //    var val2 = source.Fields[Config.sourceField2].Value != null ? source.Fields[Config.sourceField2].Value.ToString() : string.Empty;
-            //    var valT = target.Fields[Config.targetField].Value != null ? target.Fields[Config.targetField].Value.ToString() : string.Empty;
-            //    var newValT = string.Format(Config.formatExpression, val1, val2);
-            //    if (valT.Contains(val2) && val2.Trim().Length > 0)
-            //    {
-            //        Trace.WriteLine(string.Format("  [SKIP] field already merged {0}:{1}+{2} to {3}:{4}", source.Id, Config.sourceField1, Config.sourceField2, target.Id, Config.targetField));
-            //    } else if (valT.Equals(newValT))
-            //        {
-            //        Trace.WriteLine(string.Format("  [SKIP] field already merged {0}:{1}+{2} to {3}:{4}", source.Id, Config.sourceField1, Config.sourceField2, target.Id, Config.targetField));
-            //    } else
-            //    {
-            //        target.Fields[Config.targetField].Value = newValT;
-            //        Trace.WriteLine(string.Format("  [UPDATE] field merged {0}:{1}+{2} to {3}:{4}", source.Id, Config.sourceField1, Config.sourceField2, target.Id, Config.targetField));
-            //    }
-            //}
         }
     }
 }

--- a/src/MigrationTools.Clients.AzureDevops.Rest/FieldMaps/FieldToFieldMap.cs
+++ b/src/MigrationTools.Clients.AzureDevops.Rest/FieldMaps/FieldToFieldMap.cs
@@ -25,16 +25,6 @@ namespace MigrationTools.Clients.AzureDevops.Rest.FieldMaps
         internal override void InternalExecute(WorkItem source, WorkItem target)
         {
             throw new NotImplementedException();
-            //if (source.Fields.Contains(Config.sourceField) && target.Fields.Contains(Config.targetField))
-            //{
-            //    var value = source.Fields[Config.sourceField].Value;
-            //    if ((value as string is null || value as string == "") && Config.defaultValue != null)
-            //    {
-            //        value = Config.defaultValue;
-            //    }
-            //    target.Fields[Config.targetField].Value = value;
-            //    Trace.WriteLine(string.Format("  [UPDATE] field mapped {0}:{1} to {2}:{3}", source.Id, Config.sourceField, target.Id, Config.targetField));
-            //}
         }
     }
 }

--- a/src/MigrationTools.Clients.AzureDevops.Rest/FieldMaps/FieldToTagFieldMap.cs
+++ b/src/MigrationTools.Clients.AzureDevops.Rest/FieldMaps/FieldToTagFieldMap.cs
@@ -22,30 +22,7 @@ namespace MigrationTools.Clients.AzureDevops.Rest.FieldMaps
         internal override void InternalExecute(WorkItem source, WorkItem target)
         {
             throw new NotImplementedException();
-            //if (source.Fields.Contains(this.Config.sourceField))
-            //{
-            //    List<string> newTags = target.Tags.Split(char.Parse(@";")).ToList();
-            //    // to tag
-            //    if (source.Fields[this.Config.sourceField].Value != null)
-            //    {
-            //        string value = source.Fields[this.Config.sourceField].Value.ToString();
-            //        if (!string.IsNullOrEmpty(value))
-            //        {
-            //            if (string.IsNullOrEmpty(Config.formatExpression))
-            //            {
-            //                newTags.Add(value);
-            //            }
-            //            else
-            //            {
-            //                newTags.Add(string.Format(Config.formatExpression, value));
-            //            }
-            //            target.Tags = string.Join(";", newTags.ToArray());
-            //            Trace.WriteLine(string.Format("  [UPDATE] field tagged {0}:{1} to {2}:Tag with foramt of {3}", source.Id, Config.sourceField, target.Id, Config.formatExpression));
-            //        }
 
-            //    }
-
-            //}
         }
     }
 }

--- a/src/MigrationTools.Clients.AzureDevops.Rest/FieldMaps/FieldValueMap.cs
+++ b/src/MigrationTools.Clients.AzureDevops.Rest/FieldMaps/FieldValueMap.cs
@@ -19,27 +19,7 @@ namespace MigrationTools.Clients.AzureDevops.Rest.FieldMaps
         internal override void InternalExecute(WorkItem source, WorkItem target)
         {
              throw new NotImplementedException();
-            //if (source.Fields.Contains(Config.sourceField))
-            //{
-            //    var sourceVal = source.Fields[Config.sourceField].Value;
-            //    var t = target.Fields[Config.targetField].FieldDefinition.SystemType;
 
-            //    if (sourceVal is null && Config.valueMapping.ContainsKey("null"))
-            //    {
-            //        target.Fields[Config.targetField].Value = Convert.ChangeType(Config.valueMapping["null"], t);
-            //        Trace.WriteLine($"  [UPDATE] field value mapped {source.Id}:{Config.sourceField} to {target.Id}:{Config.targetField}");
-            //    }
-            //    else if (sourceVal != null && Config.valueMapping.ContainsKey(sourceVal.ToString()))
-            //    {
-            //        target.Fields[Config.targetField].Value = Convert.ChangeType(Config.valueMapping[sourceVal.ToString()], t);
-            //        Trace.WriteLine($"  [UPDATE] field value mapped {source.Id}:{Config.sourceField} to {target.Id}:{Config.targetField}");
-            //    }
-            //    else if (sourceVal != null && !string.IsNullOrWhiteSpace(Config.defaultValue))
-            //    {
-            //        target.Fields[Config.targetField].Value = Convert.ChangeType(Config.defaultValue, t);
-            //        Trace.WriteLine($"  [UPDATE] field set to default value {source.Id}:{Config.sourceField} to {target.Id}:{Config.targetField}");
-            //    }
-            //}
         }
     }
 }

--- a/src/MigrationTools.Clients.AzureDevops.Rest/FieldMaps/FieldValuetoTagMap.cs
+++ b/src/MigrationTools.Clients.AzureDevops.Rest/FieldMaps/FieldValuetoTagMap.cs
@@ -23,47 +23,7 @@ namespace MigrationTools.Clients.AzureDevops.Rest.FieldMaps
         internal override void InternalExecute(WorkItem source, WorkItem target)
         {
             throw new NotImplementedException();
-            //if (source.Fields.Contains(Config.sourceField))
-            //{
-            //    // parse existing tags entry
-            //    var tags = target.Tags
-            //        .Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries)
-            //        .ToList();
-
-            //    // only proceed if value is available
-            //    var value = source.Fields[Config.sourceField].Value;
-            //    var match = false;
-            //    if (value != null)
-            //    {
-            //        if (!string.IsNullOrEmpty(Config.pattern))
-            //        {
-            //            // regular expression matching is being used
-            //            match = Regex.IsMatch(value.ToString(), Config.pattern);
-            //        }
-            //        else
-            //        {
-            //            // always apply tag if value exists
-            //            match = true;
-            //        }
-            //    }
-
-            //    // add new tag if available
-            //    if (match)
-            //    {
-            //        // format or simple to string
-            //        var newTag = string.IsNullOrEmpty(Config.formatExpression) ? value.ToString() : string.Format(Config.formatExpression, value);
-            //        if (!string.IsNullOrWhiteSpace(newTag))
-            //            tags.Add(newTag);
-
-            //        // rewrite tag values if changed
-            //        var newTags = string.Join(";", tags.Distinct());
-            //        if (newTags != target.Tags)
-            //        {
-            //            target.Tags = newTags;
-            //            Trace.WriteLine(string.Format("  [UPDATE] field tagged {0}:{1} to {2}:Tag with format of {3}", source.Id, Config.sourceField, target.Id, Config.formatExpression));
-            //        }
-            //    }
-            //}
+          
         }
     }
 

--- a/src/MigrationTools.Clients.AzureDevops.Rest/FieldMaps/FieldtoFieldMultiMap.cs
+++ b/src/MigrationTools.Clients.AzureDevops.Rest/FieldMaps/FieldtoFieldMultiMap.cs
@@ -23,29 +23,9 @@ namespace MigrationTools.Clients.AzureDevops.Rest.FieldMaps
         internal override void InternalExecute(WorkItem source, WorkItem target)
         {
             throw new NotImplementedException();
-            //if (fieldsExist(Config.SourceToTargetMappings, source, target))
-            //    mapFields(Config.SourceToTargetMappings, source, target);
-            //else
-            //    Trace.WriteLine("  [SKIPPED] Not all source and target fields exist.");
+
         }
 
-        //private bool fieldsExist(Dictionary<string, string> fieldMap, WorkItem source, WorkItem target)
-        //{
-        //    bool exists = true;
-        //    foreach (var map in fieldMap)
-        //        if (!source.Fields.Contains(map.Key) || !target.Fields.Contains(map.Value))
-        //            exists = false;
 
-        //    return exists;
-        //}
-
-        //private void mapFields(Dictionary<string, string> fieldMap, WorkItem source, WorkItem target)
-        //{
-        //    foreach (var map in fieldMap)
-        //    {
-        //        target.Fields[map.Value].Value = source.Fields[map.Key].Value;
-        //        Trace.WriteLine(string.Format("  [UPDATE] field mapped {0}:{1} to {2}:{3}", source.Id, map.Key, target.Id, map.Value));
-        //    }
-        //}
     }
 }

--- a/src/MigrationTools.Clients.AzureDevops.Rest/FieldMaps/MultiValueConditionalMap.cs
+++ b/src/MigrationTools.Clients.AzureDevops.Rest/FieldMaps/MultiValueConditionalMap.cs
@@ -26,52 +26,10 @@ namespace MigrationTools.Clients.AzureDevops.Rest.FieldMaps
         internal override void InternalExecute(WorkItem source, WorkItem target)
         {
             throw new NotImplementedException();
-            //if (fieldsExist(Config.sourceFieldsAndValues, source) && fieldsExist(Config.targetFieldsAndValues, target))
-            //{
-            //    if (fieldsValueMatch(Config.sourceFieldsAndValues, source))
-            //    {
-            //        fieldsUpdate(Config.targetFieldsAndValues, target);
-            //    }                
-            //    Trace.WriteLine(string.Format("  [UPDATE] field mapped {0}:{1} to {2}:{3}", source.Id, Config.sourceFieldsAndValues.Keys.ToString(), target.Id, Config.targetFieldsAndValues.Keys.ToString()));
-            //} else
-            //{
-            //    Trace.WriteLine(string.Format("  [SKIPPED] Not all source and target fields exist", source.Id, Config.sourceFieldsAndValues.Keys.ToString(), target.Id, Config.targetFieldsAndValues.Keys.ToString()));
-            //}
+           
         }
 
-        //private void fieldsUpdate(Dictionary<string, string> fieldAndValues, WorkItem workitem)
-        //{
-        //    foreach (string field in fieldAndValues.Keys)
-        //    {
-        //        workitem.Fields[field].Value = fieldAndValues[field];
-        //    }
-        //}
-
-        //private bool fieldsValueMatch(Dictionary<string, string> fieldAndValues, WorkItem workitem)
-        //{
-        //    bool matches = true;
-        //    foreach (string field in fieldAndValues.Keys)
-        //    {
-        //        if((string)workitem.Fields[field].Value != fieldAndValues[field])
-        //        {
-        //            matches = false;
-        //        }
-        //    }
-        //    return matches;
-        //}
-
-        //private bool fieldsExist(Dictionary<string, string> fieldsAndValues, WorkItem workitem)
-        //{
-        //    bool exists = true;
-        //    foreach (string field in fieldsAndValues.Keys)
-        //    {
-        //        if (!workitem.Fields.Contains(field))
-        //        {
-        //            exists = false;
-        //        }
-        //    }
-        //    return exists;
-        //}
+       
 
 
     }

--- a/src/MigrationTools.Clients.AzureDevops.Rest/FieldMaps/RegexFieldMap.cs
+++ b/src/MigrationTools.Clients.AzureDevops.Rest/FieldMaps/RegexFieldMap.cs
@@ -21,14 +21,7 @@ namespace MigrationTools.Clients.AzureDevops.Rest.FieldMaps
         internal override void InternalExecute(WorkItem source, WorkItem target)
         {
             throw new NotImplementedException();
-            //if (source.Fields.Contains(Config.sourceField) && source.Fields[Config.sourceField].Value != null && target.Fields.Contains(Config.targetField))
-            //{
-            //    if (Regex.IsMatch(source.Fields[Config.sourceField].Value.ToString(), Config.pattern))
-            //    {
-            //        target.Fields[Config.targetField].Value = Regex.Replace(source.Fields[Config.sourceField].Value.ToString(), Config.pattern, Config.replacement);
-            //        Trace.WriteLine(string.Format("  [UPDATE] field tagged {0}:{1} to {2}:{3} with regex pattern of {4} resulting in {5}", source.Id, Config.sourceField, target.Id, Config.targetField, Config.pattern, target.Fields[Config.targetField].Value));
-            //    }
-            //}
+           
         }
     }
 }

--- a/src/MigrationTools.ConsoleFull/Program.cs
+++ b/src/MigrationTools.ConsoleFull/Program.cs
@@ -49,6 +49,9 @@ namespace VstsSyncMigrator.ConsoleApp
 
                     // Enrichers
                     services.AddSingleton<WorkItemLinkEnricher>();
+                    services.AddSingleton<EmbededImagesRepairEnricher>();
+                    services.AddSingleton<GitRepositoryEnricher>();
+                    services.AddSingleton<NodeStructureEnricher>();
 
                     // Core
                     services.AddTransient<IMigrationClient, MigrationClient>();

--- a/src/MigrationTools.Host/MigrationToolHost.cs
+++ b/src/MigrationTools.Host/MigrationToolHost.cs
@@ -11,6 +11,7 @@ using MigrationTools.CustomDiagnostics;
 using MigrationTools.Engine.Containers;
 using MigrationTools.Services;
 using Serilog;
+using Serilog.Events;
 
 namespace MigrationTools.Host
 {
@@ -18,7 +19,7 @@ namespace MigrationTools.Host
     {
         public static IHostBuilder CreateDefaultBuilder(string[] args)
         {
-            var hostBuilder = Microsoft.Extensions.Hosting.Host.CreateDefaultBuilder(args)
+               var hostBuilder = Microsoft.Extensions.Hosting.Host.CreateDefaultBuilder(args)
                 .UseSerilog((hostingContext, services, loggerConfiguration) =>
                 {
                     /////////////////////////////////////////////////////////
@@ -34,8 +35,8 @@ namespace MigrationTools.Host
                         .Enrich.WithMachineName()
                         .Enrich.WithProcessId()
                         .WriteTo.Console()
-                        .WriteTo.ApplicationInsights(services.GetService<ITelemetryLogger>().Configuration, new CustomConverter(), Serilog.Events.LogEventLevel.Error)
-                        .WriteTo.File(logPath);
+                        .WriteTo.ApplicationInsights( services.GetService<ITelemetryLogger>().Configuration, new CustomConverter(), LogEventLevel.Error)
+                        .WriteTo.File(logPath,  LogEventLevel.Verbose);
                 })
                 .ConfigureLogging((context, logBuilder) =>
                 {

--- a/src/MigrationTools/Configuration/EngineConfiguration.cs
+++ b/src/MigrationTools/Configuration/EngineConfiguration.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using Microsoft.Extensions.Logging;
 using MigrationTools.CommandLine;
+using Serilog.Events;
 
 namespace MigrationTools.Configuration
 {
@@ -11,7 +12,7 @@ namespace MigrationTools.Configuration
         private readonly EngineConfiguration _engineConfiguration;
 
         public override string Version { get { return _engineConfiguration.Version; } set { _engineConfiguration.Version = value; } }
-        public override bool TelemetryEnableTrace { get { return _engineConfiguration.TelemetryEnableTrace; } set { _engineConfiguration.TelemetryEnableTrace = value; } }
+        public override LogEventLevel LogLevel { get { return _engineConfiguration.LogLevel; } set { _engineConfiguration.LogLevel = value; } }
         public override bool workaroundForQuerySOAPBugEnabled { get { return _engineConfiguration.workaroundForQuerySOAPBugEnabled; } set { _engineConfiguration.workaroundForQuerySOAPBugEnabled = value; } }
         public override string ChangeSetMappingFile { get { return _engineConfiguration.ChangeSetMappingFile; } set { _engineConfiguration.ChangeSetMappingFile = value; } }
         public override TeamProjectConfig Source { get { return _engineConfiguration.Source; } set { _engineConfiguration.Source = value; } }
@@ -44,7 +45,6 @@ namespace MigrationTools.Configuration
     public class EngineConfiguration
     {
         public virtual string Version { get; set; }
-        public virtual bool TelemetryEnableTrace { get; set; }
         public virtual bool workaroundForQuerySOAPBugEnabled { get; set; }
         public virtual string ChangeSetMappingFile { get; set; }
         public virtual TeamProjectConfig Source { get; set; }
@@ -53,6 +53,6 @@ namespace MigrationTools.Configuration
         public virtual Dictionary<string, string> WorkItemTypeDefinition { get; set; }
         public virtual Dictionary<string, string> GitRepoMapping { get; set; }
         public virtual List<IProcessorConfig> Processors { get; set; }
-
+        public virtual LogEventLevel LogLevel { get; set; }
     }
 }

--- a/src/MigrationTools/Configuration/EngineConfigurationBuilder.cs
+++ b/src/MigrationTools/Configuration/EngineConfigurationBuilder.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Logging;
 using MigrationTools.Configuration.FieldMap;
 using MigrationTools.Configuration.Processing;
 using Newtonsoft.Json;
+using Serilog.Events;
 
 namespace MigrationTools.Configuration
 {
@@ -76,7 +77,7 @@ namespace MigrationTools.Configuration
         public EngineConfiguration CreateEmptyConfig()
         {
             EngineConfiguration ec = new EngineConfiguration();
-            ec.TelemetryEnableTrace = false;
+            ec.LogLevel = LogEventLevel.Information;
             ec.Version = System.Reflection.Assembly.GetExecutingAssembly().GetName().Version.ToString(2);
             ec.Source = new TeamProjectConfig()
             {

--- a/src/MigrationTools/Engine/Containers/FieldMapContainer.cs
+++ b/src/MigrationTools/Engine/Containers/FieldMapContainer.cs
@@ -32,7 +32,7 @@ namespace MigrationTools.Engine.Containers
             {
                 foreach (IFieldMapConfig fieldmapConfig in Config.FieldMaps)
                 {
-                    Log.Information("Adding FieldMap {FieldMapName}", fieldmapConfig.FieldMap);
+                    Log.Information("FieldMapContainer: Adding FieldMap {FieldMapName} for {WorkItemTypeName}", fieldmapConfig.FieldMap, fieldmapConfig.WorkItemTypeName);
                     string typePattern = $"MigrationTools.Sinks.*.FieldMaps.{fieldmapConfig.FieldMap}";
 
                     Type type = AppDomain.CurrentDomain.GetAssemblies()

--- a/src/MigrationTools/Engine/Containers/ProcessorContainer.cs
+++ b/src/MigrationTools/Engine/Containers/ProcessorContainer.cs
@@ -30,11 +30,12 @@ namespace MigrationTools.Engine.Containers
             if (Config.Processors != null)
             {
                 var enabledProcessors = Config.Processors.Where(x => x.Enabled).ToList();
+                Log.Information("ProcessorContainer: Of {ProcessorCount} configured Processors only {EnabledProcessorCount} are enabled", Config.Processors.Count, enabledProcessors.Count);
                 foreach (IProcessorConfig processorConfig in enabledProcessors)
                 {
                     if (processorConfig.IsProcessorCompatible(enabledProcessors))
                     {
-                        Log.Information("Adding Processor {ProcessorName}", processorConfig.Processor);
+                        Log.Information("ProcessorContainer: Adding Processor {ProcessorName}", processorConfig.Processor);
                         string typePattern = $"VstsSyncMigrator.Engine.{processorConfig.Processor}";
 
                         Type type = AppDomain.CurrentDomain.GetAssemblies()
@@ -54,9 +55,9 @@ namespace MigrationTools.Engine.Containers
                     }
                     else
                     {
-                        var message = "{Context}: Cannot add Processor {ProcessorName}. Processor is not compatible with other enabled processors in configuration.";
-                        Log.Error(message, processorConfig.Processor, "MigrationEngine");
-                        throw new InvalidOperationException(string.Format(message, processorConfig.Processor, "MigrationEngine"));
+                        var message = "ProcessorContainer: Cannot add Processor {ProcessorName}. Processor is not compatible with other enabled processors in configuration.";
+                        Log.Error(message, processorConfig.Processor);
+                        throw new InvalidOperationException(string.Format(message, processorConfig.Processor, "ProcessorContainer"));
                     }
                 }
             }

--- a/src/MigrationTools/Engine/Containers/TypeDefinitionMapContainer.cs
+++ b/src/MigrationTools/Engine/Containers/TypeDefinitionMapContainer.cs
@@ -34,7 +34,7 @@ namespace MigrationTools.Engine.Containers
         {
             if (!_TypeDefinitions.ContainsKey(workItemTypeName))
             {
-                Log.Verbose("TypeDefinitionMapContainer: Adding Work Item Type {WorkItemType}", workItemTypeName);
+                Log.Debug("TypeDefinitionMapContainer: Adding Work Item Type {WorkItemType}", workItemTypeName);
                 _TypeDefinitions.Add(workItemTypeName, workItemTypeDefinitionMap);
             }
         }

--- a/src/MigrationTools/Engine/Containers/TypeDefinitionMapContainer.cs
+++ b/src/MigrationTools/Engine/Containers/TypeDefinitionMapContainer.cs
@@ -25,7 +25,6 @@ namespace MigrationTools.Engine.Containers
             {
                 foreach (string key in Config.WorkItemTypeDefinition.Keys)
                 {
-                    Log.Information("{Context}: Adding Work Item Type {WorkItemType}", key, "MigrationEngine");
                     AddWorkItemTypeDefinition(key, new WitMapper(Config.WorkItemTypeDefinition[key]));
                 }
             }
@@ -35,6 +34,7 @@ namespace MigrationTools.Engine.Containers
         {
             if (!_TypeDefinitions.ContainsKey(workItemTypeName))
             {
+                Log.Verbose("TypeDefinitionMapContainer: Adding Work Item Type {WorkItemType}", workItemTypeName);
                 _TypeDefinitions.Add(workItemTypeName, workItemTypeDefinitionMap);
             }
         }

--- a/src/MigrationTools/Engine/Processors/StaticProcessorBase.cs
+++ b/src/MigrationTools/Engine/Processors/StaticProcessorBase.cs
@@ -6,6 +6,7 @@ using MigrationTools;
 using Serilog;
 using MigrationTools.Engine.Containers;
 using MigrationTools;
+using Microsoft.Extensions.Logging;
 
 namespace VstsSyncMigrator.Engine
 {
@@ -18,11 +19,12 @@ namespace VstsSyncMigrator.Engine
         public IMigrationEngine Engine { get { return _me; } }
         public IServiceProvider Services { get { return _services; } }
 
-        public StaticProcessorBase(IServiceProvider services, IMigrationEngine me, ITelemetryLogger telemetry)
+        public StaticProcessorBase(IServiceProvider services, IMigrationEngine me, ITelemetryLogger telemetry, ILogger<IProcessor> logger)
         {
             _services = services;
-            _me = me;
+            _me = me; 
             Telemetry = telemetry;
+            Log = logger;
         }
 
         public abstract void Configure(IProcessorConfig config);
@@ -38,6 +40,7 @@ namespace VstsSyncMigrator.Engine
         }
 
         public ITelemetryLogger Telemetry { get; }
+        public ILogger<IProcessor> Log { get; }
 
         public void Execute()
         {
@@ -78,7 +81,7 @@ namespace VstsSyncMigrator.Engine
                       new Dictionary<string, double> {
                             { "ProcessingContextTime", executeTimer.ElapsedMilliseconds }
                       });
-                Log.Fatal(ex, "Processing Context failed.");
+                Log.LogCritical(ex, "Processing Context failed.");
             }
             finally
             {

--- a/src/MigrationTools/Enrichers/EmbededImagesRepairEnricherBase.cs
+++ b/src/MigrationTools/Enrichers/EmbededImagesRepairEnricherBase.cs
@@ -1,4 +1,5 @@
-﻿using MigrationTools.DataContracts;
+﻿using Microsoft.Extensions.Logging;
+using MigrationTools.DataContracts;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -9,21 +10,25 @@ using System.Text;
 
 namespace MigrationTools.Enrichers
 {
-    public abstract class EmbededImagesRepairEnricherBase : IEmbededImagesRepairEnricher
+    public abstract class EmbededImagesRepairEnricherBase : WorkItemEnricher
     {
         protected readonly HttpClientHandler _httpClientHandler;
         protected bool _ignore404Errors = true;
-
-        public EmbededImagesRepairEnricherBase()
-        {
-            _httpClientHandler = new HttpClientHandler { AllowAutoRedirect = false, UseDefaultCredentials = true, AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate };
-        }
-
         /**
       *  from https://gist.github.com/pietergheysens/792ed505f09557e77ddfc1b83531e4fb
       */
+        public EmbededImagesRepairEnricherBase(IMigrationEngine engine, ILogger<EmbededImagesRepairEnricherBase> logger) :base(engine, logger)
+        {
 
-        public abstract void FixEmbededImages(WorkItemData wi, string oldTfsurl, string newTfsurl, string sourcePersonalAccessToken = "");
+            _httpClientHandler = new HttpClientHandler { AllowAutoRedirect = false, UseDefaultCredentials = true, AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate };
+        }
+
+        public override abstract void Configure(bool save = true, bool filter = true);
+
+        public override abstract int Enrich(WorkItemData sourceWorkItem, WorkItemData targetWorkItem);
+
+
+        protected abstract void FixEmbededImages(WorkItemData wi, string oldTfsurl, string newTfsurl, string sourcePersonalAccessToken = "");
 
         protected static HttpResponseMessage DownloadFile(HttpClient httpClient, string url, string destinationPath)
         {
@@ -113,6 +118,8 @@ namespace MigrationTools.Enrichers
 
             return oppositeUrl;
         }
+
+      
 
         protected enum ImageFormat
         {

--- a/src/MigrationTools/Enrichers/IEmbededImagesRepairEnricher.cs
+++ b/src/MigrationTools/Enrichers/IEmbededImagesRepairEnricher.cs
@@ -1,9 +1,9 @@
-﻿using MigrationTools.DataContracts;
+﻿//using MigrationTools.DataContracts;
 
-namespace MigrationTools.Enrichers
-{
-   public interface IEmbededImagesRepairEnricher
-    {
-        void FixEmbededImages(WorkItemData wi, string oldTfsurl, string newTfsurl, string sourcePersonalAccessToken = "");
-    }
-}
+//namespace MigrationTools.Enrichers
+//{
+//   public interface IWorkItemEnricher
+//    {
+//        void FixEmbededImages(WorkItemData wi, string oldTfsurl, string newTfsurl, string sourcePersonalAccessToken = "");
+//    }
+//}

--- a/src/MigrationTools/Enrichers/IWorkItemEnricher.cs
+++ b/src/MigrationTools/Enrichers/IWorkItemEnricher.cs
@@ -1,12 +1,11 @@
-﻿using MigrationTools.DataContracts;
+﻿using Microsoft.Extensions.Logging;
+using MigrationTools.DataContracts;
 
 namespace MigrationTools.Enrichers
 {
     public interface IWorkItemEnricher
     {
-        IMigrationEngine Engine { get; }
-
-        void Configure(bool save = true, bool filterWorkItemsThatAlreadyExistInTarget = true);
-        void Enrich(WorkItemData sourceWorkItem, WorkItemData targetWorkItem);
+        void Configure(bool save = true, bool filter = true);
+        int Enrich(WorkItemData sourceWorkItem, WorkItemData targetWorkItem);
     }
 }

--- a/src/MigrationTools/Enrichers/WorkItemEnricher.cs
+++ b/src/MigrationTools/Enrichers/WorkItemEnricher.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.Extensions.Logging;
+using MigrationTools.DataContracts;
+
+namespace MigrationTools.Enrichers
+{
+    public abstract class WorkItemEnricher : IWorkItemEnricher
+    {
+
+        protected IMigrationEngine Engine { get; }
+       protected ILogger<IWorkItemEnricher> Log { get; }
+
+        public WorkItemEnricher(IMigrationEngine engine, ILogger<WorkItemEnricher> logger)
+        {
+            Engine = engine;
+            Log = logger;
+        }
+
+        public abstract void Configure(bool save = true, bool filter = true);
+        public abstract int Enrich(WorkItemData sourceWorkItem, WorkItemData targetWorkItem);
+
+    }
+}

--- a/src/MigrationTools/MigrationEngine.cs
+++ b/src/MigrationTools/MigrationEngine.cs
@@ -10,6 +10,7 @@ using MigrationTools.Configuration;
 using MigrationTools.Engine;
 using MigrationTools.Engine.Containers;
 using Serilog;
+using Serilog.Core;
 
 namespace MigrationTools
 {
@@ -124,7 +125,11 @@ namespace MigrationTools
                 });
             Stopwatch engineTimer = Stopwatch.StartNew();
 
-			ProcessingStatus ps = ProcessingStatus.Running;
+            LoggingLevelSwitch logLevel = _services.GetRequiredService<LoggingLevelSwitch>();
+            logLevel.MinimumLevel = Config.LogLevel;
+
+
+            ProcessingStatus ps = ProcessingStatus.Running;
 
             Processors.EnsureConfigured();
             TypeDefinitionMaps.EnsureConfigured();

--- a/src/VstsSyncMigrator.Core.Tests/EngineConfigurationTests.cs
+++ b/src/VstsSyncMigrator.Core.Tests/EngineConfigurationTests.cs
@@ -12,7 +12,7 @@ namespace _VstsSyncMigrator.Engine.Tests
         public void EngineConfigurationCreate()
         {
             EngineConfiguration ec = new EngineConfiguration();
-            ec.TelemetryEnableTrace = true;
+            ec.LogLevel = Serilog.Events.LogEventLevel.Verbose;
             ec.Source = new TeamProjectConfig() { Project = "DemoProjs", Collection = new Uri("https://sdd2016.visualstudio.com/"), ReflectedWorkItemIDFieldName = "TfsMigrationTool.ReflectedWorkItemId", PersonalAccessToken="" };
             ec.Target = new TeamProjectConfig() { Project = "DemoProjt", Collection = new Uri("https://sdd2016.visualstudio.com/"), ReflectedWorkItemIDFieldName = "TfsMigrationTool.ReflectedWorkItemId", PersonalAccessToken = "" };
             Assert.IsNotNull(ec);

--- a/src/VstsSyncMigrator.Core.Tests/MigrationEngineTests.cs
+++ b/src/VstsSyncMigrator.Core.Tests/MigrationEngineTests.cs
@@ -14,6 +14,7 @@ using MigrationTools;
 using MigrationTools.Clients;
 using MigrationTools.Clients.AzureDevops.ObjectModel.Clients;
 using Serilog;
+using Serilog.Core;
 
 namespace _VstsSyncMigrator.Engine.Tests
 {
@@ -26,11 +27,13 @@ namespace _VstsSyncMigrator.Engine.Tests
         [TestInitialize]
         public void Setup()
         {
-            Log.Logger = new LoggerConfiguration().WriteTo.Console().CreateLogger();
-
+            var levelSwitch = new LoggingLevelSwitch();
+            Log.Logger = new LoggerConfiguration().MinimumLevel.ControlledBy(levelSwitch).WriteTo.Console().CreateLogger();
+            
             ecb = new EngineConfigurationBuilder(new NullLogger<EngineConfigurationBuilder>());
             var services = new ServiceCollection();
-        
+            services.AddSingleton<LoggingLevelSwitch>(levelSwitch);
+
             // Field Mapps
             services.AddTransient<FieldBlankMap>();
             services.AddTransient<FieldLiteralMap>();

--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemMigrationContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemMigrationContext.cs
@@ -580,7 +580,7 @@ namespace VstsSyncMigrator.Engine
 
         private List<WorkItemData> FilterByTarget(List<WorkItemData> sourceWorkItems)
         {
-            contextLog.Verbose("FilterByTarget: START");
+            contextLog.Debug("FilterByTarget: START");
             var targetQuery = 
                 string.Format(
                     @"SELECT [System.Id], [{0}] FROM WorkItems WHERE [System.TeamProject] = @TeamProject {1} ORDER BY {2}",
@@ -588,15 +588,15 @@ namespace VstsSyncMigrator.Engine
                     _config.WIQLQueryBit,
                     _config.WIQLOrderBit
                     );
-            contextLog.Verbose("FilterByTarget: Query Execute...");
+            contextLog.Debug("FilterByTarget: Query Execute...");
             var targetFoundItems = Engine.Target.WorkItems.GetWorkItems(targetQuery);
-            contextLog.Verbose("FilterByTarget: ... query complete.");
-            contextLog.Verbose("FilterByTarget: Found {TargetWorkItemCount} based on the WIQLQueryBit in the target system.", targetFoundItems.Count());
+            contextLog.Debug("FilterByTarget: ... query complete.");
+            contextLog.Debug("FilterByTarget: Found {TargetWorkItemCount} based on the WIQLQueryBit in the target system.", targetFoundItems.Count());
             var targetFoundIds = (from WorkItemData twi in targetFoundItems select Engine.Target.WorkItems.GetReflectedWorkItemId(twi)).ToList();
             //////////////////////////////////////////////////////////
             sourceWorkItems = sourceWorkItems.Where(p => !targetFoundIds.Any(p2 => p2.ToString() == p.Id)).ToList();
-            contextLog.Verbose("FilterByTarget: After removing all found work items there are {SourceWorkItemCount} remaining to be migrated.", sourceWorkItems.Count());
-            contextLog.Verbose("FilterByTarget: END");
+            contextLog.Debug("FilterByTarget: After removing all found work items there are {SourceWorkItemCount} remaining to be migrated.", sourceWorkItems.Count());
+            contextLog.Debug("FilterByTarget: END");
             return sourceWorkItems;
         }
 

--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemMigrationContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemMigrationContext.cs
@@ -98,6 +98,7 @@ namespace VstsSyncMigrator.Engine
 
         protected override void InternalExecute()
         {
+            Log.Information("Starting ");
             if (_config == null)
             {
                 throw new Exception("You must call Configure() first");

--- a/src/VstsSyncMigrator.Core/Execution/ProcessingContext/CreateTeamFolders.cs
+++ b/src/VstsSyncMigrator.Core/Execution/ProcessingContext/CreateTeamFolders.cs
@@ -14,6 +14,7 @@ using MigrationTools;
 using MigrationTools.Clients;
 using MigrationTools;
 using MigrationTools.Clients.AzureDevops.ObjectModel.Clients;
+using Microsoft.Extensions.Logging;
 
 namespace VstsSyncMigrator.Engine
 {
@@ -21,7 +22,7 @@ namespace VstsSyncMigrator.Engine
     {
 
 
-        public CreateTeamFolders(IServiceProvider services, IMigrationEngine me, ITelemetryLogger telemetry) : base(services, me, telemetry)
+        public CreateTeamFolders(IServiceProvider services, IMigrationEngine me, ITelemetryLogger telemetry, ILogger<CreateTeamFolders> logger) : base(services, me, telemetry, logger)
         {
          
         }

--- a/src/VstsSyncMigrator.Core/Execution/ProcessingContext/ExportProfilePictureFromADContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/ProcessingContext/ExportProfilePictureFromADContext.cs
@@ -17,6 +17,7 @@ using MigrationTools.Configuration;
 using Microsoft.Extensions.Hosting;
 using MigrationTools;
 using MigrationTools;
+using Microsoft.Extensions.Logging;
 
 namespace VstsSyncMigrator.Engine
 {
@@ -34,7 +35,7 @@ namespace VstsSyncMigrator.Engine
             }
         }
 
-        public ExportProfilePictureFromADContext(IServiceProvider services, IMigrationEngine me, ITelemetryLogger telemetry) : base(services, me, telemetry)
+        public ExportProfilePictureFromADContext(IServiceProvider services, IMigrationEngine me, ITelemetryLogger telemetry, ILogger<ExportProfilePictureFromADContext> logger) : base(services, me, telemetry, logger)
         {
 
         }

--- a/src/VstsSyncMigrator.Core/Execution/ProcessingContext/ExportTeamList.cs
+++ b/src/VstsSyncMigrator.Core/Execution/ProcessingContext/ExportTeamList.cs
@@ -15,6 +15,7 @@ using MigrationTools.Configuration;
 using Microsoft.Extensions.Hosting;
 using MigrationTools;
 using MigrationTools;
+using Microsoft.Extensions.Logging;
 
 namespace VstsSyncMigrator.Engine
 {
@@ -22,7 +23,7 @@ namespace VstsSyncMigrator.Engine
     {
 
 
-        public ExportTeamList(IServiceProvider services, IMigrationEngine me, ITelemetryLogger telemetry) : base(services, me, telemetry)
+        public ExportTeamList(IServiceProvider services, IMigrationEngine me, ITelemetryLogger telemetry, ILogger<ExportTeamList> logger) : base(services, me, telemetry, logger)
         {
 
         }

--- a/src/VstsSyncMigrator.Core/Execution/ProcessingContext/ImportProfilePictureContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/ProcessingContext/ImportProfilePictureContext.cs
@@ -18,6 +18,7 @@ using MigrationTools.Configuration;
 using Microsoft.Extensions.Hosting;
 using MigrationTools;
 using MigrationTools;
+using Microsoft.Extensions.Logging;
 
 namespace VstsSyncMigrator.Engine
 {
@@ -36,7 +37,7 @@ namespace VstsSyncMigrator.Engine
             }
         }
 
-        public ImportProfilePictureContext(IServiceProvider services, IMigrationEngine me, ITelemetryLogger telemetry) : base(services, me, telemetry)
+        public ImportProfilePictureContext(IServiceProvider services, IMigrationEngine me, ITelemetryLogger telemetry, ILogger<ImportProfilePictureContext> logger) : base(services, me, telemetry, logger)
         {
             //http://www.codeproject.com/Articles/18102/Howto-Almost-Everything-In-Active-Directory-via-C
             ims2 = (IIdentityManagementService2)me.Target.GetService<IIdentityManagementService2>();

--- a/src/VstsSyncMigrator.Core/Execution/ProcessingContext/WorkItemDelete.cs
+++ b/src/VstsSyncMigrator.Core/Execution/ProcessingContext/WorkItemDelete.cs
@@ -9,6 +9,7 @@ using MigrationTools.Clients.AzureDevops.ObjectModel.Clients;
 using MigrationTools.Configuration.Processing;
 using Serilog;
 using MigrationTools.DataContracts;
+using Microsoft.Extensions.Logging;
 
 namespace VstsSyncMigrator.Engine
 {
@@ -16,7 +17,7 @@ namespace VstsSyncMigrator.Engine
     {
         WorkItemDeleteConfig _config;
 
-        public WorkItemDelete(IServiceProvider services, IMigrationEngine me, ITelemetryLogger telemetry) : base(services, me, telemetry)
+        public WorkItemDelete(IServiceProvider services, IMigrationEngine me, ITelemetryLogger telemetry, ILogger<WorkItemUpdate> logger) : base(services, me, telemetry, logger)
         {
 
         }
@@ -46,13 +47,13 @@ namespace VstsSyncMigrator.Engine
 
             if (workItems.Count > 0)
             {
-                Log.Information("We are going to delete {sourceWorkItemsCount} work items?", workItems.Count);
+                Log.LogInformation("We are going to delete {sourceWorkItemsCount} work items?", workItems.Count);
 
                 Console.WriteLine("Enter the number of work Items that we will be deleting! Then hit Enter e.g. 21");
                 string result = Console.ReadLine();
                 if (int.Parse(result) != workItems.Count)
                 {
-                    Log.Warning("USER ABORTED by selecting a number other than {sourceWorkItemsCount}", workItems.Count);
+                    Log.LogWarning("USER ABORTED by selecting a number other than {sourceWorkItemsCount}", workItems.Count);
                     return;
                 }
 
@@ -71,7 +72,7 @@ namespace VstsSyncMigrator.Engine
             }
             else
             {
-                Log.Information("Nothing to delete");
+                Log.LogInformation("Nothing to delete");
             }
 
 

--- a/src/VstsSyncMigrator.Core/Execution/ProcessingContext/WorkItemUpdate.cs
+++ b/src/VstsSyncMigrator.Core/Execution/ProcessingContext/WorkItemUpdate.cs
@@ -14,6 +14,7 @@ using MigrationTools;
 using MigrationTools.Clients.AzureDevops.ObjectModel;
 using MigrationTools;
 using MigrationTools.DataContracts;
+using Microsoft.Extensions.Logging;
 
 namespace VstsSyncMigrator.Engine
 {
@@ -21,7 +22,7 @@ namespace VstsSyncMigrator.Engine
     {
         WorkItemUpdateConfig _config;
 
-        public WorkItemUpdate(IServiceProvider services, IMigrationEngine me, ITelemetryLogger telemetry) : base(services, me, telemetry)
+        public WorkItemUpdate(IServiceProvider services, IMigrationEngine me, ITelemetryLogger telemetry, ILogger<WorkItemUpdate> logger) : base(services, me, telemetry, logger)
         {
             
         }

--- a/src/VstsSyncMigrator.Core/Execution/ProcessingContext/WorkItemUpdateAreasAsTagsContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/ProcessingContext/WorkItemUpdateAreasAsTagsContext.cs
@@ -15,6 +15,7 @@ using MigrationTools.Clients;
 using Microsoft.Extensions.DependencyInjection;
 using MigrationTools.DataContracts;
 using MigrationTools.Clients.AzureDevops.ObjectModel;
+using Microsoft.Extensions.Logging;
 
 namespace VstsSyncMigrator.Engine
 {
@@ -23,7 +24,7 @@ namespace VstsSyncMigrator.Engine
 
         WorkItemUpdateAreasAsTagsConfig config;
 
-        public WorkItemUpdateAreasAsTagsContext(IServiceProvider services, IMigrationEngine me, ITelemetryLogger telemetry) : base(services, me, telemetry)
+        public WorkItemUpdateAreasAsTagsContext(IServiceProvider services, IMigrationEngine me, ITelemetryLogger telemetry, ILogger<WorkItemUpdateAreasAsTagsContext> logger) : base(services, me, telemetry, logger)
         {
         }
 


### PR DESCRIPTION
This has been a logging run and is by mo means complete, however I have implemented many of the recommendations of @ovebastiansen and moved to ILogger. This PR Includes: 

- **You can now set `LogLevel` in the config** - This sets the base logging level for Serilog while the max logging level for Application Insights is `Error`, for the logfile is `Verbose`, and for the Console is `Debug`. 
- **Updated Core Executeiopn ProcessingContext classes to ILogger.**
- **Moved all Enrichers to ILogger, Services, & same interface**

This update requires +semver: minor as it changes the config, and adds `"LogLevel": "Verbose"` and removes `  "TelemetryEnableTrace": false,`. 