### PR TITLE
Feature/654

### DIFF
--- a/configuration.json
+++ b/configuration.json
@@ -116,12 +116,35 @@
   },
   "GitRepoMapping": null,
   "Processors": [
-    {
-      "ObjectType": "WorkItemDeleteConfig",
-      "Enabled": true,
-      "WIQLQueryBit": "AND [System.WorkItemType] NOT IN ('Test Suite', 'Test Plan')",
-      "WIQLOrderBit": "[System.ChangedDate] desc"
-    },
+    //{
+    //  "ObjectType": "WorkItemDeleteConfig",
+    //  "Enabled": true,
+    //  "WIQLQueryBit": "AND [System.WorkItemType] NOT IN ('Test Suite', 'Test Plan')",
+    //  "WIQLOrderBit": "[System.ChangedDate] desc"
+    //},
+    //{
+    //  "ObjectType": "WorkItemMigrationConfig",
+    //  "ReplayRevisions": true,
+    //  "PrefixProjectToNodes": false,
+    //  "UpdateCreatedDate": true,
+    //  "UpdateCreatedBy": true,
+    //  "BuildFieldTable": false,
+    //  "AppendMigrationToolSignatureFooter": false,
+    //  "WIQLQueryBit": "AND [System.WorkItemType] NOT IN ('Test Suite', 'Test Plan')",
+    //  "WIQLOrderBit": "[System.ChangedDate] desc",
+    //  "Enabled": true,
+    //  "LinkMigration": true,
+    //  "AttachmentMigration": true,
+    //  "AttachmentWorkingPath": "c:\\temp\\WorkItemAttachmentWorkingFolder\\",
+    //  "FixHtmlAttachmentLinks": false,
+    //  "SkipToFinalRevisedWorkItemType": false,
+    //  "WorkItemCreateRetryLimit": 5,
+    //  "FilterWorkItemsThatAlreadyExistInTarget": true,
+    //  "PauseAfterEachWorkItem": false,
+    //  "AttachmentMaxSize": 480000000,
+    //  "CollapseRevisions": false,
+    //  "LinkMigrationSaveEachAsAdded": true
+    //},
     {
       "ObjectType": "WorkItemMigrationConfig",
       "ReplayRevisions": true,
@@ -139,7 +162,7 @@
       "FixHtmlAttachmentLinks": false,
       "SkipToFinalRevisedWorkItemType": false,
       "WorkItemCreateRetryLimit": 5,
-      "FilterWorkItemsThatAlreadyExistInTarget": true,
+      "FilterWorkItemsThatAlreadyExistInTarget": false,
       "PauseAfterEachWorkItem": false,
       "AttachmentMaxSize": 480000000,
       "CollapseRevisions": false,

--- a/src/MigrationTools.Clients.AzureDevops.ObjectModel/Clients/TfsReflectedWorkItemId.cs
+++ b/src/MigrationTools.Clients.AzureDevops.ObjectModel/Clients/TfsReflectedWorkItemId.cs
@@ -38,12 +38,9 @@ namespace MigrationTools.Clients
             }
         }
 
-        public new string ToString
+        public override string ToString()
         {
-            get
-            {
-                return string.Format("{0}/{1}/_workitems/edit/{2}", _Connection.ToString().TrimEnd('/'), _ProjectName, _WorkItemId);
-            }
+            return string.Format("{0}/{1}/_workitems/edit/{2}", _Connection.ToString().TrimEnd('/'), _ProjectName, _WorkItemId);
         }
     }
 }

--- a/src/MigrationTools.Clients.AzureDevops.ObjectModel/Clients/TfsReflectedWorkItemId.cs
+++ b/src/MigrationTools.Clients.AzureDevops.ObjectModel/Clients/TfsReflectedWorkItemId.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Text.RegularExpressions;
+using MigrationTools.DataContracts;
+
+namespace MigrationTools.Clients
+{
+    public class TfsReflectedWorkItemId : ReflectedWorkItemId
+    {
+        private Uri _Connection;
+        private string _ProjectName;
+        private string _WorkItemId;
+
+        public TfsReflectedWorkItemId(WorkItemData workItem) : base(workItem.Id)
+        {
+            if (workItem is null)
+            {
+                throw new ArgumentNullException(nameof(workItem));
+            }
+
+            _WorkItemId = workItem.Id;
+            _ProjectName = workItem.ProjectName;
+            _Connection = workItem.ToWorkItem().Store.TeamProjectCollection.Uri;
+        }
+
+        public TfsReflectedWorkItemId(string ReflectedWorkItemId) : base(ReflectedWorkItemId)
+        {
+            if (ReflectedWorkItemId is null)
+            {
+                throw new ArgumentNullException(nameof(ReflectedWorkItemId));
+            }
+            var re = new Regex(@"^(?<org>\S+)\/(?<project>\S+)\/_workitems\/edit\/(?<id>\d+)");
+            var match = re.Match(ReflectedWorkItemId);
+            if (match.Success)
+            {
+                _WorkItemId = match.Groups["id"].Value;
+                _ProjectName = match.Groups["project"].Value;
+                _Connection = new Uri(match.Groups["org"].Value);
+            }
+        }
+
+        public new string ToString
+        {
+            get
+            {
+                return string.Format("{0}/{1}/_workitems/edit/{2}", _Connection.ToString().TrimEnd('/'), _ProjectName, _WorkItemId);
+            }
+        }
+    }
+}

--- a/src/MigrationTools.Clients.AzureDevops.ObjectModel/Clients/TfsWiqlDefinition.cs
+++ b/src/MigrationTools.Clients.AzureDevops.ObjectModel/Clients/TfsWiqlDefinition.cs
@@ -1,0 +1,8 @@
+﻿namespace MigrationTools.Clients
+{
+    public class TfsWiqlDefinition
+    {
+        public string QueryBit { get; set; }
+        public string OrderBit { get; set; }
+    }
+}

--- a/src/MigrationTools.Clients.AzureDevops.ObjectModel/Clients/TfsWorkItemMigrationClient.cs
+++ b/src/MigrationTools.Clients.AzureDevops.ObjectModel/Clients/TfsWorkItemMigrationClient.cs
@@ -38,11 +38,7 @@ namespace MigrationTools.Clients
 
             var workItemToFind = workItemToReflect.ToWorkItem();
 
-            WorkItem found = null;
-            if (Cache.ContainsKey(workItemToFind.Id))
-            {
-                return Cache[workItemToFind.Id]; ;
-            }
+            WorkItem found = GetFromCache(ReflectedWorkItemId)?.ToWorkItem();
 
             // If we have a Reflected WorkItem ID field on the source store, assume it is pointing to the desired work item on the target store
             if (Config.AsTeamProjectConfig().ReflectedWorkItemIDFieldName != null && workItemToFind.Fields.Contains(Config.AsTeamProjectConfig().ReflectedWorkItemIDFieldName) && !string.IsNullOrEmpty(workItemToFind.Fields[Config.AsTeamProjectConfig().ReflectedWorkItemIDFieldName]?.Value?.ToString()))
@@ -73,7 +69,7 @@ namespace MigrationTools.Clients
             }
             if (found != null && cache)
             {
-                AddToCache(workItemToFind.Id, found.AsWorkItemData());/// TODO MEMORY LEAK
+                AddToCache(found.AsWorkItemData());/// TODO MEMORY LEAK
             }
             return found?.AsWorkItemData();
         }

--- a/src/MigrationTools.Tests/Core/Clients/WorkItemMigrationClientMock.cs
+++ b/src/MigrationTools.Tests/Core/Clients/WorkItemMigrationClientMock.cs
@@ -134,5 +134,25 @@ namespace MigrationTools.Clients.Tests
         {
             throw new System.NotImplementedException();
         }
+
+        public WorkItemData FindReflectedWorkItemByMigrationRef(ReflectedWorkItemId refId)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public WorkItemData FindReflectedWorkItemByReflectedWorkItemId(ReflectedWorkItemId refId, bool cache)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        ReflectedWorkItemId IWorkItemMigrationClient.CreateReflectedWorkItemId(WorkItemData workItem)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        ReflectedWorkItemId IWorkItemMigrationClient.GetReflectedWorkItemId(WorkItemData workItem)
+        {
+            throw new System.NotImplementedException();
+        }
     }
 }

--- a/src/MigrationTools/Clients/IWorkItemMigrationClient.cs
+++ b/src/MigrationTools/Clients/IWorkItemMigrationClient.cs
@@ -29,13 +29,7 @@ namespace MigrationTools.Clients
 
         WorkItemData FindReflectedWorkItem(WorkItemData workItem, bool cache);
 
-        WorkItemData FindReflectedWorkItemByTitle(string title);
-
-        WorkItemData FindReflectedWorkItemByMigrationRef(ReflectedWorkItemId refId);
-
         WorkItemData FindReflectedWorkItemByReflectedWorkItemId(string refId);
-
-        WorkItemData FindReflectedWorkItemByReflectedWorkItemId(ReflectedWorkItemId refId, bool cache);
 
         WorkItemData FindReflectedWorkItemByReflectedWorkItemId(WorkItemData refWi);
 

--- a/src/MigrationTools/Clients/IWorkItemMigrationClient.cs
+++ b/src/MigrationTools/Clients/IWorkItemMigrationClient.cs
@@ -31,16 +31,16 @@ namespace MigrationTools.Clients
 
         WorkItemData FindReflectedWorkItemByTitle(string title);
 
-        WorkItemData FindReflectedWorkItemByMigrationRef(string refId);
+        WorkItemData FindReflectedWorkItemByMigrationRef(ReflectedWorkItemId refId);
 
         WorkItemData FindReflectedWorkItemByReflectedWorkItemId(string refId);
 
-        WorkItemData FindReflectedWorkItemByReflectedWorkItemId(int refId, bool cache);
+        WorkItemData FindReflectedWorkItemByReflectedWorkItemId(ReflectedWorkItemId refId, bool cache);
 
         WorkItemData FindReflectedWorkItemByReflectedWorkItemId(WorkItemData refWi);
 
-        string CreateReflectedWorkItemId(WorkItemData workItem);
+        ReflectedWorkItemId CreateReflectedWorkItemId(WorkItemData workItem);
 
-        int GetReflectedWorkItemId(WorkItemData workItem);
+        ReflectedWorkItemId GetReflectedWorkItemId(WorkItemData workItem);
     }
 }

--- a/src/MigrationTools/Clients/ReflectedWorkItemId.cs
+++ b/src/MigrationTools/Clients/ReflectedWorkItemId.cs
@@ -3,7 +3,7 @@ using MigrationTools.DataContracts;
 
 namespace MigrationTools.Clients
 {
-    public class ReflectedWorkItemId
+    public abstract class ReflectedWorkItemId
     {
         private string _WorkItemId;
 
@@ -24,6 +24,11 @@ namespace MigrationTools.Clients
                 throw new ArgumentNullException(nameof(ReflectedWorkItemId));
             }
             _WorkItemId = ReflectedWorkItemId;
+        }
+
+        public override string ToString()
+        {
+            return WorkItemId;
         }
 
         public string WorkItemId

--- a/src/MigrationTools/Clients/ReflectedWorkItemId.cs
+++ b/src/MigrationTools/Clients/ReflectedWorkItemId.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using MigrationTools.DataContracts;
+
+namespace MigrationTools.Clients
+{
+    public class ReflectedWorkItemId
+    {
+        private string _WorkItemId;
+
+        public ReflectedWorkItemId(WorkItemData workItem)
+        {
+            if (workItem is null)
+            {
+                throw new ArgumentNullException(nameof(workItem));
+            }
+
+            _WorkItemId = workItem.Id;
+        }
+
+        public ReflectedWorkItemId(string ReflectedWorkItemId)
+        {
+            if (ReflectedWorkItemId is null)
+            {
+                throw new ArgumentNullException(nameof(ReflectedWorkItemId));
+            }
+            _WorkItemId = ReflectedWorkItemId;
+        }
+
+        public string WorkItemId
+        {
+            get
+            {
+                return _WorkItemId;
+            }
+        }
+    }
+}

--- a/src/MigrationTools/Clients/WorkItemMigrationClientBase.cs
+++ b/src/MigrationTools/Clients/WorkItemMigrationClientBase.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using MigrationTools.Configuration;
 using MigrationTools.DataContracts;
 
@@ -8,7 +7,7 @@ namespace MigrationTools.Clients
 {
     public abstract class WorkItemMigrationClientBase : IWorkItemMigrationClient
     {
-        private Dictionary<ReflectedWorkItemId, WorkItemData> _Cache = new Dictionary<ReflectedWorkItemId, WorkItemData>();
+        private Dictionary<string, WorkItemData> _Cache = new Dictionary<string, WorkItemData>();
         private IMigrationClient _migrationClient;
 
         public WorkItemMigrationClientBase(IServiceProvider services, ITelemetryLogger telemetry)
@@ -63,27 +62,26 @@ namespace MigrationTools.Clients
 
         protected void AddToCache(WorkItemData workItem)
         {
-            _Cache.Add(GetReflectedWorkItemId(workItem), workItem);
+            string key = GetReflectedWorkItemId(workItem).ToString();
+            if (!_Cache.ContainsKey(key))
+            {
+                _Cache.Add(key, workItem);
+            }
         }
 
         protected void AddToCache(List<WorkItemData> workItems)
         {
             foreach (WorkItemData workItem in workItems)
             {
-                _Cache.Add(GetReflectedWorkItemId(workItem), workItem);
+                AddToCache(workItem);
             }
         }
 
         protected WorkItemData GetFromCache(ReflectedWorkItemId reflectedWorkItemId)
         {
-            if (_Cache.ContainsKey(reflectedWorkItemId))
+            if (_Cache.ContainsKey(reflectedWorkItemId.ToString()))
             {
-                return _Cache[reflectedWorkItemId];
-            }
-            var found = (from ReflectedWorkItemId x in _Cache.Keys where x.ToString() == reflectedWorkItemId.ToString() select x).SingleOrDefault();
-            if (found != null)
-            {
-                return _Cache[found];
+                return _Cache[reflectedWorkItemId.ToString()];
             }
             return null;
         }

--- a/src/MigrationTools/Clients/WorkItemMigrationClientBase.cs
+++ b/src/MigrationTools/Clients/WorkItemMigrationClientBase.cs
@@ -38,15 +38,9 @@ namespace MigrationTools.Clients
 
         public abstract WorkItemData FindReflectedWorkItem(WorkItemData reflectedWorkItem, bool cache);
 
-        public abstract WorkItemData FindReflectedWorkItemByMigrationRef(ReflectedWorkItemId reflectedWorkItemId);
-
         public abstract WorkItemData FindReflectedWorkItemByReflectedWorkItemId(string reflectedWorkItemId);
 
-        public abstract WorkItemData FindReflectedWorkItemByReflectedWorkItemId(ReflectedWorkItemId reflectedWorkItemId, bool cache);
-
         public abstract WorkItemData FindReflectedWorkItemByReflectedWorkItemId(WorkItemData reflectedWorkItem);
-
-        public abstract WorkItemData FindReflectedWorkItemByTitle(string title);
 
         public abstract ProjectData GetProject();
 

--- a/src/MigrationTools/Clients/WorkItemMigrationClientBase.cs
+++ b/src/MigrationTools/Clients/WorkItemMigrationClientBase.cs
@@ -11,20 +11,18 @@ namespace MigrationTools.Clients
         private Dictionary<int, WorkItemData> _Cache = new Dictionary<int, WorkItemData>();
         private IMigrationClient _migrationClient;
 
-        protected IMigrationClient MigrationClient { get { return _migrationClient; } }
-        protected IServiceProvider Services { get; }
-        protected ITelemetryLogger Telemetry { get; }
-
-        protected ReadOnlyDictionary<int, WorkItemData> Cache { get { return new ReadOnlyDictionary<int, WorkItemData>(_Cache); } }
-
-        public abstract IMigrationClientConfig Config { get; }
-        public abstract ProjectData Project { get; }
-
         public WorkItemMigrationClientBase(IServiceProvider services, ITelemetryLogger telemetry)
         {
             Services = services;
             Telemetry = telemetry;
         }
+
+        public abstract IMigrationClientConfig Config { get; }
+        public abstract ProjectData Project { get; }
+        protected ReadOnlyDictionary<int, WorkItemData> Cache { get { return new ReadOnlyDictionary<int, WorkItemData>(_Cache); } }
+        protected IMigrationClient MigrationClient { get { return _migrationClient; } }
+        protected IServiceProvider Services { get; }
+        protected ITelemetryLogger Telemetry { get; }
 
         public void Configure(IMigrationClient migrationClient, bool bypassRules = true)
         {
@@ -36,12 +34,29 @@ namespace MigrationTools.Clients
             InnerConfigure(migrationClient, bypassRules);
         }
 
-        protected void AddToCache(int sourceIdKey, WorkItemData workItem)
-        {
-            _Cache.Add(sourceIdKey, workItem);
-        }
+        public abstract ReflectedWorkItemId CreateReflectedWorkItemId(WorkItemData workItem);
 
-        public abstract void InnerConfigure(IMigrationClient migrationClient, bool bypassRules = true);
+        public abstract WorkItemData FindReflectedWorkItem(WorkItemData reflectedWorkItem, bool cache);
+
+        public abstract WorkItemData FindReflectedWorkItemByMigrationRef(ReflectedWorkItemId reflectedWorkItemId);
+
+        public abstract WorkItemData FindReflectedWorkItemByReflectedWorkItemId(string reflectedWorkItemId);
+
+        public abstract WorkItemData FindReflectedWorkItemByReflectedWorkItemId(ReflectedWorkItemId reflectedWorkItemId, bool cache);
+
+        public abstract WorkItemData FindReflectedWorkItemByReflectedWorkItemId(WorkItemData reflectedWorkItem);
+
+        public abstract WorkItemData FindReflectedWorkItemByTitle(string title);
+
+        public abstract ProjectData GetProject();
+
+        public abstract ReflectedWorkItemId GetReflectedWorkItemId(WorkItemData workItem);
+
+        public abstract WorkItemData GetRevision(WorkItemData workItem, int revision);
+
+        public abstract WorkItemData GetWorkItem(string id);
+
+        public abstract WorkItemData GetWorkItem(int id);
 
         public abstract List<WorkItemData> GetWorkItems();
 
@@ -49,30 +64,13 @@ namespace MigrationTools.Clients
 
         public abstract List<WorkItemData> GetWorkItems(IWorkItemQueryBuilder queryBuilder);
 
+        public abstract void InnerConfigure(IMigrationClient migrationClient, bool bypassRules = true);
+
         public abstract WorkItemData PersistWorkItem(WorkItemData workItem);
 
-        public abstract WorkItemData GetRevision(WorkItemData workItem, int revision);
-
-        public abstract WorkItemData FindReflectedWorkItemByTitle(string title);
-
-        public abstract WorkItemData FindReflectedWorkItemByMigrationRef(string refId);
-
-        public abstract WorkItemData FindReflectedWorkItemByReflectedWorkItemId(string refId);
-
-        public abstract WorkItemData FindReflectedWorkItemByReflectedWorkItemId(int refId, bool cache);
-
-        public abstract WorkItemData FindReflectedWorkItemByReflectedWorkItemId(WorkItemData refWi);
-
-        public abstract string CreateReflectedWorkItemId(WorkItemData workItem);
-
-        public abstract int GetReflectedWorkItemId(WorkItemData workItem);
-
-        public abstract WorkItemData FindReflectedWorkItem(WorkItemData workItem, bool cache);
-
-        public abstract ProjectData GetProject();
-
-        public abstract WorkItemData GetWorkItem(string id);
-
-        public abstract WorkItemData GetWorkItem(int id);
+        protected void AddToCache(int sourceIdKey, WorkItemData workItem)
+        {
+            _Cache.Add(sourceIdKey, workItem);
+        }
     }
 }

--- a/src/MigrationTools/Clients/WorkItemMigrationClientBase.cs
+++ b/src/MigrationTools/Clients/WorkItemMigrationClientBase.cs
@@ -66,6 +66,14 @@ namespace MigrationTools.Clients
             _Cache.Add(GetReflectedWorkItemId(workItem), workItem);
         }
 
+        protected void AddToCache(List<WorkItemData> workItems)
+        {
+            foreach (WorkItemData workItem in workItems)
+            {
+                _Cache.Add(GetReflectedWorkItemId(workItem), workItem);
+            }
+        }
+
         protected WorkItemData GetFromCache(ReflectedWorkItemId reflectedWorkItemId)
         {
             if (_Cache.ContainsKey(reflectedWorkItemId))

--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/TestPlansAndSuitesMigrationContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/TestPlansAndSuitesMigrationContext.cs
@@ -601,7 +601,7 @@ namespace VstsSyncMigrator.Engine
                     foreach (Match match in matches)
                     {
                         var qid = match.Value.Split('=')[1].Trim();
-                        var targetWi = Engine.Target.WorkItems.FindReflectedWorkItemByReflectedWorkItemId(Convert.ToInt32(qid), false);
+                        var targetWi = Engine.Target.WorkItems.FindReflectedWorkItemByReflectedWorkItemId(qid);
 
                         if (targetWi == null)
                         {

--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemMigrationContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemMigrationContext.cs
@@ -108,7 +108,7 @@ namespace VstsSyncMigrator.Engine
             if (_config.FilterWorkItemsThatAlreadyExistInTarget)
             {
                 contextLog.Information("[FilterWorkItemsThatAlreadyExistInTarget] is enabled. Searching for work items that have already been migrated to the target...", sourceWorkItems.Count());
-                sourceWorkItems = FilterByTarget(sourceWorkItems);
+                sourceWorkItems = ((TfsWorkItemMigrationClient)Engine.Target.WorkItems).FilterExistingWorkItems(sourceWorkItems, new TfsWiqlDefinition() { OrderBit = _config.WIQLQueryBit, QueryBit = _config.WIQLOrderBit });
                 contextLog.Information("!! After removing all found work items there are {SourceWorkItemCount} remaining to be migrated.", sourceWorkItems.Count());
             }
             //////////////////////////////////////////////////
@@ -235,6 +235,7 @@ namespace VstsSyncMigrator.Engine
             return newwit.AsWorkItemData();
         }
 
+        [Obsolete("Replaced be TfsWorkItemMigrationClient.FilterExistingWorkItems ", true)]
         private List<WorkItemData> FilterByTarget(List<WorkItemData> sourceWorkItems)
         {
             contextLog.Debug("FilterByTarget: START");

--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemMigrationContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemMigrationContext.cs
@@ -108,7 +108,7 @@ namespace VstsSyncMigrator.Engine
             if (_config.FilterWorkItemsThatAlreadyExistInTarget)
             {
                 contextLog.Information("[FilterWorkItemsThatAlreadyExistInTarget] is enabled. Searching for work items that have already been migrated to the target...", sourceWorkItems.Count());
-                sourceWorkItems = ((TfsWorkItemMigrationClient)Engine.Target.WorkItems).FilterExistingWorkItems(sourceWorkItems, new TfsWiqlDefinition() { OrderBit = _config.WIQLQueryBit, QueryBit = _config.WIQLOrderBit });
+                sourceWorkItems = ((TfsWorkItemMigrationClient)Engine.Target.WorkItems).FilterExistingWorkItems(sourceWorkItems, new TfsWiqlDefinition() { OrderBit = _config.WIQLOrderBit, QueryBit = _config.WIQLQueryBit });
                 contextLog.Information("!! After removing all found work items there are {SourceWorkItemCount} remaining to be migrated.", sourceWorkItems.Count());
             }
             //////////////////////////////////////////////////
@@ -231,7 +231,6 @@ namespace VstsSyncMigrator.Engine
             Telemetry.TrackDependency(new DependencyTelemetry("TfsObjectModel", Engine.Target.Config.AsTeamProjectConfig().Collection.ToString(), "NewWorkItem", null, newWorkItemstartTime, newWorkItemTimer.Elapsed, "200", true));
             if (_config.UpdateCreatedBy) { newwit.Fields["System.CreatedBy"].Value = currentRevisionWorkItem.ToWorkItem().Revisions[0].Fields["System.CreatedBy"].Value; }
             if (_config.UpdateCreatedDate) { newwit.Fields["System.CreatedDate"].Value = currentRevisionWorkItem.ToWorkItem().Revisions[0].Fields["System.CreatedDate"].Value; }
-
             return newwit.AsWorkItemData();
         }
 
@@ -356,7 +355,9 @@ namespace VstsSyncMigrator.Engine
             AddParameter("TargetProject", processWorkItemParamiters, Engine.Target.WorkItems.Project.Name);
             AddParameter("RetryLimit", processWorkItemParamiters, retryLimit.ToString());
             AddParameter("RetryNumber", processWorkItemParamiters, retrys.ToString());
-
+            Log.LogDebug("######################################################################################");
+            Log.LogDebug("ProcessWorkItem: {sourceWorkItemId}", sourceWorkItem.Id);
+            Log.LogDebug("######################################################################################");
             try
             {
                 if (sourceWorkItem.Type != "Test Plan" || sourceWorkItem.Type != "Test Suite")
@@ -573,6 +574,12 @@ namespace VstsSyncMigrator.Engine
                         currentRevisionWorkItem.ToWorkItem().Revisions[revision.Index].Fields["System.History"].Value;
                     //Debug.WriteLine("Discussion:" + currentRevisionWorkItem.Revisions[revision.Index].Fields["System.History"].Value);
 
+                    TfsReflectedWorkItemId reflectedUri = (TfsReflectedWorkItemId)Engine.Source.WorkItems.CreateReflectedWorkItemId(sourceWorkItem);
+                    if (targetWorkItem.ToWorkItem().Fields.Contains(Engine.Target.Config.AsTeamProjectConfig().ReflectedWorkItemIDFieldName))
+                    {
+                        targetWorkItem.ToWorkItem().Fields[Engine.Target.Config.AsTeamProjectConfig().ReflectedWorkItemIDFieldName].Value = reflectedUri.ToString();
+                    }
+
                     targetWorkItem.SaveToAzureDevOps();
                     TraceWriteLine(LogEventLevel.Information,
                         " Saved TargetWorkItem {TargetWorkItemId}. Replayed revision {RevisionNumber} of {RevisionsToMigrateCount}",
@@ -587,13 +594,10 @@ namespace VstsSyncMigrator.Engine
                 {
                     ProcessWorkItemAttachments(sourceWorkItem, targetWorkItem, false);
                     ProcessWorkItemLinks(Engine.Source.WorkItems, Engine.Target.WorkItems, sourceWorkItem, targetWorkItem);
-                    TfsReflectedWorkItemId reflectedUri = (TfsReflectedWorkItemId)Engine.Source.WorkItems.CreateReflectedWorkItemId(sourceWorkItem);
-                    if (targetWorkItem.ToWorkItem().Fields.Contains(Engine.Target.Config.AsTeamProjectConfig().ReflectedWorkItemIDFieldName))
-                    {
-                        targetWorkItem.ToWorkItem().Fields[Engine.Target.Config.AsTeamProjectConfig().ReflectedWorkItemIDFieldName].Value = reflectedUri;
-                    }
+
                     if (_config.GenerateMigrationComment)
                     {
+                        var reflectedUri = targetWorkItem.ToWorkItem().Fields[Engine.Target.Config.AsTeamProjectConfig().ReflectedWorkItemIDFieldName].Value;
                         var history = new StringBuilder();
                         history.Append(
                             $"This work item was migrated from a different project or organization. You can find the old version at <a href=\"{reflectedUri}\">{reflectedUri}</a>.");

--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemMigrationContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemMigrationContext.cs
@@ -586,7 +586,7 @@ namespace VstsSyncMigrator.Engine
                 {
                     ProcessWorkItemAttachments(sourceWorkItem, targetWorkItem, false);
                     ProcessWorkItemLinks(Engine.Source.WorkItems, Engine.Target.WorkItems, sourceWorkItem, targetWorkItem);
-                    string reflectedUri = Engine.Source.WorkItems.CreateReflectedWorkItemId(sourceWorkItem);
+                    TfsReflectedWorkItemId reflectedUri = (TfsReflectedWorkItemId)Engine.Source.WorkItems.CreateReflectedWorkItemId(sourceWorkItem);
                     if (targetWorkItem.ToWorkItem().Fields.Contains(Engine.Target.Config.AsTeamProjectConfig().ReflectedWorkItemIDFieldName))
                     {
                         targetWorkItem.ToWorkItem().Fields[Engine.Target.Config.AsTeamProjectConfig().ReflectedWorkItemIDFieldName].Value = reflectedUri;


### PR DESCRIPTION
This should resolve #654! When we are merging multiple Team Projects from multiple Orgs we may have duplicate ID's. So comparing only the ID element for the cache is not such a good idea. This change moves that compare to the full ReflectedWorkItemId.