### PR TITLE
Enable IOptions to be referenced.

### DIFF
--- a/docs/Reference/EndpointEnrichers/TfsWorkItemAttachmentEnricher.json
+++ b/docs/Reference/EndpointEnrichers/TfsWorkItemAttachmentEnricher.json
@@ -2,5 +2,6 @@
   "$type": "TfsWorkItemAttachmentEnricherOptions",
   "Enabled": true,
   "WorkingPath": "c:\\temp\\WorkItemAttachmentWorkingFolder\\",
-  "MaxSize": 480000000
+  "MaxSize": 480000000,
+  "RefName": null
 }

--- a/docs/Reference/EndpointEnrichers/TfsWorkItemAttachmentEnricher.md
+++ b/docs/Reference/EndpointEnrichers/TfsWorkItemAttachmentEnricher.md
@@ -13,6 +13,7 @@ missng XML code comments
 | WorkingPath | String | missng XML code comments | missng XML code comments |
 | MaxSize | Int32 | missng XML code comments | missng XML code comments |
 | Enabled | Boolean | missng XML code comments | missng XML code comments |
+| RefName | String | missng XML code comments | missng XML code comments |
 
 
 ### Example JSON
@@ -22,6 +23,7 @@ missng XML code comments
   "$type": "TfsWorkItemAttachmentEnricherOptions",
   "Enabled": true,
   "WorkingPath": "c:\\temp\\WorkItemAttachmentWorkingFolder\\",
-  "MaxSize": 480000000
+  "MaxSize": 480000000,
+  "RefName": null
 }
 ```

--- a/docs/Reference/Endpoints/FileSystemWorkItemEndpoint.json
+++ b/docs/Reference/Endpoints/FileSystemWorkItemEndpoint.json
@@ -1,5 +1,6 @@
 {
   "$type": "FileSystemWorkItemEndpointOptions",
   "FileStore": "c:\\temp\\Store",
-  "EndpointEnrichers": null
+  "EndpointEnrichers": null,
+  "RefName": null
 }

--- a/docs/Reference/Endpoints/FileSystemWorkItemEndpoint.md
+++ b/docs/Reference/Endpoints/FileSystemWorkItemEndpoint.md
@@ -12,6 +12,7 @@ missng XML code comments
 |------------------------|---------|------------------------------------------|------------------------------------------|
 | FileStore | String | missng XML code comments | missng XML code comments |
 | EndpointEnrichers | List | missng XML code comments | missng XML code comments |
+| RefName | String | missng XML code comments | missng XML code comments |
 
 
 ### Example JSON
@@ -20,6 +21,7 @@ missng XML code comments
 {
   "$type": "FileSystemWorkItemEndpointOptions",
   "FileStore": "c:\\temp\\Store",
-  "EndpointEnrichers": null
+  "EndpointEnrichers": null,
+  "RefName": null
 }
 ```

--- a/docs/Reference/Endpoints/TfsEndpoint.json
+++ b/docs/Reference/Endpoints/TfsEndpoint.json
@@ -5,5 +5,6 @@
   "AuthenticationMode": "AccessToken",
   "AccessToken": "6i4jyylsadkjanjniaydxnjsi4zsz3qarxhl2y5ngzzffiqdostq",
   "ReflectedWorkItemIdField": "Custom.ReflectedWorkItemId",
-  "EndpointEnrichers": null
+  "EndpointEnrichers": null,
+  "RefName": null
 }

--- a/docs/Reference/Endpoints/TfsEndpoint.md
+++ b/docs/Reference/Endpoints/TfsEndpoint.md
@@ -16,6 +16,7 @@ missng XML code comments
 | Project | String | missng XML code comments | missng XML code comments |
 | ReflectedWorkItemIdField | String | missng XML code comments | missng XML code comments |
 | EndpointEnrichers | List | missng XML code comments | missng XML code comments |
+| RefName | String | missng XML code comments | missng XML code comments |
 
 
 ### Example JSON
@@ -28,6 +29,7 @@ missng XML code comments
   "AuthenticationMode": "AccessToken",
   "AccessToken": "6i4jyylsadkjanjniaydxnjsi4zsz3qarxhl2y5ngzzffiqdostq",
   "ReflectedWorkItemIdField": "Custom.ReflectedWorkItemId",
-  "EndpointEnrichers": null
+  "EndpointEnrichers": null,
+  "RefName": null
 }
 ```

--- a/docs/Reference/Endpoints/TfsTeamSettingsEndpoint.json
+++ b/docs/Reference/Endpoints/TfsTeamSettingsEndpoint.json
@@ -5,5 +5,6 @@
   "AuthenticationMode": "AccessToken",
   "AccessToken": "6i4jyylsadkjanjniaydxnjsi4zsz3qarxhl2y5ngzzffiqdostq",
   "ReflectedWorkItemIdField": "Custom.ReflectedWorkItemId",
-  "EndpointEnrichers": null
+  "EndpointEnrichers": null,
+  "RefName": null
 }

--- a/docs/Reference/Endpoints/TfsTeamSettingsEndpoint.md
+++ b/docs/Reference/Endpoints/TfsTeamSettingsEndpoint.md
@@ -16,6 +16,7 @@ missng XML code comments
 | Project | String | missng XML code comments | missng XML code comments |
 | ReflectedWorkItemIdField | String | missng XML code comments | missng XML code comments |
 | EndpointEnrichers | List | missng XML code comments | missng XML code comments |
+| RefName | String | missng XML code comments | missng XML code comments |
 
 
 ### Example JSON
@@ -28,6 +29,7 @@ missng XML code comments
   "AuthenticationMode": "AccessToken",
   "AccessToken": "6i4jyylsadkjanjniaydxnjsi4zsz3qarxhl2y5ngzzffiqdostq",
   "ReflectedWorkItemIdField": "Custom.ReflectedWorkItemId",
-  "EndpointEnrichers": null
+  "EndpointEnrichers": null,
+  "RefName": null
 }
 ```

--- a/docs/Reference/Endpoints/TfsWorkItemEndpoint.json
+++ b/docs/Reference/Endpoints/TfsWorkItemEndpoint.json
@@ -13,5 +13,6 @@
   "AuthenticationMode": "AccessToken",
   "AccessToken": "6i4jyylsadkjanjniaydxnjsi4zsz3qarxhl2y5ngzzffiqdostq",
   "ReflectedWorkItemIdField": "Custom.ReflectedWorkItemId",
-  "EndpointEnrichers": null
+  "EndpointEnrichers": null,
+  "RefName": null
 }

--- a/docs/Reference/Endpoints/TfsWorkItemEndpoint.md
+++ b/docs/Reference/Endpoints/TfsWorkItemEndpoint.md
@@ -38,7 +38,8 @@ The `Direction` option is required to allow the system to set direction. At a mi
   "AuthenticationMode": "AccessToken",
   "AccessToken": "6i4jyylsadkjanjniaydxnjsi4zsz3qarxhl2y5ngzzffiqdostq",
   "ReflectedWorkItemIdField": "Custom.ReflectedWorkItemId",
-  "EndpointEnrichers": null
+  "EndpointEnrichers": null,
+  "RefName": null
 }
     }
 ```

--- a/docs/Reference/Generated/MigrationTools.xml
+++ b/docs/Reference/Generated/MigrationTools.xml
@@ -9,6 +9,11 @@
             Active the enricher if it true.
             </summary>
         </member>
+        <member name="P:MigrationTools.Options.IOptions.RefName">
+            <summary>
+            If you set a `RefName` then this configration will be added to a Catalog of configurations that can be refernced using tha `RefName` so tha tyou dont have to keep adding the ame items with the same configuration.
+            </summary>
+        </member>
         <member name="P:MigrationTools.Processors.IProcessorOptions.Source">
             <summary>
             This is the `IEndpoint` that will be used as the source of the Migration. Can be null for a write only processor.

--- a/docs/Reference/ProcessorEnrichers/AppendMigrationToolSignatureFooter.json
+++ b/docs/Reference/ProcessorEnrichers/AppendMigrationToolSignatureFooter.json
@@ -1,4 +1,5 @@
 {
   "$type": "AppendMigrationToolSignatureFooterOptions",
-  "Enabled": true
+  "Enabled": true,
+  "RefName": null
 }

--- a/docs/Reference/ProcessorEnrichers/AppendMigrationToolSignatureFooter.md
+++ b/docs/Reference/ProcessorEnrichers/AppendMigrationToolSignatureFooter.md
@@ -11,6 +11,7 @@ missng XML code comments
 | Parameter name         | Type    | Description                              | Default Value                            |
 |------------------------|---------|------------------------------------------|------------------------------------------|
 | Enabled | Boolean | missng XML code comments | missng XML code comments |
+| RefName | String | missng XML code comments | missng XML code comments |
 
 
 ### Example JSON
@@ -18,6 +19,7 @@ missng XML code comments
 ```JSON
 {
   "$type": "AppendMigrationToolSignatureFooterOptions",
-  "Enabled": true
+  "Enabled": true,
+  "RefName": null
 }
 ```

--- a/docs/Reference/ProcessorEnrichers/FilterWorkItemsThatAlreadyExistInTarget.json
+++ b/docs/Reference/ProcessorEnrichers/FilterWorkItemsThatAlreadyExistInTarget.json
@@ -5,5 +5,6 @@
     "$type": "QueryOptions",
     "Query": "SELECT [System.Id], [System.Tags] FROM WorkItems WHERE [System.TeamProject] = @TeamProject AND [System.WorkItemType] NOT IN ('Test Suite', 'Test Plan') ORDER BY [System.ChangedDate] desc",
     "Paramiters": null
-  }
+  },
+  "RefName": null
 }

--- a/docs/Reference/ProcessorEnrichers/FilterWorkItemsThatAlreadyExistInTarget.md
+++ b/docs/Reference/ProcessorEnrichers/FilterWorkItemsThatAlreadyExistInTarget.md
@@ -12,6 +12,7 @@ missng XML code comments
 |------------------------|---------|------------------------------------------|------------------------------------------|
 | Query | QueryOptions | missng XML code comments | missng XML code comments |
 | Enabled | Boolean | missng XML code comments | missng XML code comments |
+| RefName | String | missng XML code comments | missng XML code comments |
 
 
 ### Example JSON
@@ -24,6 +25,7 @@ missng XML code comments
     "$type": "QueryOptions",
     "Query": "SELECT [System.Id], [System.Tags] FROM WorkItems WHERE [System.TeamProject] = @TeamProject AND [System.WorkItemType] NOT IN ('Test Suite', 'Test Plan') ORDER BY [System.ChangedDate] desc",
     "Paramiters": null
-  }
+  },
+  "RefName": null
 }
 ```

--- a/docs/Reference/ProcessorEnrichers/PauseAfterEachItem.json
+++ b/docs/Reference/ProcessorEnrichers/PauseAfterEachItem.json
@@ -1,4 +1,5 @@
 {
   "$type": "PauseAfterEachItemOptions",
-  "Enabled": true
+  "Enabled": true,
+  "RefName": null
 }

--- a/docs/Reference/ProcessorEnrichers/PauseAfterEachItem.md
+++ b/docs/Reference/ProcessorEnrichers/PauseAfterEachItem.md
@@ -11,6 +11,7 @@ missng XML code comments
 | Parameter name         | Type    | Description                              | Default Value                            |
 |------------------------|---------|------------------------------------------|------------------------------------------|
 | Enabled | Boolean | missng XML code comments | missng XML code comments |
+| RefName | String | missng XML code comments | missng XML code comments |
 
 
 ### Example JSON
@@ -18,6 +19,7 @@ missng XML code comments
 ```JSON
 {
   "$type": "PauseAfterEachItemOptions",
-  "Enabled": true
+  "Enabled": true,
+  "RefName": null
 }
 ```

--- a/docs/Reference/ProcessorEnrichers/SkipToFinalRevisedWorkItemType.json
+++ b/docs/Reference/ProcessorEnrichers/SkipToFinalRevisedWorkItemType.json
@@ -1,4 +1,5 @@
 {
   "$type": "SkipToFinalRevisedWorkItemTypeOptions",
-  "Enabled": true
+  "Enabled": true,
+  "RefName": null
 }

--- a/docs/Reference/ProcessorEnrichers/SkipToFinalRevisedWorkItemType.md
+++ b/docs/Reference/ProcessorEnrichers/SkipToFinalRevisedWorkItemType.md
@@ -11,6 +11,7 @@ missng XML code comments
 | Parameter name         | Type    | Description                              | Default Value                            |
 |------------------------|---------|------------------------------------------|------------------------------------------|
 | Enabled | Boolean | missng XML code comments | missng XML code comments |
+| RefName | String | missng XML code comments | missng XML code comments |
 
 
 ### Example JSON
@@ -18,6 +19,7 @@ missng XML code comments
 ```JSON
 {
   "$type": "SkipToFinalRevisedWorkItemTypeOptions",
-  "Enabled": true
+  "Enabled": true,
+  "RefName": null
 }
 ```

--- a/docs/Reference/ProcessorEnrichers/TfsValidateRequiredField.json
+++ b/docs/Reference/ProcessorEnrichers/TfsValidateRequiredField.json
@@ -1,4 +1,5 @@
 {
   "$type": "TfsValidateRequiredFieldOptions",
-  "Enabled": true
+  "Enabled": true,
+  "RefName": null
 }

--- a/docs/Reference/ProcessorEnrichers/TfsValidateRequiredField.md
+++ b/docs/Reference/ProcessorEnrichers/TfsValidateRequiredField.md
@@ -11,6 +11,7 @@ missng XML code comments
 | Parameter name         | Type    | Description                              | Default Value                            |
 |------------------------|---------|------------------------------------------|------------------------------------------|
 | Enabled | Boolean | missng XML code comments | missng XML code comments |
+| RefName | String | missng XML code comments | missng XML code comments |
 
 
 ### Example JSON
@@ -18,6 +19,7 @@ missng XML code comments
 ```JSON
 {
   "$type": "TfsValidateRequiredFieldOptions",
-  "Enabled": true
+  "Enabled": true,
+  "RefName": null
 }
 ```

--- a/docs/Reference/Processors/TfsSharedQueryProcessor.json
+++ b/docs/Reference/Processors/TfsSharedQueryProcessor.json
@@ -12,7 +12,8 @@
     "AuthenticationMode": "AccessToken",
     "AccessToken": "6i4jyylsadkjanjniaydxnjsi4zsz3qarxhl2y5ngzzffiqdostq",
     "ReflectedWorkItemIdField": "Custom.ReflectedWorkItemId",
-    "EndpointEnrichers": null
+    "EndpointEnrichers": null,
+    "RefName": null
   },
   "Target": {
     "$type": "TfsEndpointOptions",
@@ -21,6 +22,8 @@
     "AuthenticationMode": "AccessToken",
     "AccessToken": "6i4jyylsadkjanjniaydxnjsi4zsz3qarxhl2y5ngzzffiqdostq",
     "ReflectedWorkItemIdField": "Custom.ReflectedWorkItemId",
-    "EndpointEnrichers": null
-  }
+    "EndpointEnrichers": null,
+    "RefName": null
+  },
+  "RefName": null
 }

--- a/docs/Reference/Processors/TfsSharedQueryProcessor.md
+++ b/docs/Reference/Processors/TfsSharedQueryProcessor.md
@@ -17,6 +17,7 @@ The TfsSharedQueryProcessor enabled you to migrate queries from one locatio nto 
 | ProcessorEnrichers | List | missng XML code comments | missng XML code comments |
 | Source | IEndpointOptions | missng XML code comments | missng XML code comments |
 | Target | IEndpointOptions | missng XML code comments | missng XML code comments |
+| RefName | String | missng XML code comments | missng XML code comments |
 
 
 ### Example JSON
@@ -36,7 +37,8 @@ The TfsSharedQueryProcessor enabled you to migrate queries from one locatio nto 
     "AuthenticationMode": "AccessToken",
     "AccessToken": "6i4jyylsadkjanjniaydxnjsi4zsz3qarxhl2y5ngzzffiqdostq",
     "ReflectedWorkItemIdField": "Custom.ReflectedWorkItemId",
-    "EndpointEnrichers": null
+    "EndpointEnrichers": null,
+    "RefName": null
   },
   "Target": {
     "$type": "TfsEndpointOptions",
@@ -45,7 +47,9 @@ The TfsSharedQueryProcessor enabled you to migrate queries from one locatio nto 
     "AuthenticationMode": "AccessToken",
     "AccessToken": "6i4jyylsadkjanjniaydxnjsi4zsz3qarxhl2y5ngzzffiqdostq",
     "ReflectedWorkItemIdField": "Custom.ReflectedWorkItemId",
-    "EndpointEnrichers": null
-  }
+    "EndpointEnrichers": null,
+    "RefName": null
+  },
+  "RefName": null
 }
 ```

--- a/docs/Reference/Processors/TfsTeamSettingsProcessor.json
+++ b/docs/Reference/Processors/TfsTeamSettingsProcessor.json
@@ -13,7 +13,8 @@
     "AuthenticationMode": "AccessToken",
     "AccessToken": "6i4jyylsadkjanjniaydxnjsi4zsz3qarxhl2y5ngzzffiqdostq",
     "ReflectedWorkItemIdField": "Custom.ReflectedWorkItemId",
-    "EndpointEnrichers": null
+    "EndpointEnrichers": null,
+    "RefName": null
   },
   "Target": {
     "$type": "TfsEndpointOptions",
@@ -22,6 +23,8 @@
     "AuthenticationMode": "AccessToken",
     "AccessToken": "6i4jyylsadkjanjniaydxnjsi4zsz3qarxhl2y5ngzzffiqdostq",
     "ReflectedWorkItemIdField": "Custom.ReflectedWorkItemId",
-    "EndpointEnrichers": null
-  }
+    "EndpointEnrichers": null,
+    "RefName": null
+  },
+  "RefName": null
 }

--- a/docs/Reference/Processors/TfsTeamSettingsProcessor.md
+++ b/docs/Reference/Processors/TfsTeamSettingsProcessor.md
@@ -18,6 +18,7 @@ Native TFS Processor, does not work with any other Endpoints.
 | ProcessorEnrichers | List | missng XML code comments | missng XML code comments |
 | Source | IEndpointOptions | missng XML code comments | missng XML code comments |
 | Target | IEndpointOptions | missng XML code comments | missng XML code comments |
+| RefName | String | missng XML code comments | missng XML code comments |
 
 
 ### Example JSON
@@ -38,7 +39,8 @@ Native TFS Processor, does not work with any other Endpoints.
     "AuthenticationMode": "AccessToken",
     "AccessToken": "6i4jyylsadkjanjniaydxnjsi4zsz3qarxhl2y5ngzzffiqdostq",
     "ReflectedWorkItemIdField": "Custom.ReflectedWorkItemId",
-    "EndpointEnrichers": null
+    "EndpointEnrichers": null,
+    "RefName": null
   },
   "Target": {
     "$type": "TfsEndpointOptions",
@@ -47,7 +49,9 @@ Native TFS Processor, does not work with any other Endpoints.
     "AuthenticationMode": "AccessToken",
     "AccessToken": "6i4jyylsadkjanjniaydxnjsi4zsz3qarxhl2y5ngzzffiqdostq",
     "ReflectedWorkItemIdField": "Custom.ReflectedWorkItemId",
-    "EndpointEnrichers": null
-  }
+    "EndpointEnrichers": null,
+    "RefName": null
+  },
+  "RefName": null
 }
 ```

--- a/docs/Reference/Processors/WorkItemTrackingProcessor.json
+++ b/docs/Reference/Processors/WorkItemTrackingProcessor.json
@@ -8,13 +8,16 @@
   "ProcessorEnrichers": [
     {
       "$type": "PauseAfterEachItemOptions",
-      "Enabled": true
+      "Enabled": true,
+      "RefName": null
     },
     {
       "$type": "AppendMigrationToolSignatureFooterOptions",
-      "Enabled": true
+      "Enabled": true,
+      "RefName": null
     }
   ],
   "Source": null,
-  "Target": null
+  "Target": null,
+  "RefName": null
 }

--- a/docs/Reference/Processors/WorkItemTrackingProcessor.md
+++ b/docs/Reference/Processors/WorkItemTrackingProcessor.md
@@ -19,6 +19,7 @@ This processor is intended, with the aid of [ProcessorEnrichers](../ProcessorEnr
 | ProcessorEnrichers | List | missng XML code comments | missng XML code comments |
 | Source | IEndpointOptions | missng XML code comments | missng XML code comments |
 | Target | IEndpointOptions | missng XML code comments | missng XML code comments |
+| RefName | String | missng XML code comments | missng XML code comments |
 
 
 ### Supported Endpoints
@@ -51,15 +52,18 @@ This processor is intended, with the aid of [ProcessorEnrichers](../ProcessorEnr
   "ProcessorEnrichers": [
     {
       "$type": "PauseAfterEachItemOptions",
-      "Enabled": true
+      "Enabled": true,
+      "RefName": null
     },
     {
       "$type": "AppendMigrationToolSignatureFooterOptions",
-      "Enabled": true
+      "Enabled": true,
+      "RefName": null
     }
   ],
   "Source": null,
-  "Target": null
+  "Target": null,
+  "RefName": null
 }
 ```
 

--- a/src/MigrationTools/EndPoints/EndPointContainer.cs
+++ b/src/MigrationTools/EndPoints/EndPointContainer.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using MigrationTools.EndPoints;
 
 namespace MigrationTools.Endpoints
 {
@@ -38,13 +39,29 @@ namespace MigrationTools.Endpoints
             _SourceOptions = source ?? throw new ArgumentNullException(nameof(source));
             _TargetOptions = target ?? throw new ArgumentNullException(nameof(target));
 
-            var sourceEp = (IEndpoint)Services.GetRequiredService(_SourceOptions.ToConfigure);
-            sourceEp.Configure(_SourceOptions);
-            _Source = sourceEp;
+            if (source is RefEndpointOptions)
+            {
+                // Must load from catalog
+                throw new NotImplementedException("RefEndpointOptions has not yet been implemnted");
+            }
+            else
+            {
+                var sourceEp = (IEndpoint)Services.GetRequiredService(_SourceOptions.ToConfigure);
+                sourceEp.Configure(_SourceOptions);
+                _Source = sourceEp;
+            }
 
-            var targetEp = (IEndpoint)Services.GetRequiredService(_TargetOptions.ToConfigure);
-            targetEp.Configure(_TargetOptions);
-            _Target = targetEp;
+            if (target is RefEndpointOptions)
+            {
+                // Must load from catalog
+                throw new NotImplementedException("RefEndpointOptions has not yet been implemnted");
+            }
+            else
+            {
+                var targetEp = (IEndpoint)Services.GetRequiredService(_TargetOptions.ToConfigure);
+                targetEp.Configure(_TargetOptions);
+                _Target = targetEp;
+            }
             _Configured = true;
         }
     }

--- a/src/MigrationTools/EndPoints/EndpointOptions.cs
+++ b/src/MigrationTools/EndPoints/EndpointOptions.cs
@@ -11,6 +11,7 @@ namespace MigrationTools.Endpoints
         public abstract Type ToConfigure { get; }
 
         public List<IEndpointEnricherOptions> EndpointEnrichers { get; set; }
+        public string RefName { get; set; }
 
         public virtual void SetDefaults()
         {

--- a/src/MigrationTools/EndPoints/RefEndpointOptions.cs
+++ b/src/MigrationTools/EndPoints/RefEndpointOptions.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using MigrationTools.EndpointEnrichers;
+using MigrationTools.Endpoints;
+
+namespace MigrationTools.EndPoints
+{
+    public class RefEndpointOptions : IEndpointOptions
+    {
+        public List<IEndpointEnricherOptions> EndpointEnrichers { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+        public string RefName { get; set; }
+
+        public Type ToConfigure => throw new NotImplementedException();
+
+        public void SetDefaults()
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/MigrationTools/EndpointEnrichers/EndpointEnricherOptions.cs
+++ b/src/MigrationTools/EndpointEnrichers/EndpointEnricherOptions.cs
@@ -9,6 +9,7 @@ namespace MigrationTools.EndpointEnrichers
         public bool Enabled { get; set; }
 
         public abstract Type ToConfigure { get; }
+        public string RefName { get; set; }
 
         public abstract void SetDefaults();
     }

--- a/src/MigrationTools/Helpers/NewtonsoftHelpers.cs
+++ b/src/MigrationTools/Helpers/NewtonsoftHelpers.cs
@@ -24,7 +24,8 @@ namespace MigrationTools.Helpers
                 TypeNameHandling = typeHandling,
                 TypeNameAssemblyFormatHandling = TypeNameAssemblyFormatHandling.Simple,
                 SerializationBinder = new OptionsSerializationBinder(),
-                Formatting = Formatting.Indented
+                Formatting = Formatting.Indented,
+                ContractResolver = new OptionsSerializeContractResolver()
             };
         }
     }

--- a/src/MigrationTools/Options/IOptions.cs
+++ b/src/MigrationTools/Options/IOptions.cs
@@ -5,6 +5,11 @@ namespace MigrationTools.Options
 {
     public interface IOptions
     {
+        /// <summary>
+        /// If you set a `RefName` then this configration will be added to a Catalog of configurations that can be refernced using tha `RefName` so tha tyou dont have to keep adding the ame items with the same configuration.
+        /// </summary>
+        public string RefName { get; set; }
+
         [JsonIgnoreAttribute]
         Type ToConfigure { get; }
 

--- a/src/MigrationTools/Options/OptionsSerializeContractResolver.cs
+++ b/src/MigrationTools/Options/OptionsSerializeContractResolver.cs
@@ -1,0 +1,19 @@
+﻿using System.Reflection;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+
+namespace MigrationTools.Options
+{
+    public class OptionsSerializeContractResolver : DefaultContractResolver
+    {
+        protected override JsonProperty CreateProperty(MemberInfo member, MemberSerialization memberSerialization)
+        {
+            JsonProperty property = base.CreateProperty(member, memberSerialization);
+            if (property.PropertyName == "RefName")
+            {
+                property.ShouldSerialize = instance => string.IsNullOrEmpty((instance?.GetType().GetProperty(property.PropertyName).GetValue(instance)?.ToString()));
+            }
+            return property;
+        }
+    }
+}

--- a/src/MigrationTools/ProcessorEnrichers/ProcessorEnricherOptions.cs
+++ b/src/MigrationTools/ProcessorEnrichers/ProcessorEnricherOptions.cs
@@ -7,6 +7,7 @@ namespace MigrationTools.Enrichers
         public bool Enabled { get; set; }
 
         public abstract Type ToConfigure { get; }
+        public string RefName { get; set; }
 
         public abstract void SetDefaults();
     }

--- a/src/MigrationTools/Processors/ProcessorOptions.cs
+++ b/src/MigrationTools/Processors/ProcessorOptions.cs
@@ -20,6 +20,7 @@ namespace MigrationTools.Processors
         public IEndpointOptions Source { get; set; }
         public IEndpointOptions Target { get; set; }
         public abstract Type ToConfigure { get; }
+        public string RefName { get; set; }
 
         public abstract IProcessorOptions GetDefault();
 


### PR DESCRIPTION
We want to be able to have `RefName` based Endpoints so that you can use them in multiple Processors.

The idea would be to create a catalogue of IOptions that have been configured with a unique `RefName` and then allow you to simply reference an existing one.