### PR TITLE
Fixed Processor Naming

### DIFF
--- a/src/MigrationTools.Clients.AzureDevops.ObjectModel/Processors/TfsSharedQueryProcessorOptions.cs
+++ b/src/MigrationTools.Clients.AzureDevops.ObjectModel/Processors/TfsSharedQueryProcessorOptions.cs
@@ -35,9 +35,9 @@ namespace MigrationTools.Processors
         /// </summary>
         public Dictionary<string, string> SourceToTargetFieldMappings { get; set; }
 
-        public override string Processor => nameof(TfsSharedQueryProcessor);
-
         public override Type ToConfigure => typeof(TfsSharedQueryProcessor);
+
+        public override string Processor => ToConfigure.Name;
 
         public override IProcessorOptions GetDefault()
         {

--- a/src/MigrationTools.Clients.AzureDevops.ObjectModel/Processors/TfsTeamSettingsProcessorOptions.cs
+++ b/src/MigrationTools.Clients.AzureDevops.ObjectModel/Processors/TfsTeamSettingsProcessorOptions.cs
@@ -31,7 +31,7 @@ namespace MigrationTools.Processors
 
         public override Type ToConfigure => typeof(TfsTeamSettingsProcessor);
 
-        public override string Processor => nameof(TfsTeamSettingsProcessor);
+        public override string Processor => ToConfigure.Name;
 
         public override IProcessorOptions GetDefault()
         {

--- a/src/MigrationTools/Processors/WorkItemProcessor/WorkItemTrackingProcessorOptions.cs
+++ b/src/MigrationTools/Processors/WorkItemProcessor/WorkItemTrackingProcessorOptions.cs
@@ -10,10 +10,8 @@ namespace MigrationTools.Processors
         public bool PrefixProjectToNodes { get; set; }
         public bool CollapseRevisions { get; set; }
         public int WorkItemCreateRetryLimit { get; set; }
-
-        public override string Processor => nameof(ToConfigure);
-
         public override Type ToConfigure => typeof(WorkItemTrackingProcessor);
+        public override string Processor => ToConfigure.Name;
 
         public override IProcessorOptions GetDefault()
         {


### PR DESCRIPTION
This fixes the Naming of the `Processor` Object so we don't have to set the processor twice