### PR TITLE
Add property FixTeamSettingsForExistingTeams to TeamMigrationContext

### DIFF
--- a/docs/Processors/TeamMigrationConfig.md
+++ b/docs/Processors/TeamMigrationConfig.md
@@ -10,4 +10,5 @@ This should be run after `NodeStructuresMigrationConfig` and before all other pr
 | `Enabled`                     | Boolean | Active the processor if it true.                                           | false                                                                |
 | `ObjectType`                  | string  | The name of the processor                                                  | TeamMigrationConfig |
 | `EnableTeamSettingsMigration` | Boolean | Migrate original team settings after their creation on target team project | false                                                                |
+| `FixTeamSettingsForExistingTeams` | Boolean | Reset the target team settings to match the source if the team exists | false                                                                |
 | `PrefixProjectToNodes`        | Boolean | Prefix your iterations and areas with the project name. If you have enabled this in `NodeStructuresMigrationConfig` you must do it here too. | false |

--- a/src/MigrationTools/Configuration/Processing/TeamMigrationConfig.cs
+++ b/src/MigrationTools/Configuration/Processing/TeamMigrationConfig.cs
@@ -11,6 +11,8 @@ namespace MigrationTools.Configuration.Processing
 
         public bool EnableTeamSettingsMigration { get; set; }
 
+        public bool FixTeamSettingsForExistingTeams { get; set; }
+
         /// <inheritdoc />
         public string Processor
         {

--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/TeamMigrationContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/TeamMigrationContext.cs
@@ -64,10 +64,10 @@ namespace VstsSyncMigrator.Engine
             {
                 Stopwatch witstopwatch = Stopwatch.StartNew();
                 var foundTargetTeam = (from x in targetTL where x.Name == sourceTeam.Name select x).SingleOrDefault();
-                if (foundTargetTeam == null)
+                if (foundTargetTeam == null || _config.FixTeamSettingsForExistingTeams)
                 {
                     Log.LogDebug("Processing team '{0}':", sourceTeam.Name);
-                    TeamFoundationTeam newTeam = targetTS.CreateTeam(targetProject.ToProject().Uri.ToString(), sourceTeam.Name, sourceTeam.Description, null);
+                    TeamFoundationTeam newTeam = foundTargetTeam ?? targetTS.CreateTeam(targetProject.ToProject().Uri.ToString(), sourceTeam.Name, sourceTeam.Description, null);
                     Log.LogDebug("-> Team '{0}' created", sourceTeam.Name);
 
                     if (_config.EnableTeamSettingsMigration)


### PR DESCRIPTION
This flag will allow the processor to effectively reset a target teams settings through the migration without deleting them and migrating again.

This PR will allow for resetting of iterations and area path configuration. I'm looking at team members at the moment to see if that is something that could go in easily or not off another flag 😀