### PR TITLE
Update AsDictionary to use the field reference name as key and refactor FieldValueMap as example to work properly with ReplayRevisions

### DIFF
--- a/src/MigrationTools.Clients.AzureDevops.ObjectModel/FieldMaps/FieldMapBase.cs
+++ b/src/MigrationTools.Clients.AzureDevops.ObjectModel/FieldMaps/FieldMapBase.cs
@@ -26,11 +26,18 @@ namespace MigrationTools.FieldMaps.AzureDevops.ObjectModel
         {
             try
             {
-                InternalExecute(source.ToWorkItem(), target.ToWorkItem());
+                if (RefactoredToUseWorkItemData)
+                {
+                    InternalExecute(source, target);
+                }
+                else
+                {
+                    InternalExecute(source.ToWorkItem(), target.ToWorkItem());
+                }
             }
             catch (Exception ex)
             {
-                Log.LogError(ex, "Field mapp fault",
+                Log.LogError(ex, "Field map fault",
                        new Dictionary<string, string> {
                             { "Source", source.ToWorkItem().Id.ToString() },
                             { "Target",  target.ToWorkItem().Id.ToString()}
@@ -50,5 +57,12 @@ namespace MigrationTools.FieldMaps.AzureDevops.ObjectModel
         public ILogger<FieldMapBase> Log { get; }
 
         internal abstract void InternalExecute(WorkItem source, WorkItem target);
+
+        internal virtual bool RefactoredToUseWorkItemData => false;
+
+        internal virtual void InternalExecute(WorkItemData source, WorkItemData target)
+        {
+
+        }
     }
 }

--- a/src/MigrationTools.Clients.AzureDevops.ObjectModel/FieldMaps/FieldValueMap.cs
+++ b/src/MigrationTools.Clients.AzureDevops.ObjectModel/FieldMaps/FieldValueMap.cs
@@ -2,6 +2,7 @@
 using Microsoft.Extensions.Logging;
 using Microsoft.TeamFoundation.WorkItemTracking.Client;
 using MigrationTools._EngineV1.Configuration.FieldMap;
+using MigrationTools._EngineV1.DataContracts;
 
 namespace MigrationTools.FieldMaps.AzureDevops.ObjectModel
 {
@@ -17,24 +18,32 @@ namespace MigrationTools.FieldMaps.AzureDevops.ObjectModel
 
         internal override void InternalExecute(WorkItem source, WorkItem target)
         {
-            if (source.Fields.Contains(Config.sourceField))
+            throw new NotImplementedException("Use the WorkItemData overload instead");
+        }
+
+        internal override bool RefactoredToUseWorkItemData { get; } = true;
+
+        internal override void InternalExecute(WorkItemData source, WorkItemData target)
+        {
+            if (source.Fields.ContainsKey(Config.sourceField))
             {
-                var sourceVal = source.Fields[Config.sourceField].Value;
-                var t = target.Fields[Config.targetField].FieldDefinition.SystemType;
+                var sourceVal = source.Fields[Config.sourceField];
+                var targetWi = target.ToWorkItem();
+                var t = targetWi.Fields[Config.targetField].FieldDefinition.SystemType;
 
                 if (sourceVal is null && Config.valueMapping.ContainsKey("null"))
                 {
-                    target.Fields[Config.targetField].Value = Convert.ChangeType(Config.valueMapping["null"], t);
+                    targetWi.Fields[Config.targetField].Value = Convert.ChangeType(Config.valueMapping["null"], t);
                     Log.LogDebug("FieldValueMap: [UPDATE] field value mapped {SourceId}:{SourceField} to {TargetId}:{TargetField}", source.Id, Config.sourceField, target.Id, Config.targetField);
                 }
                 else if (sourceVal != null && Config.valueMapping.ContainsKey(sourceVal.ToString()))
                 {
-                    target.Fields[Config.targetField].Value = Convert.ChangeType(Config.valueMapping[sourceVal.ToString()], t);
+                    targetWi.Fields[Config.targetField].Value = Convert.ChangeType(Config.valueMapping[sourceVal.ToString()], t);
                     Log.LogDebug("FieldValueMap: [UPDATE] field value mapped {SourceId}:{SourceField} to {TargetId}:{TargetField}", source.Id, Config.sourceField, target.Id, Config.targetField);
                 }
                 else if (sourceVal != null && !string.IsNullOrWhiteSpace(Config.defaultValue))
                 {
-                    target.Fields[Config.targetField].Value = Convert.ChangeType(Config.defaultValue, t);
+                    targetWi.Fields[Config.targetField].Value = Convert.ChangeType(Config.defaultValue, t);
                     Log.LogDebug("FieldValueMap: [UPDATE] field value mapped {SourceId}:{SourceField} to {TargetId}:{TargetField}", source.Id, Config.sourceField, target.Id, Config.targetField);
                 }
             }

--- a/src/MigrationTools.Clients.AzureDevops.ObjectModel/TfsExtensions.cs
+++ b/src/MigrationTools.Clients.AzureDevops.ObjectModel/TfsExtensions.cs
@@ -166,7 +166,7 @@ namespace MigrationTools
             var dict = new Dictionary<string, object>();
             for (var ix = 0; ix < col.Count; ix++)
             {
-                dict.Add(col[ix].Name, col[ix].Value);
+                dict.Add(col[ix].ReferenceName, col[ix].Value);
             }
             return dict;
         }

--- a/src/MigrationTools/_EngineV1/DataContracts/WorkItemData.cs
+++ b/src/MigrationTools/_EngineV1/DataContracts/WorkItemData.cs
@@ -22,31 +22,31 @@ namespace MigrationTools._EngineV1.DataContracts
                     return _id;
                 }
 
-                _id = GetField("ID")?.ToString();
+                _id = GetField("System.Id")?.ToString(); // ToString() will create a new string while the field value already is a string => as cast is more efficient here
                 return _id;
             }
             set
             {
                 var val = int.Parse(value);
                 _id = value;
-                SetField<int>("ID", val);
+                SetField<int>("System.Id", val);
             }
         }
 
         public string Type
         {
-            get => GetField("Work Item Type").ToString();
-            set => SetField("Work Item Type", value);
+            get => GetField("System.WorkItemType").ToString(); // ToString() will create a new string while the field value already is a string => as cast is more efficient here
+            set => SetField("System.WorkItemType", value);
         }
 
         public string Title
         {
-            get => GetField("Title").ToString();
-            set => SetField("Title", value);
+            get => GetField("System.Title").ToString(); // ToString() will create a new string while the field value already is a string => as cast is more efficient here
+            set => SetField("System.Title", value);
         }
 
-        public int Rev => int.Parse(GetField("Rev").ToString());
-        public DateTime RevisedDate => DateTime.Parse(GetField("Revised Date").ToString());
+        public int Rev => int.Parse(GetField("System.Rev").ToString()); // Rev is always an int => cast is more efficient than ToString() and parsing it
+        public DateTime ChangedDate => DateTime.Parse(GetField("System.ChangedDate").ToString()); // ChangedDate always is DateTime => cast is more efficient than ToString() and parsing its
         public string ProjectName { get; set; }
 
         [JsonIgnore]

--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemMigrationContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemMigrationContext.cs
@@ -522,7 +522,7 @@ namespace VstsSyncMigrator.Engine
                         {
                             revWi.Id,
                             revWi.Rev,
-                            revWi.RevisedDate,
+                            revWi.ChangedDate, // According to https://docs.microsoft.com/en-us/azure/devops/reference/xml/reportable-fields-reference?view=azure-devops-2020 Revised Date was misused here
                             revWi.Fields
                         };
                     });
@@ -562,13 +562,14 @@ namespace VstsSyncMigrator.Engine
                     WorkItemTypeChange(targetWorkItem, skipToFinalRevisedWorkItemType, finalDestType, revision, currentRevisionWorkItem, destType);
 
                     PopulateWorkItem(currentRevisionWorkItem, targetWorkItem, destType);
+
+                    // Todo: Ensure all field maps use WorkItemData.Fields to apply a correct mapping
                     Engine.FieldMaps.ApplyFieldMappings(currentRevisionWorkItem, targetWorkItem);
 
-                    targetWorkItem.ToWorkItem().Fields["System.ChangedBy"].Value =
-                        currentRevisionWorkItem.ToWorkItem().Revisions[revision.Index].Fields["System.ChangedBy"].Value;
+                    // Todo: Think about an "UpdateChangedBy" flag as this is expensive! (2s/WI instead of 1,5s when writing "Migration")
+                    targetWorkItem.ToWorkItem().Fields["System.ChangedBy"].Value = currentRevisionWorkItem.Fields["System.ChangedBy"];
 
-                    targetWorkItem.ToWorkItem().Fields["System.History"].Value =
-                        currentRevisionWorkItem.ToWorkItem().Revisions[revision.Index].Fields["System.History"].Value;
+                    targetWorkItem.ToWorkItem().Fields["System.History"].Value = currentRevisionWorkItem.Fields["System.History"];
                     //Debug.WriteLine("Discussion:" + currentRevisionWorkItem.Revisions[revision.Index].Fields["System.History"].Value);
 
                     TfsReflectedWorkItemId reflectedUri = (TfsReflectedWorkItemId)Engine.Source.WorkItems.CreateReflectedWorkItemId(sourceWorkItem);


### PR DESCRIPTION
This is the beginning of what needs to be done to make ReplayRevisons work properly. In addition I replaced RevisedDate with ChangedDate as according to https://docs.microsoft.com/en-us/azure/devops/reference/xml/reportable-fields-reference?view=azure-devops-2020 RevisedDate was misused.

Of course `RefactoredToUseWorkItemData` can be removed some day but I don't have the time to fix all maps right now (We won't use ReplayRevisions in our environment). This way at least the code keeps compilable.

Partially solves #741 