### PR TITLE
Repair sourceId <-> targetId mapping for Pipeline Processor

### DIFF
--- a/src/MigrationTools.Clients.AzureDevops.Rest/Endpoints/AzureDevOpsEndpoint.cs
+++ b/src/MigrationTools.Clients.AzureDevops.Rest/Endpoints/AzureDevOpsEndpoint.cs
@@ -290,7 +290,7 @@ namespace MigrationTools.Endpoints
                     migratedDefinitions.Add(new Mapping()
                     {
                         Name = definitionToBeMigrated.Name,
-                        SourceId = definitionToBeMigrated.Id,
+                        SourceId = definitionToBeMigrated.GetSourceId(),
                         TargetId = targetObject.Id
                     });
                 }

--- a/src/MigrationTools.Clients.AzureDevops.Rest/Processors/AzureDevOpsPipelineProcessor.cs
+++ b/src/MigrationTools.Clients.AzureDevops.Rest/Processors/AzureDevOpsPipelineProcessor.cs
@@ -80,13 +80,13 @@ namespace MigrationTools.Processors
             {
                 serviceConnectionMappings = await CreateServiceConnectionsAsync();
             }
-            if (_Options.MigrateTaskGroups)
-            {
-                taskGroupMappings = await CreateTaskGroupDefinitionsAsync();
-            }
             if (_Options.MigrateVariableGroups)
             {
                 variableGroupMappings = await CreateVariableGroupDefinitionsAsync();
+            }
+            if (_Options.MigrateTaskGroups)
+            {
+                taskGroupMappings = await CreateTaskGroupDefinitionsAsync();
             }
             if (_Options.MigrateBuildPipelines)
             {

--- a/src/MigrationTools/DataContracts/Pipelines/BuildDefinitions.cs
+++ b/src/MigrationTools/DataContracts/Pipelines/BuildDefinitions.cs
@@ -63,6 +63,7 @@ namespace MigrationTools.DataContracts.Pipelines
         ///<inheritdoc/>
         public override void ResetObject()
         {
+            SetSourceId(Id);
             Links = null;
             AuthoredBy = null;
             Queue = null;

--- a/src/MigrationTools/DataContracts/Pipelines/ReleaseDefinitions.cs
+++ b/src/MigrationTools/DataContracts/Pipelines/ReleaseDefinitions.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Dynamic;
 using System.Linq;
-using Microsoft.VisualStudio.Services.Common;
 using Newtonsoft.Json;
 
 namespace MigrationTools.DataContracts.Pipelines
@@ -48,17 +47,15 @@ namespace MigrationTools.DataContracts.Pipelines
         ///<inheritdoc/>
         public override void ResetObject()
         {
+            SetSourceId(Id);
             Source = "restApi";
             Revision = 1;
-
             Links = null;
-
             Artifacts = null;
             Url = null;
             Links = null;
             Id = "0";
             Triggers = null;
-
             PipelineProcess = null;
 
             foreach (var env in Environments)
@@ -199,7 +196,7 @@ namespace MigrationTools.DataContracts.Pipelines
             Owner = null;
             BadgeUrl = null;
             CurrentRelease = null;
-            
+
             foreach (var deployPhase in DeployPhases)
             {
                 deployPhase.ResetObject();

--- a/src/MigrationTools/DataContracts/Pipelines/ServiceConnection.cs
+++ b/src/MigrationTools/DataContracts/Pipelines/ServiceConnection.cs
@@ -1,17 +1,10 @@
 ﻿using System;
-using System.Dynamic;
-using System.Globalization;
-using Microsoft.Extensions.Logging;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
-using Microsoft.VisualStudio.Services.Servicing.Client;
-using Microsoft.VisualStudio.Services.ServiceEndpoints.WebApi;
-using Microsoft.VisualStudio.Services.Common.Internal;
-using System.Runtime.Serialization;
 using System.Collections.Generic;
+using System.Runtime.Serialization;
+using Microsoft.VisualStudio.Services.Common.Internal;
+using Microsoft.VisualStudio.Services.ServiceEndpoints.WebApi;
 using Microsoft.VisualStudio.Services.WebApi;
 using Newtonsoft.Json.Linq;
-using System.Collections;
 
 namespace MigrationTools.DataContracts.Pipelines
 {
@@ -22,9 +15,7 @@ namespace MigrationTools.DataContracts.Pipelines
         [DataMember(EmitDefaultValue = false, Name = "Data")]
         private Dictionary<string, string> m_data;
 
-        //
-        // Summary:
-        //     Gets or sets the type of the endpoint.
+        // Summary: Gets or sets the type of the endpoint.
         [DataMember(EmitDefaultValue = false)]
         public string Type
         {
@@ -32,9 +23,7 @@ namespace MigrationTools.DataContracts.Pipelines
             set;
         }
 
-        //
-        // Summary:
-        //     Gets or sets the url of the endpoint.
+        // Summary: Gets or sets the url of the endpoint.
         [DataMember(EmitDefaultValue = false)]
         public Uri Url
         {
@@ -42,9 +31,7 @@ namespace MigrationTools.DataContracts.Pipelines
             set;
         }
 
-        //
-        // Summary:
-        //     Gets or sets the identity reference for the user who created the Service endpoint.
+        // Summary: Gets or sets the identity reference for the user who created the Service endpoint.
         [DataMember(EmitDefaultValue = false)]
         public IdentityRef CreatedBy
         {
@@ -52,9 +39,7 @@ namespace MigrationTools.DataContracts.Pipelines
             set;
         }
 
-        //
-        // Summary:
-        //     Gets or sets the description of endpoint.
+        // Summary: Gets or sets the description of endpoint.
         [DataMember(EmitDefaultValue = false)]
         public string Description
         {
@@ -62,9 +47,7 @@ namespace MigrationTools.DataContracts.Pipelines
             set;
         }
 
-        //
-        // Summary:
-        //     Gets or sets the authorization data for talking to the endpoint.
+        // Summary: Gets or sets the authorization data for talking to the endpoint.
         [DataMember(EmitDefaultValue = false)]
         public EndpointAuthorization Authorization
         {
@@ -72,9 +55,7 @@ namespace MigrationTools.DataContracts.Pipelines
             set;
         }
 
-        //
-        // Summary:
-        //     This is a deprecated field.
+        // Summary: This is a deprecated field.
         [DataMember(EmitDefaultValue = false)]
         public Guid GroupScopeId
         {
@@ -82,10 +63,7 @@ namespace MigrationTools.DataContracts.Pipelines
             internal set;
         }
 
-        //
-        // Summary:
-        //     Gets or sets the identity reference for the administrators group of the service
-        //     endpoint.
+        // Summary: Gets or sets the identity reference for the administrators group of the service endpoint.
         [DataMember(EmitDefaultValue = false)]
         public IdentityRef AdministratorsGroup
         {
@@ -93,9 +71,7 @@ namespace MigrationTools.DataContracts.Pipelines
             internal set;
         }
 
-        //
-        // Summary:
-        //     Gets or sets the identity reference for the readers group of the service endpoint.
+        // Summary: Gets or sets the identity reference for the readers group of the service endpoint.
         [DataMember(EmitDefaultValue = false)]
         public IdentityRef ReadersGroup
         {
@@ -103,9 +79,7 @@ namespace MigrationTools.DataContracts.Pipelines
             internal set;
         }
 
-        //
-        // Summary:
-        //     Gets the custom data associated with this endpoint.
+        // Summary: Gets the custom data associated with this endpoint.
         public IDictionary<string, string> Data
         {
             get
@@ -121,9 +95,7 @@ namespace MigrationTools.DataContracts.Pipelines
             }
         }
 
-        //
-        // Summary:
-        //     Indicates whether service endpoint is shared with other projects or not.
+        // Summary: Indicates whether service endpoint is shared with other projects or not.
         [DataMember(EmitDefaultValue = true)]
         public bool IsShared
         {
@@ -131,9 +103,7 @@ namespace MigrationTools.DataContracts.Pipelines
             set;
         }
 
-        //
-        // Summary:
-        //     EndPoint state indicator
+        // Summary: EndPoint state indicator
         [DataMember(EmitDefaultValue = true)]
         public bool IsReady
         {
@@ -141,9 +111,7 @@ namespace MigrationTools.DataContracts.Pipelines
             set;
         }
 
-        //
-        // Summary:
-        //     Error message during creation/deletion of endpoint
+        // Summary: Error message during creation/deletion of endpoint
         [DataMember(EmitDefaultValue = false)]
         public JObject OperationStatus
         {
@@ -151,9 +119,7 @@ namespace MigrationTools.DataContracts.Pipelines
             set;
         }
 
-        //
-        // Summary:
-        //     Owner of the endpoint Supported values are "library", "agentcloud"
+        // Summary: Owner of the endpoint Supported values are "library", "agentcloud"
         [DataMember(EmitDefaultValue = false)]
         public string Owner
         {
@@ -201,8 +167,11 @@ namespace MigrationTools.DataContracts.Pipelines
 
             return true;
         }
+
         public override void ResetObject()
         {
+            SetSourceId(Id);
+
             //Replace null Keys since it can't be null
             var parameters = Authorization.Parameters;
             bool hasNullKey = false;
@@ -235,5 +204,4 @@ namespace MigrationTools.DataContracts.Pipelines
             return false;
         }
     }
-
 }

--- a/src/MigrationTools/DataContracts/Pipelines/TaskGroups.cs
+++ b/src/MigrationTools/DataContracts/Pipelines/TaskGroups.cs
@@ -99,6 +99,7 @@ namespace MigrationTools.DataContracts.Pipelines
 
         public override void ResetObject()
         {
+            SetSourceId(Id);
             Revision = 0;
         }
     }

--- a/src/MigrationTools/DataContracts/Pipelines/VariableGroups.cs
+++ b/src/MigrationTools/DataContracts/Pipelines/VariableGroups.cs
@@ -1,10 +1,8 @@
-﻿using System;
-using System.Dynamic;
+﻿using System.Dynamic;
 using Microsoft.Extensions.Logging;
 
 namespace MigrationTools.DataContracts.Pipelines
 {
-
     [ApiPath("distributedtask/variablegroups")]
     [ApiName("Variable Groups")]
     public class VariableGroups : RestApiDefinition
@@ -35,6 +33,7 @@ namespace MigrationTools.DataContracts.Pipelines
 
         public override void ResetObject()
         {
+            SetSourceId(Id);
             Id = "0";
             CreatedBy = null;
             CreatedOn = null;

--- a/src/MigrationTools/DataContracts/RestApiDefinition.cs
+++ b/src/MigrationTools/DataContracts/RestApiDefinition.cs
@@ -4,8 +4,19 @@ namespace MigrationTools.DataContracts
 {
     public abstract class RestApiDefinition
     {
+        private string sId;
         public virtual string Name { get; set; }
         public virtual string Id { get; set; }
+
+        public string GetSourceId()
+        {
+            return sId;
+        }
+
+        public void SetSourceId(string id)
+        {
+            sId = id;
+        }
 
         /// <summary>
         /// reset values that cannot be set on new objects


### PR DESCRIPTION
Since the Pipeline / Definition gets reset (because the DevOps REST API doesn't accept some incoming values such as "Id") and the mapping is made afterward, to initial Id is gone.
Because of that, the mapping isn't resolved properly when running all pipeline options after each other. If you run just one option e.x VariableGroups, stop the Tool and then just migrate Release Definitions which use that Variable Groups, the mapping would be right since it is now created by comparing target and source names, instead of Ids. -> Id comparison/lookup is just used when creating a Definition

This PR changes that behavior. Before resetting the Definition, the initial Id gets set into a private variable, which later on (when the mapping gets created) is received again.
This way