### PR TITLE
Fix typo in class name TestVariablesMigrationContext…

### DIFF
--- a/src/MigrationTools.ConsoleFull/Program.cs
+++ b/src/MigrationTools.ConsoleFull/Program.cs
@@ -35,7 +35,7 @@ namespace VstsSyncMigrator.ConsoleApp
                     services.AddSingleton<TeamMigrationContext>();
                     services.AddSingleton<TestConfigurationsMigrationContext>();
                     services.AddSingleton<TestPlandsAndSuitesMigrationContext>();
-                    services.AddSingleton<TestVeriablesMigrationContext>();
+                    services.AddSingleton<TestVariablesMigrationContext>();
                     services.AddSingleton<WorkItemPostProcessingContext>();
                     services.AddSingleton<WorkItemQueryMigrationContext>();
                     services.AddSingleton<CreateTeamFolders>();

--- a/src/MigrationTools/Engine/Containers/ProcessorContainer.cs
+++ b/src/MigrationTools/Engine/Containers/ProcessorContainer.cs
@@ -33,6 +33,10 @@ namespace MigrationTools.Engine.Containers
             {
                 var enabledProcessors = Config.Processors.Where(x => x.Enabled).ToList();
                 Log.Information("ProcessorContainer: Of {ProcessorCount} configured Processors only {EnabledProcessorCount} are enabled", Config.Processors.Count, enabledProcessors.Count);
+                var allTypes = AppDomain.CurrentDomain.GetAssemblies()
+                    .Where(a => !a.IsDynamic)
+                    .SelectMany(a => a.GetTypes()).ToList();
+
                 foreach (IProcessorConfig processorConfig in enabledProcessors)
                 {
                     if (processorConfig.IsProcessorCompatible(enabledProcessors))
@@ -40,9 +44,7 @@ namespace MigrationTools.Engine.Containers
                         Log.Information("ProcessorContainer: Adding Processor {ProcessorName}", processorConfig.Processor);
                         string typePattern = $"VstsSyncMigrator.Engine.{processorConfig.Processor}";
 
-                        Type type = AppDomain.CurrentDomain.GetAssemblies()
-                              .Where(a => !a.IsDynamic)
-                              .SelectMany(a => a.GetTypes())
+                        Type type = allTypes
                               .FirstOrDefault(t => t.Name.Equals(processorConfig.Processor) || t.FullName.Equals(typePattern));
 
                         if (type == null)

--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/TestVariablesMigrationContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/TestVariablesMigrationContext.cs
@@ -10,15 +10,15 @@ using VstsSyncMigrator.Engine.ComponentContext;
 
 namespace VstsSyncMigrator.Engine
 {
-    public class TestVeriablesMigrationContext : MigrationProcessorBase
+    public class TestVariablesMigrationContext : MigrationProcessorBase
     {
-        public TestVeriablesMigrationContext(IMigrationEngine engine, IServiceProvider services, ITelemetryLogger telemetry, ILogger<TestVeriablesMigrationContext> logger) : base(engine, services, telemetry, logger)
+        public TestVariablesMigrationContext(IMigrationEngine engine, IServiceProvider services, ITelemetryLogger telemetry, ILogger<TestVariablesMigrationContext> logger) : base(engine, services, telemetry, logger)
         {
         }
 
         public override string Name
         {
-            get { return "TestVeriablesMigrationContext"; }
+            get { return "TestVariablesMigrationContext"; }
         }
 
         public override void Configure(IProcessorConfig config)


### PR DESCRIPTION
… which prevented the tool from finding the correct processor type

This bug was ugly to find and my colleagues cried why the tool crashes when they run a TestPlan migration. I also improved the Processor Container as we don't need to get all types every time inside the loop.