### PR TITLE
Migrate AI to Worker

### DIFF
--- a/ApplicationInsights.config
+++ b/ApplicationInsights.config
@@ -101,6 +101,7 @@
       <TelemetryChannel Type="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.ServerTelemetryChannel, Microsoft.AI.ServerTelemetryChannel" />
     </Add>
   </TelemetrySinks>
+  <TelemetryChannel Type="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.ServerTelemetryChannel, Microsoft.AI.ServerTelemetryChannel" />
   <!--
     Learn more about Application Insights configuration with ApplicationInsights.config here:
     http://go.microsoft.com/fwlink/?LinkID=513840

--- a/ApplicationInsights.config
+++ b/ApplicationInsights.config
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <ApplicationInsights schemaVersion="2014-05-30" xmlns="http://schemas.microsoft.com/ApplicationInsights/2013/Settings">
-  <InstrumentationKey>4b9bb17b-c7ee-43e5-b220-ec6db2c33373</InstrumentationKey>
   <TelemetryInitializers>
     <Add Type="Microsoft.ApplicationInsights.DependencyCollector.HttpDependenciesParsingTelemetryInitializer, Microsoft.AI.DependencyCollector" />
     <Add Type="Microsoft.ApplicationInsights.WindowsServer.AzureRoleEnvironmentTelemetryInitializer, Microsoft.AI.WindowsServer" />
@@ -25,6 +24,9 @@
       </IncludeDiagnosticSourceActivities>
     </Add>
     <Add Type="Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.PerformanceCollectorModule, Microsoft.AI.PerfCounterCollector">
+      <Counters>
+        <Add PerformanceCounter="\.NET CLR Memory(??APP_WIN32_PROC??)\# GC Handles" ReportAs="GC Handles" />
+      </Counters>
       <!--
       Use the following syntax here to collect additional performance counters:
 
@@ -99,9 +101,10 @@
       <TelemetryChannel Type="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.ServerTelemetryChannel, Microsoft.AI.ServerTelemetryChannel" />
     </Add>
   </TelemetrySinks>
-<!--
+  <!--
     Learn more about Application Insights configuration with ApplicationInsights.config here:
     http://go.microsoft.com/fwlink/?LinkID=513840
 
     Note: If not present, please add <InstrumentationKey>Your Key</InstrumentationKey> to the top of this file.
-  --></ApplicationInsights>
+  -->
+</ApplicationInsights>

--- a/MigrationTools.sln
+++ b/MigrationTools.sln
@@ -39,7 +39,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.editorconfig = .editorconfig
 		.gitattributes = .gitattributes
 		.gitignore = .gitignore
-		ApplicationInsights.config = ApplicationInsights.config
 		configuration.json = configuration.json
 		Directory.Build.props = Directory.Build.props
 		GitVersion.yml = GitVersion.yml

--- a/MigrationTools.sln
+++ b/MigrationTools.sln
@@ -39,6 +39,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.editorconfig = .editorconfig
 		.gitattributes = .gitattributes
 		.gitignore = .gitignore
+		ApplicationInsights.config = ApplicationInsights.config
 		configuration.json = configuration.json
 		Directory.Build.props = Directory.Build.props
 		GitVersion.yml = GitVersion.yml

--- a/src/MigrationTools.ConsoleCore/MigrationTools.ConsoleCore.csproj
+++ b/src/MigrationTools.ConsoleCore/MigrationTools.ConsoleCore.csproj
@@ -14,6 +14,12 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Include="..\..\ApplicationInsights.config" Link="ApplicationInsights.config">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.PerfCounterCollector" Version="2.15.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.15.0" />
@@ -32,12 +38,6 @@
     <ProjectReference Include="..\MigrationTools.Clients.AzureDevops.Rest\MigrationTools.Clients.AzureDevops.Rest.csproj" />
     <ProjectReference Include="..\MigrationTools\MigrationTools.csproj" />
     <ProjectReference Include="..\MigrationTools.Host\MigrationTools.Host.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Update="appsettings.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
   </ItemGroup>
 
 </Project>

--- a/src/MigrationTools.ConsoleCore/MigrationTools.ConsoleCore.csproj
+++ b/src/MigrationTools.ConsoleCore/MigrationTools.ConsoleCore.csproj
@@ -14,12 +14,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="..\..\ApplicationInsights.config" Link="ApplicationInsights.config">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.PerfCounterCollector" Version="2.15.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.15.0" />

--- a/src/MigrationTools.ConsoleCore/appsettings.json
+++ b/src/MigrationTools.ConsoleCore/appsettings.json
@@ -1,5 +1,0 @@
-{
-  "ApplicationInsights": {
-    "InstrumentationKey": "4b9bb17b-c7ee-43e5-b220-ec6db2c33373"
-  }
-}

--- a/src/MigrationTools.ConsoleFull/MigrationTools.ConsoleFull.csproj
+++ b/src/MigrationTools.ConsoleFull/MigrationTools.ConsoleFull.csproj
@@ -21,7 +21,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.ApplicationInsights.PerfCounterCollector" Version="2.15.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.TraceListener" Version="2.15.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.15.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MigrationTools.ConsoleFull/MigrationTools.ConsoleFull.csproj
+++ b/src/MigrationTools.ConsoleFull/MigrationTools.ConsoleFull.csproj
@@ -15,12 +15,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="..\..\ApplicationInsights.config" Link="ApplicationInsights.config">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="Microsoft.ApplicationInsights.PerfCounterCollector" Version="2.15.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.TraceListener" Version="2.15.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.15.0" />

--- a/src/MigrationTools.ConsoleFull/MigrationTools.ConsoleFull.csproj
+++ b/src/MigrationTools.ConsoleFull/MigrationTools.ConsoleFull.csproj
@@ -15,6 +15,12 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Include="..\..\ApplicationInsights.config" Link="ApplicationInsights.config">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.ApplicationInsights.TraceListener" Version="2.15.0" />
   </ItemGroup>
 
@@ -22,15 +28,6 @@
     <ProjectReference Include="..\MigrationTools.Host\MigrationTools.Host.csproj" />
     <ProjectReference Include="..\MigrationTools.Clients.AzureDevops.ObjectModel\MigrationTools.Clients.AzureDevops.ObjectModel.csproj" />
     <ProjectReference Include="..\VstsSyncMigrator.Core\VstsSyncMigrator.Core.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Update="ApplicationInsights.config">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="appsettings.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
   </ItemGroup>
 
 </Project>

--- a/src/MigrationTools.ConsoleFull/appsettings.json
+++ b/src/MigrationTools.ConsoleFull/appsettings.json
@@ -1,5 +1,0 @@
-{
-  "ApplicationInsights": {
-    "InstrumentationKey": "4b9bb17b-c7ee-43e5-b220-ec6db2c33373"
-  }
-}

--- a/src/MigrationTools.Host/MigrationToolHost.cs
+++ b/src/MigrationTools.Host/MigrationToolHost.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Threading.Tasks;
 using CommandLine;
+using Microsoft.ApplicationInsights;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using MigrationTools.CommandLine;
@@ -39,7 +40,7 @@ namespace MigrationTools.Host
                      .Enrich.WithMachineName()
                      .Enrich.WithProcessId()
                      .WriteTo.Console(restrictedToMinimumLevel: LogEventLevel.Debug, theme: AnsiConsoleTheme.Code)
-                     .WriteTo.ApplicationInsights(services.GetService<ITelemetryLogger>().Configuration, new CustomConverter(), LogEventLevel.Error)
+                     .WriteTo.ApplicationInsights(services.GetService<TelemetryClient>(), new CustomConverter(), LogEventLevel.Error)
                      .WriteTo.File(logPath, LogEventLevel.Verbose);
              })
              .ConfigureLogging((context, logBuilder) =>
@@ -66,7 +67,18 @@ namespace MigrationTools.Host
                  services.AddOptions();
                  // Sieralog
                  services.AddSingleton<LoggingLevelSwitch>(levelSwitch);
+
+                 // Application Insights
+
+                 Microsoft.ApplicationInsights.WorkerService.ApplicationInsightsServiceOptions aiOptions
+                    = new Microsoft.ApplicationInsights.WorkerService.ApplicationInsightsServiceOptions
+                    {
+                        // Disables adaptive sampling.
+                        InstrumentationKey = "2d666f84-b3fb-4dcf-9aad-65de038d2772"
+                    };
+                 services.AddApplicationInsightsTelemetryWorkerService(aiOptions);
                  // Services
+
                  services.AddTransient<IDetectOnlineService, DetectOnlineService>();
                  services.AddTransient<IDetectVersionService, DetectVersionService>();
                  services.AddSingleton<ITelemetryLogger, TelemetryClientAdapter>();

--- a/src/MigrationTools.Tests/Services/TelemetryLoggerMock.cs
+++ b/src/MigrationTools.Tests/Services/TelemetryLoggerMock.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using Microsoft.ApplicationInsights.DataContracts;
-using Microsoft.ApplicationInsights.Extensibility;
 
 namespace MigrationTools.Services
 {
@@ -9,7 +8,7 @@ namespace MigrationTools.Services
     {
         public bool EnableTrace { get; set; }
 
-        public TelemetryConfiguration Configuration { get; }
+        public string SessionId => throw new NotImplementedException();
 
         public void CloseAndFlush()
         {

--- a/src/MigrationTools/MigrationEngine.cs
+++ b/src/MigrationTools/MigrationEngine.cs
@@ -17,7 +17,6 @@ namespace MigrationTools
         private ExecuteOptions executeOptions;
 
         private readonly IServiceProvider _services;
-        private readonly Guid _Guid = Guid.NewGuid();
 
         public ProcessorContainer Processors { get; }
         public TypeDefinitionMapContainer TypeDefinitionMaps { get; }
@@ -39,7 +38,7 @@ namespace MigrationTools
             FieldMapContainer fieldMaps,
             ITelemetryLogger telemetry)
         {
-            Log.Information("Creating Migration Engine {Guid}", _Guid);
+            Log.Information("Creating Migration Engine {Guid}", telemetry.SessionId);
             _services = services;
             FieldMaps = fieldMaps;
             this.executeOptions = executeOptions;

--- a/src/MigrationTools/Services/ITelemetryLogger.cs
+++ b/src/MigrationTools/Services/ITelemetryLogger.cs
@@ -7,8 +7,8 @@ namespace MigrationTools
 {
     public interface ITelemetryLogger
     {
-        bool EnableTrace { get; set; }
         TelemetryConfiguration Configuration { get; }
+        string SessionId { get; }
 
         void TrackDependency(DependencyTelemetry dependencyTelemetry);
 

--- a/src/MigrationTools/Services/ITelemetryLogger.cs
+++ b/src/MigrationTools/Services/ITelemetryLogger.cs
@@ -1,13 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 using Microsoft.ApplicationInsights.DataContracts;
-using Microsoft.ApplicationInsights.Extensibility;
 
 namespace MigrationTools
 {
     public interface ITelemetryLogger
     {
-        TelemetryConfiguration Configuration { get; }
         string SessionId { get; }
 
         void TrackDependency(DependencyTelemetry dependencyTelemetry);

--- a/src/MigrationTools/Services/TelemetryClientAdapter.cs
+++ b/src/MigrationTools/Services/TelemetryClientAdapter.cs
@@ -3,18 +3,14 @@ using System.Collections.Generic;
 using Microsoft.ApplicationInsights;
 using Microsoft.ApplicationInsights.DataContracts;
 using Microsoft.ApplicationInsights.Extensibility;
-using Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector;
 
 namespace MigrationTools
 {
     public class TelemetryClientAdapter : ITelemetryLogger
     {
-        private const string applicationInsightsKey = "4b9bb17b-c7ee-43e5-b220-ec6db2c33373";
         private TelemetryClient telemetryClient;
-        private TelemetryConfiguration telemetryConfiguration;
-        private bool enableTrace = false;
 
-        public bool EnableTrace { get { return enableTrace; } set { enableTrace = value; } }
+        private TelemetryConfiguration telemetryConfiguration;
 
         public TelemetryConfiguration Configuration
         {
@@ -27,23 +23,20 @@ namespace MigrationTools
         public TelemetryClientAdapter()
         {
             telemetryConfiguration = TelemetryConfiguration.CreateDefault();
-            telemetryConfiguration.InstrumentationKey = applicationInsightsKey;
-
+            telemetryConfiguration.InstrumentationKey = "2d666f84-b3fb-4dcf-9aad-65de038d2772";
+            telemetryConfiguration.ConnectionString = "InstrumentationKey=2d666f84-b3fb-4dcf-9aad-65de038d2772;IngestionEndpoint=https://northeurope-0.in.applicationinsights.azure.com/";
             telemetryClient = new TelemetryClient(telemetryConfiguration);
             telemetryClient.Context.Session.Id = Guid.NewGuid().ToString();
             telemetryClient.Context.Device.OperatingSystem = Environment.OSVersion.ToString();
-
             telemetryClient.Context.Component.Version = System.Reflection.Assembly.GetEntryAssembly().GetName().Version.ToString();
-
-            AddModules(telemetryConfiguration);
         }
 
-        private void AddModules(TelemetryConfiguration telemetryConfiguration)
+        public string SessionId
         {
-            var perfCollectorModule = new PerformanceCollectorModule();
-            perfCollectorModule.Counters.Add(new PerformanceCounterCollectionRequest(
-              string.Format(@"\.NET CLR Memory({0})\# GC Handles", System.AppDomain.CurrentDomain.FriendlyName), "GC Handles"));
-            perfCollectorModule.Initialize(telemetryConfiguration);
+            get
+            {
+                return telemetryClient.Context.Session.Id;
+            }
         }
 
         public void TrackDependency(DependencyTelemetry dependencyTelemetry)

--- a/src/MigrationTools/Services/TelemetryClientAdapter.cs
+++ b/src/MigrationTools/Services/TelemetryClientAdapter.cs
@@ -12,17 +12,9 @@ namespace MigrationTools
 
         private TelemetryConfiguration telemetryConfiguration;
 
-        public TelemetryConfiguration Configuration
-        {
-            get
-            {
-                return telemetryConfiguration;
-            }
-        }
-
         public TelemetryClientAdapter()
         {
-            telemetryConfiguration = TelemetryConfiguration.CreateDefault();
+            telemetryConfiguration = TelemetryConfiguration.CreateFromConfiguration("ApplicationInsights.config");
             telemetryConfiguration.InstrumentationKey = "2d666f84-b3fb-4dcf-9aad-65de038d2772";
             telemetryConfiguration.ConnectionString = "InstrumentationKey=2d666f84-b3fb-4dcf-9aad-65de038d2772;IngestionEndpoint=https://northeurope-0.in.applicationinsights.azure.com/";
             telemetryClient = new TelemetryClient(telemetryConfiguration);
@@ -31,12 +23,25 @@ namespace MigrationTools
             telemetryClient.Context.Component.Version = System.Reflection.Assembly.GetEntryAssembly().GetName().Version.ToString();
         }
 
+        public TelemetryConfiguration Configuration
+        {
+            get
+            {
+                return telemetryConfiguration;
+            }
+        }
+
         public string SessionId
         {
             get
             {
                 return telemetryClient.Context.Session.Id;
             }
+        }
+
+        public void CloseAndFlush()
+        {
+            telemetryClient.Flush();
         }
 
         public void TrackDependency(DependencyTelemetry dependencyTelemetry)
@@ -59,19 +64,14 @@ namespace MigrationTools
             telemetryClient.TrackEvent(name, properties, measurements);
         }
 
-        public void TrackRequest(string name, DateTimeOffset startTime, TimeSpan duration, string responseCode, bool success)
-        {
-            telemetryClient.TrackRequest(name, startTime, duration, responseCode, success);
-        }
-
         public void TrackException(Exception ex, IDictionary<string, string> properties, IDictionary<string, double> measurements)
         {
             telemetryClient.TrackException(ex, properties, measurements);
         }
 
-        public void CloseAndFlush()
+        public void TrackRequest(string name, DateTimeOffset startTime, TimeSpan duration, string responseCode, bool success)
         {
-            telemetryClient.Flush();
+            telemetryClient.TrackRequest(name, startTime, duration, responseCode, success);
         }
     }
 }

--- a/src/MigrationTools/Services/TelemetryClientAdapter.cs
+++ b/src/MigrationTools/Services/TelemetryClientAdapter.cs
@@ -2,97 +2,62 @@
 using System.Collections.Generic;
 using Microsoft.ApplicationInsights;
 using Microsoft.ApplicationInsights.DataContracts;
-using Microsoft.ApplicationInsights.Extensibility;
-using Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.QuickPulse;
 
 namespace MigrationTools
 {
     public class TelemetryClientAdapter : ITelemetryLogger
     {
-        private TelemetryClient telemetryClient;
+        private TelemetryClient _telemetryClient;
 
-        private TelemetryConfiguration telemetryConfiguration;
-
-        public TelemetryClientAdapter()
+        public TelemetryClientAdapter(TelemetryClient telemetryClient)
         {
-            GetConfiguration();
-            telemetryClient = new TelemetryClient(telemetryConfiguration);
             telemetryClient.Context.Session.Id = Guid.NewGuid().ToString();
             telemetryClient.Context.Device.OperatingSystem = Environment.OSVersion.ToString();
             telemetryClient.Context.Component.Version = System.Reflection.Assembly.GetEntryAssembly().GetName().Version.ToString();
-        }
-
-        private void GetConfiguration()
-        {
-            telemetryConfiguration = TelemetryConfiguration.CreateFromConfiguration("ApplicationInsights.config");
-            telemetryConfiguration.InstrumentationKey = "2d666f84-b3fb-4dcf-9aad-65de038d2772";
-            telemetryConfiguration.ConnectionString = "InstrumentationKey=2d666f84-b3fb-4dcf-9aad-65de038d2772;IngestionEndpoint=https://northeurope-0.in.applicationinsights.azure.com/";
-
-            ///
-            QuickPulseTelemetryProcessor processor = null;
-            telemetryConfiguration.TelemetryProcessorChainBuilder
-                .Use((next) =>
-                {
-                    processor = new QuickPulseTelemetryProcessor(next);
-                    return processor;
-                })
-                .Build();
-
-            var QuickPulse = new QuickPulseTelemetryModule();
-            QuickPulse.Initialize(telemetryConfiguration);
-            QuickPulse.RegisterTelemetryProcessor(processor);
-            ///
-        }
-
-        public TelemetryConfiguration Configuration
-        {
-            get
-            {
-                return telemetryConfiguration;
-            }
+            _telemetryClient = telemetryClient;
         }
 
         public string SessionId
         {
             get
             {
-                return telemetryClient.Context.Session.Id;
+                return _telemetryClient.Context.Session.Id;
             }
         }
 
         public void CloseAndFlush()
         {
-            telemetryClient.Flush();
+            _telemetryClient.Flush();
         }
 
         public void TrackDependency(DependencyTelemetry dependencyTelemetry)
         {
-            telemetryClient.TrackDependency(dependencyTelemetry);
+            _telemetryClient.TrackDependency(dependencyTelemetry);
         }
 
         public void TrackEvent(EventTelemetry eventTelemetry)
         {
-            telemetryClient.TrackEvent(eventTelemetry);
+            _telemetryClient.TrackEvent(eventTelemetry);
         }
 
         public void TrackEvent(string name)
         {
-            telemetryClient.TrackEvent(name);
+            _telemetryClient.TrackEvent(name);
         }
 
         public void TrackEvent(string name, IDictionary<string, string> properties, IDictionary<string, double> measurements)
         {
-            telemetryClient.TrackEvent(name, properties, measurements);
+            _telemetryClient.TrackEvent(name, properties, measurements);
         }
 
         public void TrackException(Exception ex, IDictionary<string, string> properties, IDictionary<string, double> measurements)
         {
-            telemetryClient.TrackException(ex, properties, measurements);
+            _telemetryClient.TrackException(ex, properties, measurements);
         }
 
         public void TrackRequest(string name, DateTimeOffset startTime, TimeSpan duration, string responseCode, bool success)
         {
-            telemetryClient.TrackRequest(name, startTime, duration, responseCode, success);
+            _telemetryClient.TrackRequest(name, startTime, duration, responseCode, success);
         }
     }
 }

--- a/src/VstsSyncMigrator.Core.Tests/TelemetryLoggerMock.cs
+++ b/src/VstsSyncMigrator.Core.Tests/TelemetryLoggerMock.cs
@@ -1,15 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
 using Microsoft.ApplicationInsights.DataContracts;
-using Microsoft.ApplicationInsights.Extensibility;
 
 namespace MigrationTools.Services
 {
     public class TelemetryLoggerMock : ITelemetryLogger
     {
-        public bool EnableTrace { get; set; }
-
-        public TelemetryConfiguration Configuration { get; }
+        public string SessionId => throw new NotImplementedException();
 
         public void CloseAndFlush()
         {


### PR DESCRIPTION
I have migrated Application Insights to `AddApplicationInsightsTelemetryWorkerService`. This allowed us to delete the ApplicationInsights.config as well as move the `TelemetryClientAdapter` to the same instance as 'Serilog`.

Thanks for the suggestion @ovebastiansen 

I also created a new ApplicationInsights Key as the old one is costing £100/month :o which is excessive. Since many folks have forked and still use the tools with the OLD key I have deleted the old endpoint and created a new one. 