### PR TITLE
Make sure PAT is used for WorkItemStore and WitHttpClient also

### DIFF
--- a/src/MigrationTools.Clients.AzureDevops.ObjectModel/TfsExtensions.cs
+++ b/src/MigrationTools.Clients.AzureDevops.ObjectModel/TfsExtensions.cs
@@ -34,7 +34,7 @@ namespace MigrationTools
             var fails = workItem.Validate();
             if (fails.Count > 0)
             {
-                Log.Warning("Work Item is not ready to save as it has some invalid fields. This may not result in an error. Enable LogLevel as 'Debug' in the ocnfig to see more.");
+                Log.Warning("Work Item is not ready to save as it has some invalid fields. This may not result in an error. Enable LogLevel as 'Debug' in the config to see more.");
                 Log.Debug("--------------------------------------------------------------------------------------------------------------------");
                 Log.Debug("--------------------------------------------------------------------------------------------------------------------");
                 foreach (Field f in fails)

--- a/src/MigrationTools.Clients.AzureDevops.ObjectModel/_Enginev1/Clients/TfsWorkItemMigrationClient.cs
+++ b/src/MigrationTools.Clients.AzureDevops.ObjectModel/_Enginev1/Clients/TfsWorkItemMigrationClient.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using Microsoft.ApplicationInsights.DataContracts;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.TeamFoundation.Client;
 using Microsoft.TeamFoundation.WorkItemTracking.Client;
 using MigrationTools;
 using MigrationTools._EngineV1.Configuration;
@@ -313,7 +314,7 @@ namespace MigrationTools._EngineV1.Clients
             WorkItemStore store;
             try
             {
-                store = new WorkItemStore(MigrationClient.Config.AsTeamProjectConfig().Collection.ToString(), bypassRules);
+                store = new WorkItemStore((TfsTeamProjectCollection)MigrationClient.InternalCollection, bypassRules);
                 timer.Stop();
                 Telemetry.TrackDependency(new DependencyTelemetry("TfsObjectModel", MigrationClient.Config.AsTeamProjectConfig().Collection.ToString(), "GetWorkItemStore", null, startTime, timer.Elapsed, "200", true));
             }

--- a/src/MigrationTools.Tests/Core/Clients/MigrationClientMock.cs
+++ b/src/MigrationTools.Tests/Core/Clients/MigrationClientMock.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Net;
+using Microsoft.VisualStudio.Services.Common;
 using MigrationTools._EngineV1.Clients;
 using MigrationTools._EngineV1.Configuration;
 
@@ -21,6 +22,8 @@ namespace MigrationTools.Tests.Core.Clients
         public IWorkItemMigrationClient WorkItems => workItemMigrationClient;
 
         public ITestPlanMigrationClient TestPlans => throw new NotImplementedException();
+
+        public VssCredentials Credentials => throw new NotImplementedException();
 
         public void Configure(IMigrationClientConfig config, NetworkCredential credentials = null)
         {

--- a/src/MigrationTools.Tests/Core/Configuration/EngineConfigurationTests.cs
+++ b/src/MigrationTools.Tests/Core/Configuration/EngineConfigurationTests.cs
@@ -62,7 +62,7 @@ namespace MigrationTools.Tests
         [TestMethod]
         public void TestDeseraliseFromJson2()
         {
-            TestSeraliseToJson();
+            TestSeraliseToJson2();
             EngineConfiguration ec;
             StreamReader sr = new StreamReader("configuration2.json");
             string configurationjson = sr.ReadToEnd();

--- a/src/MigrationTools/MigrationTools.csproj
+++ b/src/MigrationTools/MigrationTools.csproj
@@ -17,6 +17,7 @@
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="3.1.9" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="3.1.9" />
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.2.8" />
+    <PackageReference Include="Microsoft.VisualStudio.Services.Client" Version="16.153.0" />
     <PackageReference Include="NuGet.Protocol" Version="5.7.0" />
     <PackageReference Include="NuGet.Versioning" Version="5.7.0" />
     <PackageReference Include="Serilog" Version="2.10.0" />

--- a/src/MigrationTools/ServiceCollectionExtensions.cs
+++ b/src/MigrationTools/ServiceCollectionExtensions.cs
@@ -8,6 +8,7 @@ using MigrationTools.EndPoints;
 using MigrationTools.Enrichers;
 using MigrationTools.Processors;
 using Serilog;
+using Serilog.Core;
 using Serilog.Events;
 
 namespace MigrationTools
@@ -30,6 +31,7 @@ namespace MigrationTools
             Log.Logger = loggers.CreateLogger();
             Log.Logger.Information("Logger is initialized");
             context.AddLogging(loggingBuilder => loggingBuilder.AddSerilog(dispose: true));
+            context.AddSingleton<LoggingLevelSwitch>();
         }
 
         public static void AddMigrationToolServices(this IServiceCollection context)
@@ -65,6 +67,12 @@ namespace MigrationTools
             context.AddSingleton<IEngineConfigurationBuilder, EngineConfigurationBuilder>();
             context.AddSingleton<EngineConfiguration, EngineConfigurationWrapper>();
 
+            // Containers
+            context.AddSingleton<TypeDefinitionMapContainer>();
+            context.AddSingleton<ProcessorContainer>();
+            context.AddSingleton<GitRepoMapContainer>();
+            context.AddSingleton<FieldMapContainer>();
+            context.AddSingleton<ChangeSetMappingContainer>();
             //Engine
             context.AddSingleton<FieldMapContainer>();
             context.AddSingleton<ProcessorContainer>();

--- a/src/MigrationTools/Services/TelemetryClientAdapter.cs
+++ b/src/MigrationTools/Services/TelemetryClientAdapter.cs
@@ -13,7 +13,10 @@ namespace MigrationTools
         {
             telemetryClient.Context.Session.Id = Guid.NewGuid().ToString();
             telemetryClient.Context.Device.OperatingSystem = Environment.OSVersion.ToString();
-            telemetryClient.Context.Component.Version = System.Reflection.Assembly.GetEntryAssembly().GetName().Version.ToString();
+            if (!(System.Reflection.Assembly.GetEntryAssembly() is null))
+            {
+                telemetryClient.Context.Component.Version = System.Reflection.Assembly.GetEntryAssembly().GetName().Version.ToString();
+            }
             _telemetryClient = telemetryClient;
         }
 

--- a/src/MigrationTools/_EngineV1/Clients/IMigrationClient.cs
+++ b/src/MigrationTools/_EngineV1/Clients/IMigrationClient.cs
@@ -1,5 +1,5 @@
-﻿using System;
-using System.Net;
+﻿using System.Net;
+using Microsoft.VisualStudio.Services.Common;
 using MigrationTools._EngineV1.Configuration;
 
 namespace MigrationTools._EngineV1.Clients
@@ -10,11 +10,12 @@ namespace MigrationTools._EngineV1.Clients
         IWorkItemMigrationClient WorkItems { get; }
         ITestPlanMigrationClient TestPlans { get; }
 
+        VssCredentials Credentials { get; }
+
         void Configure(IMigrationClientConfig config, NetworkCredential credentials = null);
 
         T GetService<T>();
 
-        [Obsolete]
         object InternalCollection { get; }
     }
 }

--- a/src/MigrationTools/_EngineV1/Containers/FieldMapContainer.cs
+++ b/src/MigrationTools/_EngineV1/Containers/FieldMapContainer.cs
@@ -90,7 +90,7 @@ namespace MigrationTools._EngineV1.Containers
         {
             foreach (IFieldMap map in list)
             {
-                Log.Debug("{Context} Running Field Map: {MapName} {MappingDisplayName}", map.Name, map.MappingDisplayName);
+                Log.Debug("Running Field Map: {MapName} {MappingDisplayName}", map.Name, map.MappingDisplayName);
                 map.Execute(source, target);
             }
         }

--- a/src/VstsSyncMigrator.Core.Tests/VstsSyncMigrator.Core.Tests.csproj
+++ b/src/VstsSyncMigrator.Core.Tests/VstsSyncMigrator.Core.Tests.csproj
@@ -14,6 +14,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemMigrationContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemMigrationContext.cs
@@ -90,8 +90,7 @@ namespace VstsSyncMigrator.Engine
             embededImagesEnricher = Services.GetRequiredService<TfsEmbededImagesEnricher>();
             gitRepositoryEnricher = Services.GetRequiredService<TfsGitRepositoryEnricher>();
             nodeStructureEnricher = Services.GetRequiredService<TfsNodeStructureEnricher>();
-            VssClientCredentials adoCreds = new VssClientCredentials();
-            _witClient = new WorkItemTrackingHttpClient(Engine.Target.Config.AsTeamProjectConfig().Collection, adoCreds);
+            _witClient = new WorkItemTrackingHttpClient(Engine.Target.Config.AsTeamProjectConfig().Collection, Engine.Target.Credentials);
             //Validation: make sure that the ReflectedWorkItemId field name specified in the config exists in the target process, preferably on each work item type.
             PopulateIgnoreList();
 


### PR DESCRIPTION
Unfortunately #680 was not enough to make PATs working. Here is the fix at least for `WorkItemMigrationContext`. Maybe there are additional issues with other processors we don't use.

Additionally you'll find 2 minor logging fixes in this PR which I revealed the last days.