### PR TITLE
Set the targetWorkItem Id Field

### DIFF
--- a/src/MigrationTools.Clients.AzureDevops.ObjectModel/TfsExtensions.cs
+++ b/src/MigrationTools.Clients.AzureDevops.ObjectModel/TfsExtensions.cs
@@ -87,6 +87,7 @@ namespace MigrationTools
         {
             var workItem = (WorkItem)context.internalObject;
             context.ProjectName = workItem.Project?.Name;
+            context.Id = workItem.Id.ToString();
 
             // If fieldsOfRevision is provided we use this collection as we want to create a revised WorkItemData object
             context.Fields = fieldsOfRevision != null ? fieldsOfRevision.AsDictionary() : workItem.Fields.AsDictionary();


### PR DESCRIPTION
That change allows running the Link migrator during the same run as the Work Item gets created. Before that,  targetWorkItem.Id was always 0 since it did not get set anywhere. Because of that `if (targetWorkItemLinkStart.ToWorkItem().Id == 0)` returned 0 and the Links wouldn't get migrated.