### PR TITLE
Fixes chain of exceptions when WI is deleted,

### DIFF
--- a/src/MigrationTools.Clients.AzureDevops.ObjectModel/Clients/TfsWorkItemQuery.cs
+++ b/src/MigrationTools.Clients.AzureDevops.ObjectModel/Clients/TfsWorkItemQuery.cs
@@ -46,7 +46,7 @@ namespace MigrationTools.Clients
                     }
                     catch (DeniedOrNotExistException ex)
                     {
-                        Log.Information(ex, "Deleted Item found.");
+                        Log.Error(ex, "Deleted Item detected.");
                     }
                 }
                 timer.Stop();

--- a/src/MigrationTools.Clients.AzureDevops.ObjectModel/TfsExtensions.cs
+++ b/src/MigrationTools.Clients.AzureDevops.ObjectModel/TfsExtensions.cs
@@ -100,6 +100,15 @@ namespace MigrationTools
             return (WorkItem)workItemData.internalObject;
         }
 
+        public static List<WorkItemData> ToWorkItemDataList(this IList<WorkItem> collection)
+        {
+            List<WorkItemData> list = new List<WorkItemData>();
+            foreach (WorkItem wi in collection)
+            {
+                list.Add(wi.AsWorkItemData());
+            }
+            return list;
+        }
         public static List<WorkItemData> ToWorkItemDataList(this WorkItemCollection collection)
         {
             List<WorkItemData> list = new List<WorkItemData>();


### PR DESCRIPTION
When destination ADO have deleted related workitems (possibly because multiple executions), the deleted itens are returned on wiql queries, causing a chain of exceptions and related itens not being migrated.