### PR TITLE
#969 - A fix to FieldBlankMap to work with all types and avoid invalid value assignments.

### DIFF
--- a/src/MigrationTools.Clients.AzureDevops.ObjectModel/FieldMaps/FieldBlankMap.cs
+++ b/src/MigrationTools.Clients.AzureDevops.ObjectModel/FieldMaps/FieldBlankMap.cs
@@ -16,11 +16,25 @@ namespace MigrationTools.FieldMaps.AzureDevops.ObjectModel
 
         internal override void InternalExecute(WorkItem source, WorkItem target)
         {
-            if (target.Fields.Contains(Config.targetField))
-            {
-                target.Fields[Config.targetField].Value = "";
-                Log.LogDebug("FieldBlankMap: field mapped {0}:{1} to {2} blanked", source.Id, target.Id, this.Config.targetField);
+            if (!target.Fields.Contains(Config.targetField)) {
+                Log.LogDebug($"FieldBlankMap: target field does not exist '{Config.targetField}' for '{target.Type.Name}'");
+                return;
             }
+            var targetField = target.Fields[Config.targetField];
+            if (targetField.IsLimitedToAllowedValues && targetField.AllowedValues.Count > 0 && !targetField.AllowedValues.Contains(targetField.OriginalValue as string)) {
+                Log.LogDebug($"FieldBlankMap: target field '{Config.targetField}' is limited to allowed values list: '{string.Join("', '", targetField.AllowedValues)}'");
+                return;
+            }
+            if (!targetField.IsEditable) {
+                Log.LogDebug($"FieldBlankMap: target field '{Config.targetField}' is not editable!");
+                return;
+            }
+            if (targetField.IsRequired) {
+                Log.LogDebug($"FieldBlankMap: target field '{Config.targetField}' is required!");
+                return;
+            }
+            targetField.Value = targetField.OriginalValue;
+            Log.LogDebug("FieldBlankMap: field mapped {0}:{1} to {2} blanked", source.Id, target.Id, this.Config.targetField);
         }
     }
 }


### PR DESCRIPTION
A fix to FieldBlankMap to work with all types and avoid invalid value assignments.

The fix Initializes the field's value to be the "OriginalValue" of the field.
Also checks and avoids some cases where work items would be invalid and logs to Debug level.
I've tested with all system fields and many fields from inherited agile process and it seems to work as expected.


