### PR TITLE
Fix potential Microsoft.TeamFoundation.WorkItemTracking.Client.DeniedOrNotExistException…

### DIFF
--- a/src/MigrationTools.Clients.AzureDevops.ObjectModel/Enrichers/WorkItemLinkEnricher.cs
+++ b/src/MigrationTools.Clients.AzureDevops.ObjectModel/Enrichers/WorkItemLinkEnricher.cs
@@ -206,7 +206,14 @@ namespace MigrationTools.Clients.AzureDevops.ObjectModel.Enrichers
                     if (wiSourceR.Id != wiTargetR.Id)
                     {
                         Log.LogInformation("  [CREATE-START] Adding Link of type {0} where wiSourceL={1}, wiSourceR={2}, wiTargetL={3}, wiTargetR={4} ", rl.LinkTypeEnd.ImmutableName, wiSourceL.Id, wiSourceR.Id, wiTargetL.Id, wiTargetR.Id);
-                        WorkItemLinkTypeEnd linkTypeEnd = ((WorkItemMigrationClient)Engine.Target.WorkItems).Store.WorkItemLinkTypes.LinkTypeEnds[rl.LinkTypeEnd.ImmutableName];
+                        var client = (WorkItemMigrationClient) Engine.Target.WorkItems;
+                        if (!client.Store.WorkItemLinkTypes.LinkTypeEnds.Contains(rl.LinkTypeEnd.ImmutableName))
+                        {
+                            Log.LogError($"  [SKIP] Unable to migrate Link because type {rl.LinkTypeEnd.ImmutableName} does not exist in the target project.");
+                            return;
+                        }
+
+                        WorkItemLinkTypeEnd linkTypeEnd = client.Store.WorkItemLinkTypes.LinkTypeEnds[rl.LinkTypeEnd.ImmutableName];
                         RelatedLink newRl = new RelatedLink(linkTypeEnd, int.Parse(wiTargetR.Id));
                         if (linkTypeEnd.ImmutableName == "System.LinkTypes.Hierarchy-Forward")
                         {


### PR DESCRIPTION
… in WorkItemLinkEnricher when LinkType does not exist in the target project.

I recently had following problem: 

`Microsoft.TeamFoundation.WorkItemTracking.Client.DeniedOrNotExistException: TF201019: Der Arbeitselement-Linktyp "Microsoft.VSTS.Common.Affects-Reverse" ist nicht vorhanden.`

It says type Microsoft.VSTS.Common.Affects-Reverse isn't available. WI Migration continues though but Link Migration is stopped and potential additional Links which could be migrated won't be processed anymore. Therefore I added this check and thought I share my experience here.