### PR TITLE
Default SkipToFinalRevisedWorkItemType to true

### DIFF
--- a/docs/Processors/WorkItemMigrationConfig.md
+++ b/docs/Processors/WorkItemMigrationConfig.md
@@ -34,7 +34,7 @@ It will migrate work items using a tip or replay migrator as well as Attachments
 | `FilterWorkItemsThatAlreadyExistInTarget` | Boolean | This loads all of the work items already saved to the Target and removes them from the Source work item list prior to commencing the run. While this may take some time in large data sets it reduces the time of the overall migration significantly if you need to restart. | true |
 | `WIQLQueryBit`                           | string  | A work item query based on WIQL to select only important work items. To migrate all leave this empty. |                                          |
 | `WIQLOrderBit` | string | A work item query to affect the order in which the work items are migrated. Don't leave this empty. | [System.ChangedDate] desc
-| `SkipToFinalRevisedWorkItemType` | Boolean | If enabled, when a revision is found that changes the work item type it will use the most recent revision work item type when migrating the initial work item. This should only be enabled for migrations from Azure DevOps Service to Azure DevOps Server. | false
+| `SkipToFinalRevisedWorkItemType` | Boolean | If enabled, when a revision is found that changes the work item type it will use the most recent revision work item type when migrating the initial work item. This should only be enabled for migrations from Azure DevOps Service to Azure DevOps Server. | true
 | `CollapseRevisions` | Boolean | If enabled, all revisions except the most recent are collapsed into a JSON format and attached as an attachment. Requires ReplayRevisions to be enabled. | false
 
 

--- a/src/MigrationTools/Configuration/Processing/WorkItemMigrationConfig.cs
+++ b/src/MigrationTools/Configuration/Processing/WorkItemMigrationConfig.cs
@@ -62,6 +62,7 @@ namespace MigrationTools.Configuration.Processing
             UpdateCreatedBy = true;
             PrefixProjectToNodes = false;
             UpdateCreatedDate = true;
+            SkipToFinalRevisedWorkItemType = true;
             LinkMigrationSaveEachAsAdded = false;
             GenerateMigrationComment = true;
             WIQLQueryBit = @"AND  [Microsoft.VSTS.Common.ClosedDate] = '' AND [System.WorkItemType] NOT IN ('Test Suite', 'Test Plan')";


### PR DESCRIPTION
Since we currently have a bug in the REST API we can set this to true to bypass the "changed work item type" rest fix.