### PR TITLE
only migrate team settings if they are configured

### DIFF
--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/TeamMigrationContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/TeamMigrationContext.cs
@@ -79,38 +79,46 @@ namespace VstsSyncMigrator.Engine
 
                         foreach (var sourceConfig in sourceConfigurations)
                         {
-                            var targetConfig = targetConfigurations.FirstOrDefault(t => t.TeamName == sourceConfig.TeamName);
-                            if (targetConfig == null)
+                            if (sourceConfig.TeamSettings.BacklogIterationPath != null &&
+                                sourceConfig.TeamSettings.TeamFieldValues.Length > 0)
                             {
-                                Log.LogDebug("-> Settings for team '{sourceTeamName}'.. not found", sourceTeam.Name);
-                                continue;
-                            }
+                                var targetConfig = targetConfigurations.FirstOrDefault(t => t.TeamName == sourceConfig.TeamName);
+                                if (targetConfig == null)
+                                {
+                                    Log.LogDebug("-> Settings for team '{sourceTeamName}'.. not found", sourceTeam.Name);
+                                    continue;
+                                }
 
-                            Log.LogInformation("-> Settings found for team '{sourceTeamName}'..", sourceTeam.Name);
-                            if (_config.PrefixProjectToNodes)
-                            {
-                                targetConfig.TeamSettings.BacklogIterationPath =
-                                    string.Format("{0}\\{1}", Engine.Target.Config.AsTeamProjectConfig().Project, sourceConfig.TeamSettings.BacklogIterationPath);
-                                targetConfig.TeamSettings.IterationPaths = sourceConfig.TeamSettings.IterationPaths
-                                    .Select(path => string.Format("{0}\\{1}", Engine.Target.Config.AsTeamProjectConfig().Project, path))
-                                    .ToArray();
-                                targetConfig.TeamSettings.TeamFieldValues = sourceConfig.TeamSettings.TeamFieldValues
-                                    .Select(field => new TeamFieldValue
-                                    {
-                                        IncludeChildren = field.IncludeChildren,
-                                        Value = string.Format("{0}\\{1}", Engine.Target.Config.AsTeamProjectConfig().Project, field.Value)
-                                    })
-                                    .ToArray();
+                                Log.LogInformation("-> Settings found for team '{sourceTeamName}'..", sourceTeam.Name);
+                                if (_config.PrefixProjectToNodes)
+                                {
+                                    targetConfig.TeamSettings.BacklogIterationPath =
+                                        string.Format("{0}\\{1}", Engine.Target.Config.AsTeamProjectConfig().Project, sourceConfig.TeamSettings.BacklogIterationPath);
+                                    targetConfig.TeamSettings.IterationPaths = sourceConfig.TeamSettings.IterationPaths
+                                        .Select(path => string.Format("{0}\\{1}", Engine.Target.Config.AsTeamProjectConfig().Project, path))
+                                        .ToArray();
+                                    targetConfig.TeamSettings.TeamFieldValues = sourceConfig.TeamSettings.TeamFieldValues
+                                        .Select(field => new TeamFieldValue
+                                        {
+                                            IncludeChildren = field.IncludeChildren,
+                                            Value = string.Format("{0}\\{1}", Engine.Target.Config.AsTeamProjectConfig().Project, field.Value)
+                                        })
+                                        .ToArray();
+                                }
+                                else
+                                {
+                                    targetConfig.TeamSettings.BacklogIterationPath = sourceConfig.TeamSettings.BacklogIterationPath;
+                                    targetConfig.TeamSettings.IterationPaths = sourceConfig.TeamSettings.IterationPaths;
+                                    targetConfig.TeamSettings.TeamFieldValues = sourceConfig.TeamSettings.TeamFieldValues;
+                                }
+
+                                targetTSCS.SetTeamSettings(targetConfig.TeamId, targetConfig.TeamSettings);
+                                Log.LogDebug("-> Team '{0}' settings... applied", targetConfig.TeamName);
                             }
                             else
                             {
-                                targetConfig.TeamSettings.BacklogIterationPath = sourceConfig.TeamSettings.BacklogIterationPath;
-                                targetConfig.TeamSettings.IterationPaths = sourceConfig.TeamSettings.IterationPaths;
-                                targetConfig.TeamSettings.TeamFieldValues = sourceConfig.TeamSettings.TeamFieldValues;
+                                Log.LogWarning("-> Settings for team '{sourceTeamName}'.. not configured", sourceTeam.Name);
                             }
-
-                            targetTSCS.SetTeamSettings(targetConfig.TeamId, targetConfig.TeamSettings);
-                            Log.LogDebug("-> Team '{0}' settings... applied", targetConfig.TeamName);
                         }
                     }
                 }


### PR DESCRIPTION
If a team is not configured and in a broken state as shown below we don't want to attempt the update on the target team because it will break

![image](https://user-images.githubusercontent.com/5680199/97752418-a78c4280-1afc-11eb-8f35-0bd159b3d93d.png)

![image](https://user-images.githubusercontent.com/5680199/97752432-aa873300-1afc-11eb-8143-22d9dc498f58.png)
