### PR TITLE
Fixed #637

### DIFF
--- a/src/MigrationTools.Clients.AzureDevops.ObjectModel/Clients/MigrationClient.cs
+++ b/src/MigrationTools.Clients.AzureDevops.ObjectModel/Clients/MigrationClient.cs
@@ -72,7 +72,7 @@ namespace MigrationTools.Clients.AzureDevops.ObjectModel.Clients
             }
 
             _config = (TeamProjectConfig)config;
-            _credentials = credentials ?? throw new ArgumentNullException(nameof(credentials));
+            _credentials = credentials;
             EnsureCollection();
             _workItemClient.Configure(this);
             _testPlanClient.Configure(this);

--- a/src/MigrationTools/MigrationEngine.cs
+++ b/src/MigrationTools/MigrationEngine.cs
@@ -71,8 +71,9 @@ namespace MigrationTools
         {
             NetworkCredential sourceCredentials = null;
             if (!string.IsNullOrWhiteSpace(executeOptions?.SourceUserName) && !string.IsNullOrWhiteSpace(executeOptions.SourcePassword))
+            {
                 sourceCredentials = new NetworkCredential(executeOptions.SourceUserName, executeOptions.SourcePassword, executeOptions.SourceDomain);
-
+            }
             return sourceCredentials;
         }
 

--- a/src/MigrationTools/MigrationEngine.cs
+++ b/src/MigrationTools/MigrationEngine.cs
@@ -67,17 +67,21 @@ namespace MigrationTools
         public ITelemetryLogger Telemetry { get; }
         public TypeDefinitionMapContainer TypeDefinitionMaps { get; }
 
-        public (NetworkCredential source, NetworkCredential target) CheckForNetworkCredentials()
+        public NetworkCredential CheckForNetworkCredentials_Source()
         {
             NetworkCredential sourceCredentials = null;
-            NetworkCredential targetCredentials = null;
             if (!string.IsNullOrWhiteSpace(executeOptions?.SourceUserName) && !string.IsNullOrWhiteSpace(executeOptions.SourcePassword))
                 sourceCredentials = new NetworkCredential(executeOptions.SourceUserName, executeOptions.SourcePassword, executeOptions.SourceDomain);
 
+            return sourceCredentials;
+        }
+
+        public NetworkCredential CheckForNetworkCredentials_Target()
+        {
+            NetworkCredential targetCredentials = null;
             if (!string.IsNullOrWhiteSpace(executeOptions?.TargetUserName) && !string.IsNullOrWhiteSpace(executeOptions.TargetPassword))
                 targetCredentials = new NetworkCredential(executeOptions.TargetUserName, executeOptions.TargetPassword, executeOptions.TargetDomain);
-
-            return (sourceCredentials, targetCredentials);
+            return targetCredentials;
         }
 
         public ProcessingStatus Run()
@@ -139,11 +143,11 @@ namespace MigrationTools
         {
             if (_Source is null)
             {
-                var credentials = CheckForNetworkCredentials();
+                var credentials = CheckForNetworkCredentials_Source();
                 if (_Source == null)
                 {
                     _Source = _services.GetRequiredService<IMigrationClient>();
-                    _Source.Configure(Config.Source, credentials.source);
+                    _Source.Configure(Config.Source, credentials);
                 }
             }
             return _Source;
@@ -153,11 +157,11 @@ namespace MigrationTools
         {
             if (_Target is null)
             {
-                var credentials = CheckForNetworkCredentials();
+                var credentials = CheckForNetworkCredentials_Target();
                 if (_Target == null)
                 {
                     _Target = _services.GetRequiredService<IMigrationClient>();
-                    _Target.Configure(Config.Target, credentials.target);
+                    _Target.Configure(Config.Target, credentials);
                 }
             }
             return _Target;


### PR DESCRIPTION
There was a bug in the return type from CheckForNetworkCredentials where it glitched if the dynamic object was null.