### PR TITLE
Fix IndexOutOfRangeException in TestPlansAndSuitesMigrationContext

### DIFF
--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/TestPlansAndSuitesMigrationContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/TestPlansAndSuitesMigrationContext.cs
@@ -1025,7 +1025,7 @@ namespace VstsSyncMigrator.Engine
                 Log.LogInformation("==      Suite Title: {SourceTestSuiteTitle}=============================".PadLeft(indent), sourceTestSuite.Title.PadRight(45));
                 Log.LogInformation("===============================================================================================".PadLeft(indent));
             }
-            Log.LogInformation("== {GetLogTags()} - suiteid[{SourceTestSuiteId}] | {message}".PadLeft(indent), sourceTestSuite.Id.ToString().PadRight(6), message);
+            Log.LogInformation("== {Tags} - suiteid[{SourceTestSuiteId}] | {message}".PadLeft(indent), GetLogTags(), sourceTestSuite.Id.ToString().PadRight(6), message);
             if (header) Log.LogInformation("===============================================================================================".PadLeft(indent));
         }
 


### PR DESCRIPTION
It looks like this line hasn't been properly adapted to the new logging component. This PR fixes the exception which is always been raised in that context:

![image](https://user-images.githubusercontent.com/22304202/95872728-6c091e80-0d6f-11eb-9e7b-5b1afdc07861.png)
