### PR TITLE
Fix ReflectedWorkItemId to support blanks in project names as this is allowed

### DIFF
--- a/src/MigrationTools.Clients.AzureDevops.ObjectModel/Clients/TfsReflectedWorkItemId.cs
+++ b/src/MigrationTools.Clients.AzureDevops.ObjectModel/Clients/TfsReflectedWorkItemId.cs
@@ -9,6 +9,7 @@ namespace MigrationTools.Clients
         private Uri _Connection;
         private string _ProjectName;
         private string _WorkItemId;
+        private static readonly Regex ReflectedIdRegex = new Regex(@"^(?<org>[\S ]+)\/(?<project>[\S ]+)\/_workitems\/edit\/(?<id>\d+)", RegexOptions.Compiled);
 
         public TfsReflectedWorkItemId(WorkItemData workItem) : base(workItem.Id)
         {
@@ -28,8 +29,8 @@ namespace MigrationTools.Clients
             {
                 throw new ArgumentNullException(nameof(ReflectedWorkItemId));
             }
-            var re = new Regex(@"^(?<org>\S+)\/(?<project>\S+)\/_workitems\/edit\/(?<id>\d+)");
-            var match = re.Match(ReflectedWorkItemId);
+
+            var match = ReflectedIdRegex.Match(ReflectedWorkItemId);
             if (match.Success)
             {
                 _WorkItemId = match.Groups["id"].Value;

--- a/src/MigrationTools.Clients.AzureDevops.ObjectModel/Clients/TfsReflectedWorkItemId.cs
+++ b/src/MigrationTools.Clients.AzureDevops.ObjectModel/Clients/TfsReflectedWorkItemId.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Text.RegularExpressions;
 using MigrationTools.DataContracts;
+using Serilog;
 
 namespace MigrationTools.Clients
 {

--- a/src/MigrationTools.Clients.AzureDevops.ObjectModel/Clients/TfsReflectedWorkItemId.cs
+++ b/src/MigrationTools.Clients.AzureDevops.ObjectModel/Clients/TfsReflectedWorkItemId.cs
@@ -37,6 +37,11 @@ namespace MigrationTools.Clients
                 _ProjectName = match.Groups["project"].Value;
                 _Connection = new Uri(match.Groups["org"].Value);
             }
+            else
+            {
+                Log.Error("TfsReflectedWorkItemId: Unable to match ReflectedWorkItemId({ReflectedWorkItemId}) as id! ", ReflectedWorkItemId);
+                throw new Exception("Unable to Parse ReflectedWorkItemId. Check Log...");
+            }
         }
 
         public override string ToString()


### PR DESCRIPTION
This bug was also nasty to find (because my VS somehow didn't stop on my conditional breakpoint because of LINQ's anonymous functions) and prevented links from being migrated for source projects with blanks in it. The regex used by `GetReflectedWorkItemId()` searches only for non whitespace characters. I changed it to `[\S ]+` instead to support blanks and made it compiled to not reinit it every time which is time-consuming.