### PR TITLE
fixing TfsSharedQueryProcessor example

### DIFF
--- a/docs/Reference/Processors/TfsSharedQueryProcessor.md
+++ b/docs/Reference/Processors/TfsSharedQueryProcessor.md
@@ -24,39 +24,57 @@ The TfsSharedQueryProcessor enabled you to migrate queries from one locatio nto 
 
 ```JSON
 {
-  "$type": "TfsSharedQueryProcessorOptions",
-  "Enabled": false,
-  "PrefixProjectToNodes": false,
-  "SharedFolderName": "Shared Queries",
-  "SourceToTargetFieldMappings": null,
-  "ProcessorEnrichers": null,
-  "Source": {
-    "$type": "TfsEndpointOptions",
-    "Organisation": "https://dev.azure.com/nkdagility-preview/",
-    "Project": "sourceProject",
-    "AuthenticationMode": "AccessToken",
-    "AccessToken": "6i4jyylsadkjanjniaydxnjsi4zsz3qarxhl2y5ngzzffiqdostq",
-    "ReflectedWorkItemIdField": "Custom.ReflectedWorkItemId",
-    "LanguageMaps": {
-      "$type": "TfsLanguageMapOptions",
-      "AreaPath": "Area",
-      "IterationPath": "Iteration"
+    "Version": "11.9",
+    "LogLevel": "Verbose",
+    
+    "Endpoints": {
+      "TfsEndpoints": [
+        {
+          "Name": "Source",
+          "AccessToken": "",
+          "Query": {
+            "Query": "SELECT [System.Id], [System.Tags] FROM WorkItems WHERE [System.TeamProject] = @TeamProject AND [System.WorkItemType] NOT IN ('Test Suite', 'Test Plan') ORDER BY [System.ChangedDate] desc"
+          },
+          "Organisation": "https://dev.azure.com/like10-demos/",
+          "Project": "SourceProject",
+          "ReflectedWorkItemIdField": "Custom.ReflectedWorkItemId",
+          "AuthenticationMode": "Prompt",
+          "AllowCrossProjectLinking": false,
+          "PersonalAccessToken": "",
+          "LanguageMaps": {
+            "AreaPath": "Area",
+            "IterationPath": "Iteration"
+          }
+        },
+        {
+          "Name": "Target",
+          "AccessToken": "",
+          "Query": {
+            "Query": "SELECT [System.Id], [System.Tags] FROM WorkItems WHERE [System.TeamProject] = @TeamProject AND [System.WorkItemType] NOT IN ('Test Suite', 'Test Plan') ORDER BY [System.ChangedDate] desc"
+          },
+          "Organisation": "https://dev.azure.com/like10-demos/",
+          "Project": "TargetProject",
+          "ReflectedWorkItemIdField": "nkdScrum.ReflectedWorkItemId",
+          "AuthenticationMode": "Prompt",
+          "AllowCrossProjectLinking": false,
+          "LanguageMaps": {
+            "AreaPath": "Area",
+            "IterationPath": "Iteration"
+          }
+        }
+      ]
     },
-    "EndpointEnrichers": null
-  },
-  "Target": {
-    "$type": "TfsEndpointOptions",
-    "Organisation": "https://dev.azure.com/nkdagility-preview/",
-    "Project": "targetProject",
-    "AuthenticationMode": "AccessToken",
-    "AccessToken": "6i4jyylsadkjanjniaydxnjsi4zsz3qarxhl2y5ngzzffiqdostq",
-    "ReflectedWorkItemIdField": "Custom.ReflectedWorkItemId",
-    "LanguageMaps": {
-      "$type": "TfsLanguageMapOptions",
-      "AreaPath": "Area",
-      "IterationPath": "Iteration"
-    },
-    "EndpointEnrichers": null
+    "Processors": [     
+      {
+        "$type": "TfsSharedQueryProcessorOptions",
+        "Enabled": true,
+        "PrefixProjectToNodes": false,
+        "SharedFolderName": "Shared Queries",
+        "SourceToTargetFieldMappings": null,
+        "ProcessorEnrichers": null,
+        "SourceName": "Source",
+        "TargetName": "Target",
+      }
+    ]
   }
-}
 ```


### PR DESCRIPTION
Using the previous example on this [page](https://nkdagility.github.io/azure-devops-migration-tools/Reference/Processors/TfsSharedQueryProcessor.html), the run would fail because SourceName and TargetName were null which through an error:

```shell
[10:17:34 INF] Creating Migration Engine 783f2326-550a-4736-8a4c-0e708326b6a2
[10:17:34 INF] ProcessorContainer: Of 6 configured Processors only 1 are enabled
[10:17:34 INF] ProcessorContainer: Adding Processor TfsSharedQueryProcessor
[10:17:34 INF] Processor::Configure
[10:17:34 ERR] Unhandled exception!
System.ArgumentNullException: Value cannot be null.
Parameter name: name
   at MigrationTools.Endpoints.EndpointFactory.CreateEndpoint(String name) in D:\a\1\s\src\MigrationTools\Endpoints\EndpointFactory.cs:line 43
   at MigrationTools.Processors.Processor.Configure(IProcessorOptions options) in D:\a\1\s\src\MigrationTools\Processors\Processor.cs:line 50
   at MigrationTools.Processors.TfsSharedQueryProcessor.Configure(IProcessorOptions options) in D:\a\1\s\src\MigrationTools.Clients.AzureDevops.ObjectModel\Processors\TfsSharedQueryProcessor.cs:line 38
   at MigrationTools._EngineV1.Containers.ProcessorContainer.Configure() in D:\a\1\s\src\MigrationTools\_EngineV1\Containers\ProcessorContainer.cs:line 61
   at MigrationTools.MigrationEngine.Run() in D:\a\1\s\src\MigrationTools\MigrationEngine.cs:line 87
   at MigrationTools.Host.ExecuteHostedService.<StartAsync>b__5_1() in D:\a\1\s\src\MigrationTools.Host\ExecuteHostedService.cs:line 38
[10:17:34 INF] Application is shutting down...
[10:17:34 DBG] Hosting stopping
[10:17:34 DBG] Exiting with return code: 1
[10:17:34 INF] Terminating: Application forcebly closed.
[10:17:34 INF] Application Ending
[10:17:34 INF] The application ran in 00:00:01.1062162 and finished at 02/24/2021 10:17:34
```

Not sure if there is something else I should be doing instead - but this config worked for me whereas the previous example did not. I tried debugging and it looks like the code is trying to create a default source name / target name [here](https://github.com/nkdAgility/azure-devops-migration-tools/blob/master/src/MigrationTools.Clients.AzureDevops.ObjectModel/Processors/TfsSharedQueryProcessorOptions.cs#L45)  

It also appears it tries to create the endpoint if it doesn't exist, but that wasn't the case ([here](https://github.com/nkdAgility/azure-devops-migration-tools/blob/master/src/MigrationTools/Endpoints/EndpointFactory.cs#L45)).


The [Unit Test](https://github.com/nkdAgility/azure-devops-migration-tools/blob/master/src/MigrationTools.Clients.AzureDevops.ObjectModel.Tests/Processors/TfsSharedQueryProcessorTests.cs#L41) used `SourceName = "Source"` and `TargetName = "Target"`, which led me to try this.

Feel free to reject / suggest changes / fix it any way you feel. I just wanted to document an error and a potential fix for others. 