### PR TITLE
Documentation update for 11.6

### DIFF
--- a/docs/Processors/AttachementExportMigrationConfig.md
+++ b/docs/Processors/AttachementExportMigrationConfig.md
@@ -1,5 +1,7 @@
 # Attachment export Migration
 
+>  Obsolete -merged into WorkItemMigration
+
 With this processor you can export work item attachments from the source project.
 
 > Note: Make sure you have enough disk-space for all attachments on the migration machine.

--- a/docs/Processors/AttachementImportMigrationConfig.md
+++ b/docs/Processors/AttachementImportMigrationConfig.md
@@ -1,5 +1,7 @@
 # Attachment Import Migration
 
+>  Obsolete - merged into WorkItemMigration
+
 > Note: You can only import attachment if you also run the processor `AttachementExportMigrationConfig` before.
 
 With this processor you can import work item attachments that was exported with the `AttachementExportMigrationConfig` processor from the source project. This only works if the `ReflectedWorkItemIDFieldName` is set to the source project work item link.

--- a/docs/Processors/FixGitCommitLinksConfig.md
+++ b/docs/Processors/FixGitCommitLinksConfig.md
@@ -1,5 +1,7 @@
 # Fix Git commit links
 
+> Obsolete - merged into WorkItemMigration
+
 > Note: before this is working you must migrate you source code. See [here](./../index.md) (Code (Git))
 
 This processor add the git links to the migrated work items. You must run the processor `WorkItemMigrationConfig` first do link the commits. Then the links will be updated.
@@ -10,3 +12,5 @@ This processor add the git links to the migrated work items. You must run the pr
 | `Enabled`          | Boolean | Active the processor if it true.         | false                                    |
 | `ObjectType`       | string  | The name of the processor                | FixGitCommitLinksConfig |
 | `TargetRepository` | string  | The new name of the repository. You must only set this if your repository name change in the migration process. |  The name of the source repository                                        |
+| `QueryBit`       | string  | A query to select work items        |  |
+| `OrderBit`       | string  |  A work item query to affect the order in which the work items are returned                |  |

--- a/docs/Processors/HtmlFieldEmbeddedImageMigrationConfig.md
+++ b/docs/Processors/HtmlFieldEmbeddedImageMigrationConfig.md
@@ -1,7 +1,8 @@
 # HTML field embedded image migration
 
-This processor migrate all images in all text fields. This must run after `WorkItemMigrationConfig`.
+> Obsolete - merged into WorkItemMigration
 
+This processor migrate all images in all text fields. This must run after `WorkItemMigrationConfig`.
 
 
 | Parameter name                 | Type          | Description                              | Default Value                            |

--- a/docs/Processors/LinkMigrationConfig.md
+++ b/docs/Processors/LinkMigrationConfig.md
@@ -1,5 +1,7 @@
 # Link migration
 
+> Obsolete - merged into WorkItemMigration
+
 This processor migrate links between work items. This must run after `WorkItemMigrationConfig`.
 
 | Parameter name | Type    | Description                              | Default Value                            |

--- a/docs/Processors/NodeStructuresMigrationConfig.md
+++ b/docs/Processors/NodeStructuresMigrationConfig.md
@@ -1,5 +1,7 @@
 # Node structures migration
 
+> Obsolete - merged into WorkItemMigration
+
 This processor creates the required structure (Area(s) and iteration(s)) of the project. That should be the first migration task.
 
 

--- a/docs/Processors/TestVariablesMigrationConfig.md
+++ b/docs/Processors/TestVariablesMigrationConfig.md
@@ -1,0 +1,8 @@
+# Test variables migration
+
+This processor can migrate test variables that are defined in the test plans / suites. This must run before ` TestPlansAndSuitesMigrationConfig`
+
+| Parameter name | Type    | Description                      | Default Value                            |
+|----------------|---------|----------------------------------|------------------------------------------|
+| `Enabled`      | Boolean | Active the processor if it true. | false                                    |
+| `ObjectType`   | string  | The name of the processor        | TestVariablesMigrationConfig |

--- a/docs/Processors/WorkItemDeleteConfig.md
+++ b/docs/Processors/WorkItemDeleteConfig.md
@@ -1,3 +1,5 @@
 # Work item delete
 
-> Note: this isn't document and that is never used in the code. Maybe this is a dead end. (see [here](https://github.com/nkdAgility/azure-devops-migration-tools/blob/master/src/VstsSyncMigrator.Core/Configuration/Processing/WorkItemDeleteConfig.cs))
+Bulk delete of work items **WARNING DANGEROUS**
+
+> Note: this isn't documented and that is never used in the code. Maybe this is a dead end. (see [here](https://github.com/nkdAgility/azure-devops-migration-tools/blob/master/src/VstsSyncMigrator.Core/Configuration/Processing/WorkItemDeleteConfig.cs))

--- a/docs/Processors/WorkItemMigrationConfig.md
+++ b/docs/Processors/WorkItemMigrationConfig.md
@@ -35,8 +35,12 @@ It will migrate work items using a tip or replay migrator as well as Attachments
 | `WIQLQueryBit`                           | string  | A work item query based on WIQL to select only important work items. To migrate all leave this empty. |                                          |
 | `WIQLOrderBit` | string | A work item query to affect the order in which the work items are migrated. Don't leave this empty. | [System.ChangedDate] desc
 | `SkipToFinalRevisedWorkItemType` | Boolean | If enabled, when a revision is found that changes the work item type it will use the most recent revision work item type when migrating the initial work item. This should only be enabled for migrations from Azure DevOps Service to Azure DevOps Server. | true
-| `CollapseRevisions` | Boolean | If enabled, all revisions except the most recent are collapsed into a JSON format and attached as an attachment. Requires ReplayRevisions to be enabled. | false
-
+| `CollapseRevisions` | Boolean | If enabled, all revisions except the most recent are collapsed into a JSON format and attached as an attachment. Requires ReplayRevisions to be enabled. | false 
+| `PauseAfterEachWorkItem` | Boolean |  Pause after each work item is migrated | false
+| `CollapseRevisions ` | Boolean | If enabled, all work item revisions ar treated as a single revision | false 
+| `GenerateMigrationComment` | Boolean | If enabled, adds a comment recording the migration | true 
+| `NodeBasePaths` |Array`<string`> | The root paths of the Ares / Iterations you want migrate. | ["/"]                                    |
+| `WorkItemIDs ` | Array`<int`> | A list of work items to import | 
 
 ## WIQL Query Bits
 
@@ -47,7 +51,7 @@ The Work Item queries are all built using Work Item [Query Language (WIQL)](http
 
 You can use the [WIQL Editor](https://marketplace.visualstudio.com/items?itemName=ottostreifel.wiql-editor) to craft a query in Azure DevOps.
 
-Typical way that queris are built:
+Typical way that queries are built:
 
 ```
  var targetQuery = 

--- a/docs/Processors/WorkItemQueryMigrationConfig.md
+++ b/docs/Processors/WorkItemQueryMigrationConfig.md
@@ -4,7 +4,7 @@ This processor can migrate queries for work items. Only shared queries are inclu
 
 That processor should run after these processors:
 
-* `NodeStructuresMigrationConfig`
+* `NodeStructuresMigrationConfig` (Obsolete)
 * `TeamMigrationConfig`
  
 
@@ -15,5 +15,5 @@ That processor should run after these processors:
 | `ObjectType`           | string  | The name of the processor                | WorkItemQueryMigrationConfig |
 | `SharedFolderName`     | string  | The folder where the shared queries are in. | Shared Queries                           |
 | `PrefixProjectToNodes` | Boolean | Prefix your iterations and areas with the project name. If you have enabled this in `NodeStructuresMigrationConfig` you must do it here too. | false                                    |
-
+| `SourceToTargetFieldMappings` | Dictionary`<string, string`>| Any field mappings | none |
 

--- a/docs/Processors/WorkItemRevisionReplayMigrationConfig.md
+++ b/docs/Processors/WorkItemRevisionReplayMigrationConfig.md
@@ -1,5 +1,7 @@
 # Work item revision replay migration
 
+> Obsolete - merged into WorkItemMigration
+
 That is the working horse. This processor migrate all the work items. 
 The process is different from `WorkItemMigrationConfig`. This process will create a work item step by step. So you get a clean history in the target project. 
 

--- a/docs/Processors/WorkItemUpdateConfig.md
+++ b/docs/Processors/WorkItemUpdateConfig.md
@@ -1,5 +1,7 @@
 # Work item update
 
+> Obsolete - merged into WorkItemMigration
+
 This processor only updates work items in the target project. So you must first run a full migration so you can update this migration with this processor.
 
 | Parameter name | Type    | Description                              | Default Value                            |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -20,34 +20,119 @@ The global configuration created by the `init` command look like this:
 
 ```json
 {
-  "Version": "8.4",
-  "LogLevel": "Information",
-  "workaroundForQuerySOAPBugEnabled": false,
+  "ChangeSetMappingFile": null,
   "Source": {
-    "Collection": "https://dev.azure.com/psd45",
-    "Project": "DemoProjs",
-    "ReflectedWorkItemIDFieldName": "TfsMigrationTool.ReflectedWorkItemId",
+    "ObjectType": "TfsTeamProjectConfig",
+    "Collection": "https://dev.azure.com/nkdagility-preview/",
+    "Project": "myProjectName",
+    "ReflectedWorkItemIDFieldName": "Custom.ReflectedWorkItemId",
     "AllowCrossProjectLinking": false,
+    "PersonalAccessToken": "",
     "LanguageMaps": {
-        "AreaPath": "Area",
-        "IterationPath": "Iteration"
-	}
+      "AreaPath": "Area",
+      "IterationPath": "Iteration"
+    }
   },
   "Target": {
-    "Collection": "https://dev.azure.com/psd46",
-    "Project": "DemoProjt",
-    "ReflectedWorkItemIDFieldName": "ProcessName.ReflectedWorkItemId",
+    "ObjectType": "TfsTeamProjectConfig",
+    "Collection": "https://dev.azure.com/nkdagility-preview/",
+    "Project": "myProjectName",
+    "ReflectedWorkItemIDFieldName": "Custom.ReflectedWorkItemId",
     "AllowCrossProjectLinking": false,
+    "PersonalAccessToken": "",
     "LanguageMaps": {
-        "AreaPath": "Area",
-        "IterationPath": "Iteration"
-	}
+      "AreaPath": "Area",
+      "IterationPath": "Iteration"
+    }
   },
-  "FieldMaps": [],
-  "WorkItemTypeDefinition": {
-    "sourceWorkItemTypeName": "targetWorkItemTypeName"
-  },
+  "FieldMaps": [
+    {
+      "ObjectType": "MultiValueConditionalMapConfig",
+      "WorkItemTypeName": "*",
+      "sourceFieldsAndValues": {
+        "Field1": "Value1",
+        "Field2": "Value2"
+      },
+      "targetFieldsAndValues": {
+        "Field1": "Value1",
+        "Field2": "Value2"
+      }
+    },
+    {
+      "ObjectType": "FieldBlankMapConfig",
+      "WorkItemTypeName": "*",
+      "targetField": "TfsMigrationTool.ReflectedWorkItemId"
+    },
+    {
+      "ObjectType": "FieldValueMapConfig",
+      "WorkItemTypeName": "*",
+      "sourceField": "System.State",
+      "targetField": "System.State",
+      "defaultValue": "New",
+      "valueMapping": {
+        "Approved": "New",
+        "New": "New",
+        "Committed": "Active",
+        "In Progress": "Active",
+        "To Do": "New",
+        "Done": "Closed",
+        "Removed": "Removed"
+      }
+    },
+    {
+      "ObjectType": "FieldtoFieldMapConfig",
+      "WorkItemTypeName": "*",
+      "sourceField": "Microsoft.VSTS.Common.BacklogPriority",
+      "targetField": "Microsoft.VSTS.Common.StackRank",
+      "defaultValue": null
+    },
+    {
+      "ObjectType": "FieldtoFieldMultiMapConfig",
+      "WorkItemTypeName": "*",
+      "SourceToTargetMappings": {
+        "SourceField1": "TargetField1",
+        "SourceField2": "TargetField2"
+      }
+    },
+    {
+      "ObjectType": "FieldtoTagMapConfig",
+      "WorkItemTypeName": "*",
+      "sourceField": "System.State",
+      "formatExpression": "ScrumState:{0}"
+    },
+    {
+      "ObjectType": "FieldMergeMapConfig",
+      "WorkItemTypeName": "*",
+      "sourceField1": "System.Description",
+      "sourceField2": "Microsoft.VSTS.Common.AcceptanceCriteria",
+      "targetField": "System.Description",
+      "formatExpression": "{0} <br/><br/><h3>Acceptance Criteria</h3>{1}",
+      "doneMatch": "##DONE##"
+    },
+    {
+      "ObjectType": "RegexFieldMapConfig",
+      "WorkItemTypeName": "*",
+      "sourceField": "COMPANY.PRODUCT.Release",
+      "targetField": "COMPANY.DEVISION.MinorReleaseVersion",
+      "pattern": "PRODUCT \\d{4}.(\\d{1})",
+      "replacement": "$1"
+    },
+    {
+      "ObjectType": "FieldValuetoTagMapConfig",
+      "WorkItemTypeName": "*",
+      "sourceField": "Microsoft.VSTS.CMMI.Blocked",
+      "pattern": "Yes",
+      "formatExpression": "{0}"
+    },
+    {
+      "ObjectType": "TreeToTagMapConfig",
+      "WorkItemTypeName": "*",
+      "toSkip": 3,
+      "timeTravel": 1
+    }
+  ],
   "GitRepoMapping": null,
+  "LogLevel": "Information",
   "Processors": [
     {
       "ObjectType": "WorkItemMigrationConfig",
@@ -57,33 +142,43 @@ The global configuration created by the `init` command look like this:
       "UpdateCreatedBy": true,
       "BuildFieldTable": false,
       "AppendMigrationToolSignatureFooter": false,
-      "QueryBit": "AND  [Microsoft.VSTS.Common.ClosedDate] = '' AND [System.WorkItemType] NOT IN ('Test Suite', 'Test Plan')",
-      "OrderBit": "[System.ChangedDate] desc",
+      "WIQLQueryBit": "AND  [Microsoft.VSTS.Common.ClosedDate] = '' AND [System.WorkItemType] NOT IN ('Test Suite', 'Test Plan')",
+      "WIQLOrderBit": "[System.ChangedDate] desc",
       "Enabled": false,
       "LinkMigration": true,
       "AttachmentMigration": true,
       "AttachmentWorkingPath": "c:\\temp\\WorkItemAttachmentWorkingFolder\\",
       "FixHtmlAttachmentLinks": false,
+      "SkipToFinalRevisedWorkItemType": true,
       "WorkItemCreateRetryLimit": 5,
       "FilterWorkItemsThatAlreadyExistInTarget": true,
       "PauseAfterEachWorkItem": false,
-      "BasePaths": [
+      "AttachmentMaxSize": 480000000,
+      "CollapseRevisions": false,
+      "LinkMigrationSaveEachAsAdded": false,
+      "GenerateMigrationComment": true,
+      "NodeBasePaths": [
         "Product\\Area\\Path1",
         "Product\\Area\\Path2"
+      ],
+      "WorkItemIDs": null
     }
-  ]
+  ],
+  "Version": "11.6",
+  "workaroundForQuerySOAPBugEnabled": false,
+  "WorkItemTypeDefinition": {
+    "sourceWorkItemTypeName": "targetWorkItemTypeName"
+  }
 }
-
-
 
 ```
 
 And the description of the available options are:
 
 ### TelemetryEnableTrace
-Allows you to submit trace to Application Insights to allow the devellpment team to diagnose any issues that may be found. If you are submitting a support ticket then please include the Session GUID found in your log file for that run. This will help us find the problem.
+Allows you to submit trace to Application Insights to allow the development team to diagnose any issues that may be found. If you are submitting a support ticket then please include the Session GUID found in your log file for that run. This will help us find the problem.
 
-**note:** All exceptions that you encounter will surface inside of Visual Studio as the developers are working on the source. This will make sure that they tackle issues as they arise.
+**Note:** All exceptions that you encounter will surface inside of Visual Studio as the developers are working on the source. This will make sure that they tackle issues as they arise.
 
 ### Source & Target
 Both the `Source` and `Target` entries hold the collection URL and the Team Project name that you are connecting to. The `Source` is where the tool will read the data to migrate. The `Target` is where the tool will write the data.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -11,16 +11,16 @@ In order to run the migration you will need to install the tools first.
 1. Install Chocolatey from [https://chocolatey.org/install](https://chocolatey.org/install)
 1. Run "**choco install vsts-sync-migrator**" to install the tools [source](https://chocolatey.org/packages/vsts-sync-migrator)
 
-The tools are now installed and calling "vstssyncmigrator" from any command line will run the tools or it will not and you will need to switch to `c:\tools\vstssyncmigration\` and run `migrate.exe`.
+The tools are now installed. To run them you will need to switch to `c:\tools\MigrationTools\` and run `migrate.exe`.
 
 ## Server configuration and setup
 
-Follow the [setup instructions](./server-configuration.md) to make sure that you can run the tool against your enviroments.
+Follow the [setup instructions](./server-configuration.md) to make sure that you can run the tool against your environments.
 
 
 ## Create a default configuration file
 
-1. Open a command prompt or PowerShell window at `c:\tools\vstssyncmigration\`
+1. Open a command prompt or PowerShell window at `c:\tools\MigrationTools\`
 2. Run "./migration.exe init" to create a default configuration
 3. Open "configuration.json" from the current directory
 
@@ -28,12 +28,11 @@ You can now customise the configuration depending on what you need to do. Howeve
 
 ```
 {
-  "Version": "0.0",
-  "LogLevel": "Information",
-  "workaroundForQuerySOAPBugEnabled": false,
+  "ChangeSetMappingFile": null,
   "Source": {
+    "ObjectType": "TfsTeamProjectConfig",
     "Collection": "https://dev.azure.com/nkdagility-preview/",
-    "Project": "migrationSource1",
+    "Project": "myProjectName",
     "ReflectedWorkItemIDFieldName": "Custom.ReflectedWorkItemId",
     "AllowCrossProjectLinking": false,
     "PersonalAccessToken": "",
@@ -43,8 +42,9 @@ You can now customise the configuration depending on what you need to do. Howeve
     }
   },
   "Target": {
+    "ObjectType": "TfsTeamProjectConfig",
     "Collection": "https://dev.azure.com/nkdagility-preview/",
-    "Project": "migrationTarget1",
+    "Project": "myProjectName",
     "ReflectedWorkItemIDFieldName": "Custom.ReflectedWorkItemId",
     "AllowCrossProjectLinking": false,
     "PersonalAccessToken": "",
@@ -91,7 +91,8 @@ You can now customise the configuration depending on what you need to do. Howeve
       "ObjectType": "FieldtoFieldMapConfig",
       "WorkItemTypeName": "*",
       "sourceField": "Microsoft.VSTS.Common.BacklogPriority",
-      "targetField": "Microsoft.VSTS.Common.StackRank"
+      "targetField": "Microsoft.VSTS.Common.StackRank",
+      "defaultValue": null
     },
     {
       "ObjectType": "FieldtoFieldMultiMapConfig",
@@ -138,20 +139,9 @@ You can now customise the configuration depending on what you need to do. Howeve
       "timeTravel": 1
     }
   ],
-  "WorkItemTypeDefinition": {
-    "sourceWorkItemTypeName": "targetWorkItemTypeName"
-  },
   "GitRepoMapping": null,
+  "LogLevel": "Information",
   "Processors": [
-    {
-      "ObjectType": "NodeStructuresMigrationConfig",
-      "PrefixProjectToNodes": false,
-      "Enabled": false,
-      "BasePaths": [
-        "Product\\Area\\Path1",
-        "Product\\Area\\Path2"
-      ]
-    },
     {
       "ObjectType": "WorkItemMigrationConfig",
       "ReplayRevisions": true,
@@ -160,24 +150,34 @@ You can now customise the configuration depending on what you need to do. Howeve
       "UpdateCreatedBy": true,
       "BuildFieldTable": false,
       "AppendMigrationToolSignatureFooter": false,
-      "QueryBit": "AND  [Microsoft.VSTS.Common.ClosedDate] = '' AND [System.WorkItemType] NOT IN ('Test Suite', 'Test Plan')",
-      "OrderBit": "[System.ChangedDate] desc",
+      "WIQLQueryBit": "AND  [Microsoft.VSTS.Common.ClosedDate] = '' AND [System.WorkItemType] NOT IN ('Test Suite', 'Test Plan')",
+      "WIQLOrderBit": "[System.ChangedDate] desc",
       "Enabled": false,
       "LinkMigration": true,
       "AttachmentMigration": true,
       "AttachmentWorkingPath": "c:\\temp\\WorkItemAttachmentWorkingFolder\\",
       "FixHtmlAttachmentLinks": false,
-      "SkipToFinalRevisedWorkItemType": false,
+      "SkipToFinalRevisedWorkItemType": true,
       "WorkItemCreateRetryLimit": 5,
       "FilterWorkItemsThatAlreadyExistInTarget": true,
       "PauseAfterEachWorkItem": false,
       "AttachmentMaxSize": 480000000,
       "CollapseRevisions": false,
-      "LinkMigrationSaveEachAsAdded": false
+      "LinkMigrationSaveEachAsAdded": false,
+      "GenerateMigrationComment": true,
+      "NodeBasePaths": [
+        "Product\\Area\\Path1",
+        "Product\\Area\\Path2"
+      ],
+      "WorkItemIDs": null
     }
-  ]
+  ],
+  "Version": "0.0",
+  "workaroundForQuerySOAPBugEnabled": false,
+  "WorkItemTypeDefinition": {
+    "sourceWorkItemTypeName": "targetWorkItemTypeName"
+  }
 }
-
 ```
 
 Here we are performing the following operations:

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,10 +18,10 @@ _NOTICE: Both paid and community support is available through our [recommended c
 
 ## Change Log
 
-- v11.5 - Added more usefull logging levels. Replace `"TelemetryEnableTrace": false` with `"LogLevel": "Verbose"` in the config. Verbose will only be logged to the logfile.
-- v11.2.1 - Removed NodeMogrationContext and converted it to an enricher for Work Items. Still needs work, so that it migrates individual nodes, but currently migrates all.
+- v11.5 - Added more useful logging levels. Replace `"TelemetryEnableTrace": false` with `"LogLevel": "Verbose"` in the config. Verbose will only be logged to the logfile.
+- v11.2.1 - Removed NodeMigrationContext and converted it to an enricher for Work Items. Still needs work, so that it migrates individual nodes, but currently migrates all.
 - v10.1 - Changed config design to have only the Name and not FullName of the class. Remove `MigrationTools.Core.Configuration.FieldMap.` and `MigrationTools.Core.Configuration.Processing.` from the config leaving only the Name of the class in ObjectType field.
-- v10.0 - Start of the greate refactor over to .NET Core and the REST API as the Object Model has been retired.
+- v10.0 - Start of the great refactor over to .NET Core and the REST API as the Object Model has been retired.
 - v9.0 - Added support for migration between other language versions of Azure DevOps. Developed for German -> English
 - v8.9 - Added 'Collapse Revisions' feature to collapse and attache revisions instead of replaying them
 - v8.8 - 'SkipToFinalRevisedWorkItemType' feature added to handle scenario when changing Work Item Type
@@ -86,25 +86,27 @@ Most of these processors need to be run in order. If you try to migrate work ite
 
 |Processor | Status |Target |Usage |
 |---------|---------|---------|---------|
-| [WorkItemMigration](./Processors/WorkItemMigrationConfig.md) | ready | Work Items | Migrates either tip or history of work items with Links & Attachments based on a query with field mappings |
-| [TeamMigration](./Processors/TeamMigrationConfig.md) | beta | Teams | Migrates Teams and Team Settings |
-| [WorkItemDelete](./Processors/WorkItemDeleteConfig.md) | ready | Work Items | Bulk delete of work items **WARNING DANGEROUS** |
-| [WorkItemUpdate](./Processors/WorkItemUpdateConfig.md) | ready | Work Items | Bulk update of Work Items based on a query and field mappings |
+|[WorkItemMigration](./Processors/WorkItemMigrationConfig.md) | ready | Work Items | Migrates either tip or history of work items with Links & Attachments based on a query with field mappings |
+|[TeamMigration](./Processors/TeamMigrationConfig.md) | beta | Teams | Migrates Teams and Team Settings |
+|[WorkItemDelete](./Processors/WorkItemDeleteConfig.md) | ready | Work Items | Bulk delete of work items **WARNING DANGEROUS** |
+|[WorkItemUpdate](./Processors/WorkItemUpdateConfig.md) | ready | Work Items | Bulk update of Work Items based on a query and field mappings |
 |[WorkItemQueryMigration](./Processors/WorkItemQueryMigrationConfig.md) | ready | Queries | Migrates shared queries |
-|[TestVeriablesMigration](./Processors/TestVeriablesMigrationConfig.md) | Beta | Suits & Plans | Migrates Test Variables |
-|[TestConfigurationsMigration](./Processors/TestConfigurationsMigrationConfig.md) | Beta  | Suits & Plans | Migrates Test configurations |
-|[TestPlansAndSuitesMigration](./Processors/TestPlansAndSuitesMigrationConfig.md) | Beta  | Suits & Plans | Rebuilds Suits and plans for Test Cases migrated using the WorkItemMigration |
+|[TeamMigration](./Processors/TeamMigrationConfig.md) | Beta | Teams | Migrates Teams |
+|[TestVariablesMigration](./Processors/TestVariablesMigrationConfig.md) | Beta | Suites & Plans | Migrates Test Variables |
+|[TestConfigurationsMigration](./Processors/TestConfigurationsMigrationConfig.md) | Beta  | Suites & Plans | Migrates Test configurations |
+|[TestPlansAndSuitesMigration](./Processors/TestPlansAndSuitesMigrationConfig.md) | Beta  | Suites & Plans | Rebuilds Suits and plans for Test Cases migrated using the WorkItemMigration |
+|[ImportProfilePicture](./Processors/ImportProfilePictureConfig) & ExportProfilePictureFromAD | Beta | Profiles | Downloads corporate images and updates TFS/Azure DevOps profiles |
+|[WorkItemUpdateAreasAsTags](](./Processors/WorkItemUpdateAreasAsTagsConfig) | Beta | Work Items | Adds tags to work items  to reflect area paths on source system |
 |TestRunsMigration | Alfa | Suits & Plans | Migrates the history of Test Runs |
-|ImportProfilePicture & ExportProfilePictureFromAD | Beta | Profiles | Downloads corporate images and updates TFS/Azure DevOps profiles |
-|CreateTeamFolders | ? | ? | ? | 
-|ExportTeamList | ? | ? | ? | 
-|[NodeStructuresMigration](./Processors/NodeStructuresMigrationConfig.md) | merged | Area & Iteration | obsolite - merged into WorkItemMigration |
-|AttachementExportMigration | merged | Work Items | obsolite - merged into WorkItemMigration |
-|AttachementImportMigration | merged | Work Items | obsolite - merged into WorkItemMigration |
-|LinkMigration | merged | Work Items | obsolite - merged into WorkItemMigration |
-|HtmlFieldEmbeddedImageMigration | merged | HTML Fields | obsolite - merged into WorkItemMigration |
-|WorkItemRevisionReplayMigration | merged |  Work Items | obsolite - merged into WorkItemMigration |
-|GitCommitFix | merged | Git links | obsolite - merged into WorkItemMigration |
+|NodeStructuresMigration | merged | Area & Iteration | obsolete - merged into WorkItemMigration |
+|AttachementExportMigration | merged | Work Items | obsolete - merged into WorkItemMigration |
+|AttachementImportMigration | merged | Work Items | obsolete - merged into WorkItemMigration |
+|LinkMigration | merged | Work Items | obsolete - merged into WorkItemMigration |
+|HtmlFieldEmbeddedImageMigration | merged | HTML Fields | obsolete - merged into WorkItemMigration |
+|WorkItemRevisionReplayMigration | merged |  Work Items | obsolete - merged into WorkItemMigration |
+|GitCommitFix | merged | Git links | obsolete - merged into WorkItemMigration |
+|WorkItemUpdateConfig | merged | Work Items | obsolete - merged into WorkItemMigration |
+
 
 ### Field Maps
 


### PR DESCRIPTION
Whilst working with a client to do a migration using 11.6 I found the current documentation somewhat misleading due to the number of older processors that have been rolled into the WorkItemMigration processor.

I have made an effort to

- Make sure any processor document that is not currently in source control is marked as obsolete on both the index page and its own page
- Made sure all the configuration options on source control are present in the docs
- General update of the configuration samples and file path to reflect the currently shipping product.

