### PR TITLE
TestPlansAndSuitesMigrationContext crashes with System.IndexOutOfRangeException

### DIFF
--- a/src/MigrationTools.Extension/README.md
+++ b/src/MigrationTools.Extension/README.md
@@ -40,6 +40,7 @@ before you move to Azure DevOps.
 
 ## Quick Links
 
+ - [Start Here]()
  - [Video Overview](https://youtu.be/ZxDktQae10M)
  - [Getting Started](http://nkdagility.github.io/azure-devops-migration-tools/getting-started)
  - [Documentation](http://nkdagility.github.io/azure-devops-migration-tools/)

--- a/src/MigrationTools.Extension/vss-extension.json
+++ b/src/MigrationTools.Extension/vss-extension.json
@@ -40,7 +40,7 @@
       "uri": "https://nkdagility.github.io/azure-devops-migration-tools/"
     },
     "support": {
-      "uri": "https://stackoverflow.com/questions/tagged/azure-devops-migration-tools"
+      "uri": "https://github.com/nkdAgility/azure-devops-migration-tools/discussions"
     },
     "repository": {
       "uri": "https://github.com/nkdAgility/azure-devops-migration-tools"
@@ -51,7 +51,7 @@
   },
   "CustomerQnASupport": {
     "enableqna": "true",
-    "url": "https://stackoverflow.com/questions/tagged/azure-devops-migration-tools"
+    "url": "https://github.com/nkdAgility/azure-devops-migration-tools/discussions"
   },
   "badges": [
     {

--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/TestPlansAndSuitesMigrationContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/TestPlansAndSuitesMigrationContext.cs
@@ -963,7 +963,7 @@ namespace VstsSyncMigrator.Engine
             }
             catch (TestManagementServerException ex)
             {
-                Log.LogError(ex, " FAILED {TestSuiteType} : {Id} - {Title}",
+                Log.LogError(ex, " FAILED {TestSuiteType} : {Id} - {Title}", newTestSuite.TestSuiteType.ToString(), newTestSuite.Id.ToString(), newTestSuite.Title,
                       new Dictionary<string, string> {
                           { "Name", Name},
                           { "Target Project", Engine.Target.Config.AsTeamProjectConfig().Project},


### PR DESCRIPTION
I think this error is due to Log.LogError being different from Serilog. 

```
                Log.LogError(ex, " FAILED {TestSuiteType} : {Id} - {Title}",
                      new Dictionary<string, string> {
                          { "Name", Name},
                          { "Target Project", Engine.Target.Config.AsTeamProjectConfig().Project},
                          { "Target Collection", Engine.Target.Config.AsTeamProjectConfig().Collection.ToString() },
                          { "Source Project", Engine.Source.Config.AsTeamProjectConfig().Project},
                          { "Source Collection", Engine.Source.Config.AsTeamProjectConfig().Collection.ToString() },
                          { "Status", Status.ToString() },
                          { "Task", "SaveNewTestSuitToPlan" },
                          { "Id", newTestSuite.Id.ToString()},
                          { "Title", newTestSuite.Title},
                          { "TestSuiteType", newTestSuite.TestSuiteType.ToString()}
                      });
```
The code above is invalid as the OOB logger cant parse the dictionary. I think changing this to pass the variables that it needs directly and then the dictionary will work.