### PR TITLE
Fixed typo

### DIFF
--- a/src/MigrationTools/Configuration/Processing/TestVariablesMigrationConfig.cs
+++ b/src/MigrationTools/Configuration/Processing/TestVariablesMigrationConfig.cs
@@ -10,7 +10,7 @@ namespace MigrationTools.Configuration.Processing
         /// <inheritdoc />
         public string Processor
         {
-            get { return "TestVeriablesMigrationContext"; }
+            get { return "TestVariablesMigrationContext"; }
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
The TestVariablesMigrationConfig Processor was named TestV**e**riablesMigrationConfig 