### PR TITLE
Fix FilterExistingWorkItems

### DIFF
--- a/src/MigrationTools.Clients.AzureDevops.ObjectModel/Clients/TfsWorkItemMigrationClient.cs
+++ b/src/MigrationTools.Clients.AzureDevops.ObjectModel/Clients/TfsWorkItemMigrationClient.cs
@@ -32,7 +32,8 @@ namespace MigrationTools.Clients
             return new TfsReflectedWorkItemId(workItem);
         }
 
-        public List<WorkItemData> FilterExistingWorkItems(List<WorkItemData> sourceWorkItems, TfsWiqlDefinition wiqlDefinition)
+        public List<WorkItemData> FilterExistingWorkItems(List<WorkItemData> sourceWorkItems,
+            TfsWiqlDefinition wiqlDefinition, TfsWorkItemMigrationClient sourceWorkItemMigrationClient)
         {
             Log.Debug("FilterExistingWorkItems: START | ");
 
@@ -47,11 +48,11 @@ namespace MigrationTools.Clients
             Log.Debug("FilterByTarget: Query Execute...");
             var targetFoundItems = GetWorkItems(targetQuery);
             Log.Debug("FilterByTarget: ... query complete.");
-            Log.Debug("FilterByTarget: Found {TargetWorkItemCount} based on the WIQLQueryBit in the target system.", targetFoundItems.Count());
+            Log.Debug("FilterByTarget: Found {TargetWorkItemCount} based on the WIQLQueryBit in the target system.", targetFoundItems.Count);
             var targetFoundIds = (from WorkItemData twi in targetFoundItems select GetReflectedWorkItemId(twi)).ToList();
             //////////////////////////////////////////////////////////
-            sourceWorkItems = sourceWorkItems.Where(p => !targetFoundIds.Any(p2 => p2.ToString() == GetReflectedWorkItemId(p).ToString())).ToList();
-            Log.Debug("FilterByTarget: After removing all found work items there are {SourceWorkItemCount} remaining to be migrated.", sourceWorkItems.Count());
+            sourceWorkItems = sourceWorkItems.Where(p => targetFoundIds.All(p2 => p2.ToString() != sourceWorkItemMigrationClient.CreateReflectedWorkItemId(p).ToString())).ToList();
+            Log.Debug("FilterByTarget: After removing all found work items there are {SourceWorkItemCount} remaining to be migrated.", sourceWorkItems.Count);
             Log.Debug("FilterByTarget: END");
             return sourceWorkItems;
         }

--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemMigrationContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemMigrationContext.cs
@@ -108,7 +108,7 @@ namespace VstsSyncMigrator.Engine
             if (_config.FilterWorkItemsThatAlreadyExistInTarget)
             {
                 contextLog.Information("[FilterWorkItemsThatAlreadyExistInTarget] is enabled. Searching for work items that have already been migrated to the target...", sourceWorkItems.Count());
-                sourceWorkItems = ((TfsWorkItemMigrationClient)Engine.Target.WorkItems).FilterExistingWorkItems(sourceWorkItems, new TfsWiqlDefinition() { OrderBit = _config.WIQLOrderBit, QueryBit = _config.WIQLQueryBit });
+                sourceWorkItems = ((TfsWorkItemMigrationClient)Engine.Target.WorkItems).FilterExistingWorkItems(sourceWorkItems, new TfsWiqlDefinition() { OrderBit = _config.WIQLOrderBit, QueryBit = _config.WIQLQueryBit }, (TfsWorkItemMigrationClient)Engine.Source.WorkItems);
                 contextLog.Information("!! After removing all found work items there are {SourceWorkItemCount} remaining to be migrated.", sourceWorkItems.Count());
             }
             //////////////////////////////////////////////////


### PR DESCRIPTION
Hi,

I just realized that the Feature _FilterWorkItemsThatAlreadyExistInTarget_ is broken in the latest version. (I swapped between v8 and v11 because we heavily customized the tool to our needs based on v8 and we used v11 just for TestPlan migration. Now I was at the point that we had to integrate our customizations into v11 which was quite annoying to do...)

That's how I fixed the NullReferenceException in _FilterWorkItemsThatAlreadyExistInTarget_ quick and dirty and wanted to share it instead of creating an Issue. Any suggestions for doing it more convenient is welcome.

In addition I changed `Count()` to `Count` as I touched the file anyways and `Count` is much faster as the `List` object knows its item count. The extension method on the other hand iterates through all elements and counts them...