### PR TITLE
Makes the TfsTeamSettingsProcessor runnable

### DIFF
--- a/docs/Reference/Processors/TfsTeamSettingsProcessor.json
+++ b/docs/Reference/Processors/TfsTeamSettingsProcessor.json
@@ -7,7 +7,7 @@
   "Teams": null,
   "ProcessorEnrichers": null,
   "Source": {
-    "$type": "TfsEndpointOptions",
+    "$type": "TfsTeamSettingsEndpointOptions",
     "Organisation": "https://dev.azure.com/nkdagility-preview/",
     "Project": "sourceProject",
     "AuthenticationMode": "AccessToken",
@@ -16,7 +16,7 @@
     "EndpointEnrichers": null
   },
   "Target": {
-    "$type": "TfsEndpointOptions",
+    "$type": "TfsTeamSettingsEndpointOptions",
     "Organisation": "https://dev.azure.com/nkdagility-preview/",
     "Project": "targetProject",
     "AuthenticationMode": "AccessToken",

--- a/docs/Reference/Processors/TfsTeamSettingsProcessor.md
+++ b/docs/Reference/Processors/TfsTeamSettingsProcessor.md
@@ -33,7 +33,7 @@ Native TFS Processor, does not work with any other Endpoints.
   "Teams": null,
   "ProcessorEnrichers": null,
   "Source": {
-    "$type": "TfsEndpointOptions",
+    "$type": "TfsTeamSettingsEndpointOptions",
     "Organisation": "https://dev.azure.com/nkdagility-preview/",
     "Project": "sourceProject",
     "AuthenticationMode": "AccessToken",
@@ -42,7 +42,7 @@ Native TFS Processor, does not work with any other Endpoints.
     "EndpointEnrichers": null
   },
   "Target": {
-    "$type": "TfsEndpointOptions",
+    "$type": "TfsTeamSettingsEndpointOptions",
     "Organisation": "https://dev.azure.com/nkdagility-preview/",
     "Project": "targetProject",
     "AuthenticationMode": "AccessToken",

--- a/src/MigrationTools.Clients.AzureDevops.ObjectModel/Processors/TfsTeamSettingsProcessorOptions.cs
+++ b/src/MigrationTools.Clients.AzureDevops.ObjectModel/Processors/TfsTeamSettingsProcessorOptions.cs
@@ -29,9 +29,9 @@ namespace MigrationTools.Processors
         /// </summary>
         public List<string> Teams { get; set; }
 
-        public override string Processor => nameof(ToConfigure);
+        public override Type ToConfigure => typeof(TfsTeamSettingsProcessor);
 
-        public override Type ToConfigure => typeof(WorkItemTrackingProcessor);
+        public override string Processor => nameof(TfsTeamSettingsProcessor);
 
         public override IProcessorOptions GetDefault()
         {
@@ -43,11 +43,11 @@ namespace MigrationTools.Processors
             MigrateTeamSettings = true;
             UpdateTeamSettings = true;
             PrefixProjectToNodes = false;
-            var e1 = new TfsEndpointOptions();
+            var e1 = new TfsTeamSettingsEndpointOptions();
             e1.SetDefaults();
             e1.Project = "sourceProject";
             Source = e1;
-            var e2 = new TfsEndpointOptions();
+            var e2 = new TfsTeamSettingsEndpointOptions();
             e2.SetDefaults();
             e2.Project = "targetProject";
             Target = e2;


### PR DESCRIPTION
With those changes, that TfsTeamSettingsProcessor can be executed. But the Teams won't get saved to the target Endpoint. 

- [ ] We need to figure out why