### PR TITLE
Filter targetFoundIds for non-null objects

### DIFF
--- a/src/MigrationTools.Clients.AzureDevops.ObjectModel/Clients/TfsWorkItemMigrationClient.cs
+++ b/src/MigrationTools.Clients.AzureDevops.ObjectModel/Clients/TfsWorkItemMigrationClient.cs
@@ -49,7 +49,7 @@ namespace MigrationTools.Clients
             var targetFoundItems = GetWorkItems(targetQuery);
             Log.Debug("FilterByTarget: ... query complete.");
             Log.Debug("FilterByTarget: Found {TargetWorkItemCount} based on the WIQLQueryBit in the target system.", targetFoundItems.Count);
-            var targetFoundIds = (from WorkItemData twi in targetFoundItems select GetReflectedWorkItemId(twi)).ToList();
+            var targetFoundIds = (from WorkItemData twi in targetFoundItems select GetReflectedWorkItemId(twi)).Where(refid => refid != null).ToList();
             //////////////////////////////////////////////////////////
             sourceWorkItems = sourceWorkItems.Where(p => targetFoundIds.All(p2 => p2.ToString() != sourceWorkItemMigrationClient.CreateReflectedWorkItemId(p).ToString())).ToList();
             Log.Debug("FilterByTarget: After removing all found work items there are {SourceWorkItemCount} remaining to be migrated.", sourceWorkItems.Count);


### PR DESCRIPTION
I just had the issue that a _Code Request Review_ item was migrated which isn't intended to be migrated in our systems and doesn't have a `Custom.ReflectedWorkItemId` field. This causes the tool to crash if _FilterWorkItemsThatAlreadyExistInTarget_ is activated. Of course that means this items are going to be migrated twice but I guess it's better to continue execution instead of aborting because finding the root cause can be quite nasty without debugging.