### PR TITLE
Throw helpful error for unknown ObjectType

### DIFF
--- a/src/MigrationTools/Configuration/MigrationClientConfigJsonConverter.cs
+++ b/src/MigrationTools/Configuration/MigrationClientConfigJsonConverter.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using CommandLine;
 using Newtonsoft.Json.Linq;
 
 namespace MigrationTools.Configuration
@@ -15,6 +16,12 @@ namespace MigrationTools.Configuration
                   .Where(a => !a.IsDynamic)
                   .SelectMany(a => a.GetTypes())
                   .FirstOrDefault(t => t.Name.Equals(typename) || t.FullName.Equals(typename));
+
+                if(type == null)
+                {
+                    throw new Exception($"Unknown ObjectType: \"{typename}\" found in {jObject.ToString()}");
+                }
+
                 return (IMigrationClientConfig)Activator.CreateInstance(type);
             }
             else


### PR DESCRIPTION
Anytime an `"ObjectType"` changes from one release to another (like the recent rename of `"TeamProjectConfig"` to `"TfsTeamProjectConfig"`, and the removal of namespaces from all `ObjectType` properties before that), previous config files stop working. Most of the time the runtime exception is not helpful. These types of errors are very difficult to debug without having the source migration tool's source code installed and debuggable.

Here's an example. It tells us nothing about which ObjectType is causing the issue:

![image](https://user-images.githubusercontent.com/2544493/97441215-d63cca00-18fe-11eb-8f61-dcc27f51f522.png)

This PR adds support for throwing a more helpful error message, and provides some JSON context so that the user knows exactly which section of the JSON caused the problem. 

Here's how it looks in the console as a result of this PR:
![image](https://user-images.githubusercontent.com/2544493/97441547-3b90bb00-18ff-11eb-8bb1-5450da072ba1.png)

