### PR TITLE
Fix AssignReflectedWorkItemId in TestPlansAndSuitesMigrationContext

### DIFF
--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/TestPlansAndSuitesMigrationContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/TestPlansAndSuitesMigrationContext.cs
@@ -344,7 +344,7 @@ namespace VstsSyncMigrator.Engine
         {
             var sourceWI = Engine.Source.WorkItems.GetWorkItem(sourceWIId.ToString());
             var targetWI = Engine.Target.WorkItems.GetWorkItem(targetWIId.ToString());
-            targetWI.ToWorkItem().Fields[Engine.Target.Config.AsTeamProjectConfig().ReflectedWorkItemIDFieldName].Value = Engine.Source.WorkItems.CreateReflectedWorkItemId(sourceWI);
+            targetWI.ToWorkItem().Fields[Engine.Target.Config.AsTeamProjectConfig().ReflectedWorkItemIDFieldName].Value = Engine.Source.WorkItems.CreateReflectedWorkItemId(sourceWI).ToString();
             targetWI.SaveToAzureDevOps();
         }
 


### PR DESCRIPTION
And another bug appeared. TestPlans and Suites can't be saved anymore as the object was written to the field instead of the string value.

I allowed myself to add my local logging improvements for invalid fields also because the current implementation with the Dictionary is hard to read and prints nonsense:

From my log file:

2020-11-02 13:13:55.054 +01:00 [DBG]    Invalid Field: [Id:{"CurrentRevisionWorkItemId":38290,"CurrentRevisionWorkItemRev":2,"CurrentRevisionWorkItemTypeName":"Microsoft.TeamFoundation.WorkItemTracking.Client.WorkItemType","IsDirty":true,"FieldReferenceName":"Custom.ReflectedWorkItemId","FieldValue":"REMOVED"}**/{CurrentRevisionWorkItemRev}][Type:{CurrentRevisionWorkItemTypeName}][IsDirty:{IsDirty}][ReferenceName:{FieldReferenceName}][Value: {FieldValue}]**
2020-11-02 13:13:55.055 +01:00 [WRN] Invalid Field Object: **Microsoft.TeamFoundation.WorkItemTracking.Client.Field**

Of course I can drop that from the commit again.


