### PR TITLE
fix null reference runtime exception

### DIFF
--- a/src/MigrationTools.Clients.AzureDevops.ObjectModel/_Enginev1/Clients/TfsWorkItemMigrationClient.cs
+++ b/src/MigrationTools.Clients.AzureDevops.ObjectModel/_Enginev1/Clients/TfsWorkItemMigrationClient.cs
@@ -51,7 +51,10 @@ namespace MigrationTools._EngineV1.Clients
             var targetFoundItems = GetWorkItems(targetQuery);
             Log.Debug("FilterByTarget: ... query complete.");
             Log.Debug("FilterByTarget: Found {TargetWorkItemCount} based on the WIQLQueryBit in the target system.", targetFoundItems.Count);
-            var targetFoundIds = (from WorkItemData twi in targetFoundItems select GetReflectedWorkItemId(twi)).ToList();
+            var targetFoundIds = (from WorkItemData twi in targetFoundItems select GetReflectedWorkItemId(twi))
+                //exclude null IDs
+                .Where(x=> x != null)
+                .ToList();
             //////////////////////////////////////////////////////////
             sourceWorkItems = sourceWorkItems.Where(p => targetFoundIds.All(p2 => p2.ToString() != sourceWorkItemMigrationClient.CreateReflectedWorkItemId(p).ToString())).ToList();
             Log.Debug("FilterByTarget: After removing all found work items there are {SourceWorkItemCount} remaining to be migrated.", sourceWorkItems.Count);


### PR DESCRIPTION
Upgrading from 11.9.6 to 11.9.17 started throwing a "Object reference not set to an instance of an object" error. 

![image](https://user-images.githubusercontent.com/2544493/101183366-6ddbb980-361d-11eb-9442-eaaade7dfab0.png)

For this particular work item, it has the field for reflectedWorkItemId, (named "Custom.ReflectedWorkItemId"), but the value is empty string. 

![image](https://user-images.githubusercontent.com/2544493/101184111-518c4c80-361e-11eb-9e87-593b83760ee5.png)

This PR fixes the runtime error, but I don't know enough about the project to know if this is actually the right fix. Perhaps we should be preventing work items with null reflectedWorkItemIds from getting to this function upstream somewhere, or perhaps this will happen for every "new" work item. I'll need someone more familiar with the project to review and verify this is the right fix. 
