### PR TITLE
AzureDevOps Pipeline Processor: Task- and Variable Groups

### DIFF
--- a/docs/Reference/Generated/MigrationTools.Clients.AzureDevops.Rest.xml
+++ b/docs/Reference/Generated/MigrationTools.Clients.AzureDevops.Rest.xml
@@ -41,12 +41,6 @@
             <param name="accessToken"></param>
             <returns>List of API Definitions </returns>
         </member>
-        <member name="M:MigrationTools.Processors.AzureDevOpsPipelineProcessor.CreateApiDefinitions``1">
-            <summary>
-            Method to create an Api Definition
-            </summary>
-            <typeparam name="DefinitionType">Type of Definition. Can be: Taskgroup, Build- or Release Pipeline</typeparam>
-        </member>
         <member name="P:MigrationTools.Processors.AzureDevOpsPipelineProcessorOptions.MigrateBuildPipelines">
             <summary>
             Migrate Build Pipelines

--- a/docs/Reference/Generated/MigrationTools.Clients.AzureDevops.Rest.xml
+++ b/docs/Reference/Generated/MigrationTools.Clients.AzureDevops.Rest.xml
@@ -11,12 +11,12 @@
         </member>
         <member name="M:MigrationTools.Processors.AzureDevOpsPipelineProcessor.MigratePipelines">
             <summary>
-            Executes Method for migrating Taskgroups or Pipelines, depinding on whhat is set in the config.
+            Executes Method for migrating Taskgroups, Variablegroups or Pipelines, depinding on whhat is set in the config.
             </summary>
         </member>
         <member name="M:MigrationTools.Processors.AzureDevOpsPipelineProcessor.getModUrl(System.String,System.String,MigrationTools.DataContracts.ApiPathAttribute,MigrationTools.DataContracts.ApiNameAttribute)">
             <summary>
-            Ugly Method to get the RESP API URLs right
+            Method to get the RESP API URLs right
             </summary>
             <param name="organisation"></param>
             <param name="project"></param>
@@ -33,13 +33,40 @@
         </member>
         <member name="M:MigrationTools.Processors.AzureDevOpsPipelineProcessor.GetApiDefinitions``1(System.String,System.String,System.String)">
             <summary>
-            Generic Method to get API Definitions (Taskgroups, Build- or Release Pipelines)
+            Generic Method to get API Definitions (Taskgroups, Variablegroups, Build- or Release Pipelines)
             </summary>
             <typeparam name="DefinitionType">Type of Definition. Can be: Taskgroup, Build- or Release Pipeline</typeparam>
             <param name="organisation"></param>
             <param name="project"></param>
             <param name="accessToken"></param>
             <returns>List of API Definitions </returns>
+        </member>
+        <member name="M:MigrationTools.Processors.AzureDevOpsPipelineProcessor.AddAllreadySyncedMappings``1(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEnumerable{MigrationTools.DataContracts.Mapping})">
+            <summary>
+            Map the taskgroups that are already migrated
+            </summary>
+            <typeparam name="DefintionType"></typeparam>
+            <param name="sourceDefinitions"></param>
+            <param name="targetDefinitions"></param>
+            <param name="newMappings"></param>
+            <returns>Mapping list</returns>
+        </member>
+        <member name="M:MigrationTools.Processors.AzureDevOpsPipelineProcessor.filteredDefinitions``1(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEnumerable{``0})">
+            <summary>
+            Filter existing Definitions
+            </summary>
+            <typeparam name="DefinitionType"></typeparam>
+            <param name="sourceDefinitions"></param>
+            <param name="targetDefinitions"></param>
+            <returns>List of filtered Definitions</returns>
+        </member>
+        <member name="M:MigrationTools.Processors.AzureDevOpsPipelineProcessor.CreateApiDefinitions``1(System.Collections.Generic.IEnumerable{``0})">
+            <summary>
+            Make HTTP Request to create a Definition
+            </summary>
+            <typeparam name="DefinitionType"></typeparam>
+            <param name="definitionsToBeMigrated"></param>
+            <returns>List of Mappings</returns>
         </member>
         <member name="P:MigrationTools.Processors.AzureDevOpsPipelineProcessorOptions.MigrateBuildPipelines">
             <summary>
@@ -67,12 +94,12 @@
         </member>
         <member name="P:MigrationTools.Processors.AzureDevOpsPipelineProcessorOptions.BuildPipelines">
             <summary>
-            List of Build Pipelines to process. If this is `null` then all Build Pipelines will be processed.
+            List of Build Pipelines to process. If this is `null` then all Build Pipelines will be processed. **Not implemented yet**
             </summary>
         </member>
         <member name="P:MigrationTools.Processors.AzureDevOpsPipelineProcessorOptions.ReleasePipelines">
             <summary>
-            List of Release Pipelines to process. If this is `null` then all Release Pipelines will be processed.
+            List of Release Pipelines to process. If this is `null` then all Release Pipelines will be processed. **Not implemented yet**
             </summary>
         </member>
     </members>

--- a/docs/Reference/Generated/MigrationTools.Clients.AzureDevops.Rest.xml
+++ b/docs/Reference/Generated/MigrationTools.Clients.AzureDevops.Rest.xml
@@ -59,6 +59,12 @@
             </summary>
             <default>true</default>
         </member>
+        <member name="P:MigrationTools.Processors.AzureDevOpsPipelineProcessorOptions.MigrateVariableGroups">
+            <summary>
+            Migrate Valiable Groups
+            </summary>
+            <default>true</default>
+        </member>
         <member name="P:MigrationTools.Processors.AzureDevOpsPipelineProcessorOptions.BuildPipelines">
             <summary>
             List of Build Pipelines to process. If this is `null` then all Build Pipelines will be processed.

--- a/docs/Reference/Generated/MigrationTools.xml
+++ b/docs/Reference/Generated/MigrationTools.xml
@@ -16,6 +16,18 @@
             </summary>
             <returns>The clean RestApiDefinition</returns>
         </member>
+        <member name="M:MigrationTools.DataContracts.RestApiDefinition.HasTaskGroups">
+            <summary>
+            Checks whether the Definition references Taskgroups
+            </summary>
+            <returns>bool</returns>
+        </member>
+        <member name="M:MigrationTools.DataContracts.RestApiDefinition.HasVariableGroups">
+            <summary>
+            Checks whether the Definition references Variablegroups
+            </summary>
+            <returns>bool</returns>
+        </member>
         <member name="P:MigrationTools.Enrichers.IEnricherOptions.Enabled">
             <summary>
             Active the enricher if it true.

--- a/docs/Reference/Processors/AzureDevOpsPipelineProcessor.json
+++ b/docs/Reference/Processors/AzureDevOpsPipelineProcessor.json
@@ -4,6 +4,7 @@
   "MigrateBuildPipelines": true,
   "MigrateReleasePipelines": true,
   "MigrateTaskGroups": true,
+  "MigrateVariableGroups": true,
   "BuildPipelines": null,
   "ReleasePipelines": null,
   "ProcessorEnrichers": null,

--- a/docs/Reference/Processors/AzureDevOpsPipelineProcessor.md
+++ b/docs/Reference/Processors/AzureDevOpsPipelineProcessor.md
@@ -15,8 +15,8 @@ Azure DevOps Processor that migrates Taskgroups, Build- and Release Pipelines.
 | MigrateReleasePipelines | Boolean | Migrate Release Pipelines | true |
 | MigrateTaskGroups | Boolean | Migrate Task Groups | true |
 | MigrateVariableGroups | Boolean | Migrate Valiable Groups | true |
-| BuildPipelines | List | List of Build Pipelines to process. If this is `null` then all Build Pipelines will be processed. | missng XML code comments |
-| ReleasePipelines | List | List of Release Pipelines to process. If this is `null` then all Release Pipelines will be processed. | missng XML code comments |
+| BuildPipelines | List | List of Build Pipelines to process. If this is `null` then all Build Pipelines will be processed. **Not implemented yet** | missng XML code comments |
+| ReleasePipelines | List | List of Release Pipelines to process. If this is `null` then all Release Pipelines will be processed. **Not implemented yet** | missng XML code comments |
 | ProcessorEnrichers | List | List of Enrichers that can be used to add more features to this processor. Only works with Native Processors and not legacy Processors. | missng XML code comments |
 | Source | IEndpointOptions | This is the `IEndpoint` that will be used as the source of the Migration. Can be null for a write only processor. | missng XML code comments |
 | Target | IEndpointOptions | This is the `IEndpoint` that will be used as the Target of the Migration. Can be null for a write only processor. | missng XML code comments |

--- a/docs/Reference/Processors/AzureDevOpsPipelineProcessor.md
+++ b/docs/Reference/Processors/AzureDevOpsPipelineProcessor.md
@@ -14,6 +14,7 @@ Azure DevOps Processor that migrates Taskgroups, Build- and Release Pipelines.
 | MigrateBuildPipelines | Boolean | Migrate Build Pipelines | true |
 | MigrateReleasePipelines | Boolean | Migrate Release Pipelines | true |
 | MigrateTaskGroups | Boolean | Migrate Task Groups | true |
+| MigrateVariableGroups | Boolean | Migrate Valiable Groups | true |
 | BuildPipelines | List | List of Build Pipelines to process. If this is `null` then all Build Pipelines will be processed. | missng XML code comments |
 | ReleasePipelines | List | List of Release Pipelines to process. If this is `null` then all Release Pipelines will be processed. | missng XML code comments |
 | ProcessorEnrichers | List | List of Enrichers that can be used to add more features to this processor. Only works with Native Processors and not legacy Processors. | missng XML code comments |
@@ -31,6 +32,7 @@ Azure DevOps Processor that migrates Taskgroups, Build- and Release Pipelines.
   "MigrateBuildPipelines": true,
   "MigrateReleasePipelines": true,
   "MigrateTaskGroups": true,
+  "MigrateVariableGroups": true,
   "BuildPipelines": null,
   "ReleasePipelines": null,
   "ProcessorEnrichers": null,

--- a/src/MigrationTools.Clients.AzureDevops.Rest/Processors/AzureDevOpsPipelineProcessor.cs
+++ b/src/MigrationTools.Clients.AzureDevops.Rest/Processors/AzureDevOpsPipelineProcessor.cs
@@ -201,12 +201,21 @@ namespace MigrationTools.Processors
             {
                 var definitions = JsonConvert.DeserializeObject<RestResultDefinition<DefinitionType>>(httpResponse);
 
-                foreach (RestApiDefinition definition in definitions.Value)
+                if (!typeof(DefinitionType).ToString().Contains("TaskGroup"))
                 {
-                    //Nessecary because getting all Pipelines doesn't include all of their properties
-                    string responseMessage = client.GetStringAsync(baseUrl + "/" + definition.Id).Result;
-                    initialDefinitions.Add(JsonConvert.DeserializeObject<DefinitionType>(responseMessage));
+                    foreach (RestApiDefinition definition in definitions.Value)
+                    {
+                        //Nessecary because getting all Pipelines doesn't include all of their properties
+                        string responseMessage = client.GetStringAsync(baseUrl + "/" + definition.Id).Result;
+                        var test = JsonConvert.DeserializeObject<RestResultDefinition<DefinitionType>>(responseMessage);
+                        initialDefinitions.Add(JsonConvert.DeserializeObject<DefinitionType>(responseMessage));
+                    }
                 }
+                else
+                {
+                    initialDefinitions = definitions.Value.ToList();
+                }
+
             }
             return initialDefinitions;
         }
@@ -231,7 +240,7 @@ namespace MigrationTools.Processors
             var definitionsToBeMigrated = sourceDefinitions.Where(s => !targetDefinitions.Any(t => t.Name == s.Name));
 
             Log.LogInformation($"From {sourceDefinitions.Count} source {apiNameAttribute.Name} {definitionsToBeMigrated.Count()} {apiNameAttribute.Name} are going to be migrated..");
-            string baseUrl = getModUrl(Target.Organisation, Target.Project, apiPathAttribute, apiNameAttribute) + "?api -version=5.1-preview";
+            string baseUrl = getModUrl(Target.Organisation, Target.Project, apiPathAttribute, apiNameAttribute) + "?api-version=5.1-preview";
 
             foreach (RestApiDefinition definitionToBeMigrated in definitionsToBeMigrated)
             {

--- a/src/MigrationTools.Clients.AzureDevops.Rest/Processors/AzureDevOpsPipelineProcessorOptions.cs
+++ b/src/MigrationTools.Clients.AzureDevops.Rest/Processors/AzureDevOpsPipelineProcessorOptions.cs
@@ -25,6 +25,12 @@ namespace MigrationTools.Processors
         public bool MigrateTaskGroups { get; set; }
 
         /// <summary>
+        /// Migrate Valiable Groups
+        /// </summary>
+        /// <default>true</default>
+        public bool MigrateVariableGroups { get; set; }
+
+        /// <summary>
         /// List of Build Pipelines to process. If this is `null` then all Build Pipelines will be processed.
         /// </summary>
         public List<string> BuildPipelines { get; set; }
@@ -46,6 +52,7 @@ namespace MigrationTools.Processors
             MigrateBuildPipelines = true;
             MigrateReleasePipelines = true;
             MigrateTaskGroups = true;
+            MigrateVariableGroups = true;
             BuildPipelines = null;
             ReleasePipelines = null;
             var e1 = new AzureDevOpsEndpointOptions();

--- a/src/MigrationTools.Clients.AzureDevops.Rest/Processors/AzureDevOpsPipelineProcessorOptions.cs
+++ b/src/MigrationTools.Clients.AzureDevops.Rest/Processors/AzureDevOpsPipelineProcessorOptions.cs
@@ -31,12 +31,12 @@ namespace MigrationTools.Processors
         public bool MigrateVariableGroups { get; set; }
 
         /// <summary>
-        /// List of Build Pipelines to process. If this is `null` then all Build Pipelines will be processed.
+        /// List of Build Pipelines to process. If this is `null` then all Build Pipelines will be processed. **Not implemented yet**
         /// </summary>
         public List<string> BuildPipelines { get; set; }
 
         /// <summary>
-        /// List of Release Pipelines to process. If this is `null` then all Release Pipelines will be processed.
+        /// List of Release Pipelines to process. If this is `null` then all Release Pipelines will be processed. **Not implemented yet**
         /// </summary>
         public List<string> ReleasePipelines { get; set; }
 

--- a/src/MigrationTools/DataContracts/Mapping.cs
+++ b/src/MigrationTools/DataContracts/Mapping.cs
@@ -1,0 +1,9 @@
+﻿namespace MigrationTools.DataContracts
+{
+    public class Mapping
+    {
+        public string SId { get; set; }
+        public string TId { get; set; }
+        public string Name { get; set; }
+    }
+}

--- a/src/MigrationTools/DataContracts/Pipelines/BuildDefinitions.cs
+++ b/src/MigrationTools/DataContracts/Pipelines/BuildDefinitions.cs
@@ -3,13 +3,6 @@ using System.Dynamic;
 
 namespace MigrationTools.DataContracts.Pipelines
 {
-    public partial class BuildDefinitions
-    {
-        public long Count { get; set; }
-
-        public BuildDefinition[] Value { get; set; }
-    }
-
     [ApiPath("build/definitions")]
     [ApiName("Build Piplines")]
     public partial class BuildDefinition : RestApiDefinition

--- a/src/MigrationTools/DataContracts/Pipelines/BuildDefinitions.cs
+++ b/src/MigrationTools/DataContracts/Pipelines/BuildDefinitions.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Dynamic;
+using System.Linq;
 
 namespace MigrationTools.DataContracts.Pipelines
 {
@@ -71,6 +73,11 @@ namespace MigrationTools.DataContracts.Pipelines
             Repository.Id = null;
             Variables = null;
             return this;
+        }
+
+        public override bool HasTaskGroups()
+        {
+            return Process.Phases.Any(p => p.Steps.Any(s => s.Task.DefinitionType.ToString() == "metaTask"));  
         }
     }
 

--- a/src/MigrationTools/DataContracts/Pipelines/ReleaseDefinitions.cs
+++ b/src/MigrationTools/DataContracts/Pipelines/ReleaseDefinitions.cs
@@ -1,6 +1,8 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Dynamic;
 using System.Linq;
+using Microsoft.VisualStudio.Services.Common;
 using Newtonsoft.Json;
 
 namespace MigrationTools.DataContracts.Pipelines
@@ -44,7 +46,7 @@ namespace MigrationTools.DataContracts.Pipelines
         public TaskGroupLinks Links { get; set; }
 
         ///<inheritdoc/>
-        public override RestApiDefinition ResetObject()
+        public override void ResetObject()
         {
             Links = null;
             Revision = 0;
@@ -53,11 +55,28 @@ namespace MigrationTools.DataContracts.Pipelines
             Links = null;
             Id = null;
             VariableGroups = null;
-            return this;
+
+            //Remove secure files
+            Environments.ForEach(e => e.DeployPhases.ForEach(d => d.WorkflowTasks.ForEach(w =>
+            {
+                var secureFiles = w.Inputs.Where(i => i.Key == "secureFile");
+                for (int i = 0; i < secureFiles.Count(); i++)
+                {
+                    var secureFile = secureFiles.ElementAt(i);
+                    ((ICollection<KeyValuePair<string, object>>)w.Inputs).Remove(secureFile);
+                }
+            }
+            )));
         }
+
         public override bool HasTaskGroups()
         {
-            return Environments.Any(e => e.DeployPhases.Any(p => p.WorkflowTasks.Any(t => t.DefinitionType.ToString() == "metaTask")));
+            return Environments.Any(e => e.DeployPhases.Any(d => d.WorkflowTasks.Any(w => w.DefinitionType == "metaTask")));
+        }
+
+        public override bool HasVariableGroups()
+        {
+            return Environments.Any(e => e.VariableGroups != null);
         }
     }
 
@@ -139,7 +158,7 @@ namespace MigrationTools.DataContracts.Pipelines
 
         public EnvironmentVariables Variables { get; set; }
 
-        public object[] VariableGroups { get; set; }
+        public int[] VariableGroups { get; set; }
 
         public DeployApprovals PreDeployApprovals { get; set; }
 

--- a/src/MigrationTools/DataContracts/Pipelines/ReleaseDefinitions.cs
+++ b/src/MigrationTools/DataContracts/Pipelines/ReleaseDefinitions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Dynamic;
+using System.Linq;
 using Newtonsoft.Json;
 
 namespace MigrationTools.DataContracts.Pipelines
@@ -53,6 +54,10 @@ namespace MigrationTools.DataContracts.Pipelines
             Id = null;
             VariableGroups = null;
             return this;
+        }
+        public override bool HasTaskGroups()
+        {
+            return Environments.Any(e => e.DeployPhases.Any(p => p.WorkflowTasks.Any(t => t.DefinitionType.ToString() == "metaTask")));
         }
     }
 

--- a/src/MigrationTools/DataContracts/Pipelines/ReleaseDefinitions.cs
+++ b/src/MigrationTools/DataContracts/Pipelines/ReleaseDefinitions.cs
@@ -4,13 +4,6 @@ using Newtonsoft.Json;
 
 namespace MigrationTools.DataContracts.Pipelines
 {
-    public partial class ReleaseDefinitions
-    {
-        public long Count { get; set; }
-
-        public ReleaseDefinition[] Value { get; set; }
-    }
-
     [ApiPath("release/definitions")]
     [ApiName("Release Piplines")]
     public partial class ReleaseDefinition : RestApiDefinition

--- a/src/MigrationTools/DataContracts/Pipelines/TaskGroups.cs
+++ b/src/MigrationTools/DataContracts/Pipelines/TaskGroups.cs
@@ -76,6 +76,11 @@ namespace MigrationTools.DataContracts.Pipelines
 
         public string HelpMarkDown { get; set; }
 
+        public override bool HasTaskGroups()
+        {
+            throw new NotImplementedException("we currently not support taskgroup nesting.");
+        }
+
         public override RestApiDefinition ResetObject()
         {
             return this;

--- a/src/MigrationTools/DataContracts/Pipelines/TaskGroups.cs
+++ b/src/MigrationTools/DataContracts/Pipelines/TaskGroups.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Dynamic;
 using System.Globalization;
+using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 
@@ -10,6 +11,8 @@ namespace MigrationTools.DataContracts.Pipelines
     [ApiName("Task Groups")]
     public partial class TaskGroup : RestApiDefinition
     {
+        protected ILogger Log { get; }
+
         public TaskElement[] Tasks { get; set; }
 
         public string[] RunsOn { get; set; }
@@ -78,12 +81,14 @@ namespace MigrationTools.DataContracts.Pipelines
 
         public override bool HasTaskGroups()
         {
-            throw new NotImplementedException("we currently not support taskgroup nesting.");
+            Log.LogError("we currently not support taskgroup nesting.");
+            return false;
         }
 
         public override bool HasVariableGroups()
         {
-            throw new NotImplementedException("we currently not support variablegroup nesting.");
+            Log.LogError("we currently not support variablegroup nesting.");
+            return false;
         }
 
         public override void ResetObject()

--- a/src/MigrationTools/DataContracts/Pipelines/TaskGroups.cs
+++ b/src/MigrationTools/DataContracts/Pipelines/TaskGroups.cs
@@ -6,13 +6,6 @@ using Newtonsoft.Json.Converters;
 
 namespace MigrationTools.DataContracts.Pipelines
 {
-    public partial class TaskGroups
-    {
-        public long Count { get; set; }
-
-        public TaskGroup[] Value { get; set; }
-    }
-
     [ApiPath("distributedtask/taskgroups")]
     [ApiName("Task Groups")]
     public partial class TaskGroup : RestApiDefinition

--- a/src/MigrationTools/DataContracts/Pipelines/TaskGroups.cs
+++ b/src/MigrationTools/DataContracts/Pipelines/TaskGroups.cs
@@ -81,9 +81,13 @@ namespace MigrationTools.DataContracts.Pipelines
             throw new NotImplementedException("we currently not support taskgroup nesting.");
         }
 
-        public override RestApiDefinition ResetObject()
+        public override bool HasVariableGroups()
         {
-            return this;
+            throw new NotImplementedException("we currently not support variablegroup nesting.");
+        }
+
+        public override void ResetObject()
+        {
         }
     }
 

--- a/src/MigrationTools/DataContracts/Pipelines/VariableGroups.cs
+++ b/src/MigrationTools/DataContracts/Pipelines/VariableGroups.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Dynamic;
+using Microsoft.Extensions.Logging;
 
 namespace MigrationTools.DataContracts.Pipelines
 {
@@ -8,6 +9,8 @@ namespace MigrationTools.DataContracts.Pipelines
     [ApiName("Variable Groups")]
     public class VariableGroups : RestApiDefinition
     {
+        protected ILogger Log { get; }
+
         public ExpandoObject Variables { get; set; }
         public string Type { get; set; }
         public Createdby CreatedBy { get; set; }
@@ -18,12 +21,14 @@ namespace MigrationTools.DataContracts.Pipelines
 
         public override bool HasTaskGroups()
         {
-            throw new NotImplementedException("we currently not support taskgroup nesting.");
+            Log.LogError("we currently not support taskgroup nesting.");
+            return false;
         }
 
         public override bool HasVariableGroups()
         {
-            throw new NotImplementedException("we currently not support variablegroup nesting.");
+            Log.LogError("we currently not support variablegroup nesting.");
+            return false;
         }
 
         public override void ResetObject()

--- a/src/MigrationTools/DataContracts/Pipelines/VariableGroups.cs
+++ b/src/MigrationTools/DataContracts/Pipelines/VariableGroups.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Dynamic;
+
+namespace MigrationTools.DataContracts.Pipelines
+{
+
+    [ApiPath("distributedtask/variablegroups")]
+    [ApiName("Variable Groups")]
+    public class VariableGroups : RestApiDefinition
+    {
+        public ExpandoObject Variables { get; set; }
+        public string Type { get; set; }
+        public Createdby CreatedBy { get; set; }
+        public string CreatedOn { get; set; }
+        public Modifiedby ModifiedBy { get; set; }
+        public string ModifiedOn { get; set; }
+        public bool IsShared { get; set; }
+
+        public override bool HasTaskGroups()
+        {
+            throw new NotImplementedException("we currently not support taskgroup nesting.");
+        }
+
+        public override bool HasVariableGroups()
+        {
+            throw new NotImplementedException("we currently not support variablegroup nesting.");
+        }
+
+        public override void ResetObject()
+        {
+            Id = null;
+            CreatedBy = null;
+            CreatedOn = null;
+            ModifiedBy = null;
+            ModifiedOn = null;
+        }
+    }
+
+    public class Createdby
+    {
+        public string displayName { get; set; }
+        public string id { get; set; }
+        public string uniqueName { get; set; }
+    }
+
+    public class Modifiedby
+    {
+        public string displayName { get; set; }
+        public string id { get; set; }
+        public string uniqueName { get; set; }
+    }
+}

--- a/src/MigrationTools/DataContracts/RestApiDefinition.cs
+++ b/src/MigrationTools/DataContracts/RestApiDefinition.cs
@@ -12,6 +12,13 @@ namespace MigrationTools.DataContracts
         /// </summary>
         /// <returns>The clean RestApiDefinition</returns>
         public abstract RestApiDefinition ResetObject();
+        public abstract bool HasTaskGroups();
+    }
+
+    public class TaskGroupStore
+    {
+        public string Name { get; set; }
+        public string Id { get; set; }
     }
 
     public class RestResultDefinition<ValueType> where ValueType : RestApiDefinition, new()

--- a/src/MigrationTools/DataContracts/RestApiDefinition.cs
+++ b/src/MigrationTools/DataContracts/RestApiDefinition.cs
@@ -12,7 +12,17 @@ namespace MigrationTools.DataContracts
         /// </summary>
         /// <returns>The clean RestApiDefinition</returns>
         public abstract void ResetObject();
+
+        /// <summary>
+        /// Checks whether the Definition references Taskgroups
+        /// </summary>
+        /// <returns>bool</returns>
         public abstract bool HasTaskGroups();
+
+        /// <summary>
+        /// Checks whether the Definition references Variablegroups
+        /// </summary>
+        /// <returns>bool</returns>
         public abstract bool HasVariableGroups();
     }
 

--- a/src/MigrationTools/DataContracts/RestApiDefinition.cs
+++ b/src/MigrationTools/DataContracts/RestApiDefinition.cs
@@ -16,12 +16,6 @@ namespace MigrationTools.DataContracts
         public abstract bool HasVariableGroups();
     }
 
-    public class TaskGroupStore
-    {
-        public string Name { get; set; }
-        public string Id { get; set; }
-    }
-
     public class RestResultDefinition<ValueType> where ValueType : RestApiDefinition, new()
     {
         public long Count { get; set; }

--- a/src/MigrationTools/DataContracts/RestApiDefinition.cs
+++ b/src/MigrationTools/DataContracts/RestApiDefinition.cs
@@ -11,8 +11,9 @@ namespace MigrationTools.DataContracts
         /// reset values that cannot be set on new objects
         /// </summary>
         /// <returns>The clean RestApiDefinition</returns>
-        public abstract RestApiDefinition ResetObject();
+        public abstract void ResetObject();
         public abstract bool HasTaskGroups();
+        public abstract bool HasVariableGroups();
     }
 
     public class TaskGroupStore

--- a/src/MigrationTools/Tests/TestingConstants.cs
+++ b/src/MigrationTools/Tests/TestingConstants.cs
@@ -2,6 +2,6 @@
 {
     public static class TestingConstants
     {
-        public static readonly string AccessToken = "qosss7crwz3vie4fupzpaafjndoy6g6ulgkzhoxtmjgicv2lqjyq";
+        public static readonly string AccessToken = "iksmyfwmracmyqb22p2rlytagg6mpzxu7ntowjvpihvk4fwcjzcq";
     }
 }


### PR DESCRIPTION
- Add migration of Task and Variable Groups
- Map their IDs to the new ones in the target environment so Pipelines can reference them

Unfortunately, the nice Generic code isn't as pretty anymore since I had to add a method for every Definition Type. That is because their Structure differs too much from each other.