### PR TITLE
A few tweaks to debugging and logging, and a made node path search case insensitive

### DIFF
--- a/src/MigrationTools.Clients.AzureDevops.ObjectModel/Enrichers/TfsWorkItemLinkEnricher.cs
+++ b/src/MigrationTools.Clients.AzureDevops.ObjectModel/Enrichers/TfsWorkItemLinkEnricher.cs
@@ -355,7 +355,7 @@ namespace MigrationTools.Enrichers
             var sourceLinkAbsoluteUri = GetAbsoluteUri(sourceLink);
             if (string.IsNullOrEmpty(sourceLinkAbsoluteUri))
             {
-                Log.LogWarning($"  [SKIP] Unable to create a hyperlink to [{sourceLink.Location}]");
+                Log.LogWarning("  [SKIP] Unable to create a hyperlink to [{0}]", sourceLink.Location);
                 return;
             }
 
@@ -389,7 +389,7 @@ namespace MigrationTools.Enrichers
             }
             catch (UriFormatException e)
             {
-                Log.LogError($"Unable to get AbsoluteUri of [{hyperlink.Location}]: {e.Message}");
+                Log.LogError("Unable to get AbsoluteUri of [{0}]: {1}", hyperlink.Location, e.Message);
                 return null;
             }
         }

--- a/src/MigrationTools.Clients.AzureDevops.ObjectModel/FieldMaps/FieldBlankMap.cs
+++ b/src/MigrationTools.Clients.AzureDevops.ObjectModel/FieldMaps/FieldBlankMap.cs
@@ -17,20 +17,20 @@ namespace MigrationTools.FieldMaps.AzureDevops.ObjectModel
         internal override void InternalExecute(WorkItem source, WorkItem target)
         {
             if (!target.Fields.Contains(Config.targetField)) {
-                Log.LogDebug($"FieldBlankMap: target field does not exist '{Config.targetField}' for '{target.Type.Name}'");
+                Log.LogDebug("FieldBlankMap: target field does not exist '{0}' for '{1}'", Config.targetField, target.Type.Name);
                 return;
             }
             var targetField = target.Fields[Config.targetField];
             if (targetField.IsLimitedToAllowedValues && targetField.AllowedValues.Count > 0 && !targetField.AllowedValues.Contains(targetField.OriginalValue as string)) {
-                Log.LogDebug($"FieldBlankMap: target field '{Config.targetField}' is limited to allowed values list: '{string.Join("', '", targetField.AllowedValues)}'");
+                Log.LogDebug("FieldBlankMap: target field '{0}' is limited to allowed values list: '{1}'", Config.targetField, string.Join("', '", targetField.AllowedValues));
                 return;
             }
             if (!targetField.IsEditable) {
-                Log.LogDebug($"FieldBlankMap: target field '{Config.targetField}' is not editable!");
+                Log.LogDebug("FieldBlankMap: target field '{0}' is not editable!", Config.targetField);
                 return;
             }
             if (targetField.IsRequired) {
-                Log.LogDebug($"FieldBlankMap: target field '{Config.targetField}' is required!");
+                Log.LogDebug("FieldBlankMap: target field '{0}' is required!", Config.targetField);
                 return;
             }
             targetField.Value = targetField.OriginalValue;

--- a/src/MigrationTools.Clients.AzureDevops.ObjectModel/ProcessorEnrichers/TfsNodeStructure.cs
+++ b/src/MigrationTools.Clients.AzureDevops.ObjectModel/ProcessorEnrichers/TfsNodeStructure.cs
@@ -302,11 +302,14 @@ namespace MigrationTools.Enrichers
         private void ProcessCommonStructure(string treeTypeSource, string sourceTarget, string treeTypeTarget, string projectTarget)
         {
             Log.LogDebug("NodeStructureEnricher.ProcessCommonStructure({treeTypeSource}, {treeTypeTarget})", treeTypeSource, treeTypeTarget);
+
+            var startPath = ("\\" + this._sourceProjectName + "\\" + treeTypeSource).ToLower();
+            Log.LogDebug("Source Node Path StartsWith [{startPath}]", startPath);
+
             var nodes = _sourceRootNodes.Where((n) =>
             {
                 // (i.e. "\CoolProject\Area" )
-                var startPath = "\\" + this._sourceProjectName + "\\" + treeTypeSource;
-                return n.Path.StartsWith(startPath);
+                return n.Path.ToLower().StartsWith(startPath);
             });
             if (nodes.Count() > 1)
             {

--- a/src/MigrationTools.Clients.AzureDevops.ObjectModel/TfsExtensions.cs
+++ b/src/MigrationTools.Clients.AzureDevops.ObjectModel/TfsExtensions.cs
@@ -138,11 +138,21 @@ namespace MigrationTools
 
         public static List<WorkItemData> ToWorkItemDataList(this IList<WorkItem> collection)
         {
+            Log.Debug("Loading {0} Work Items", collection.Count);
             List<WorkItemData> list = new List<WorkItemData>();
+            var counter = 0;
+            var lastProgressUpdate = DateTime.Now.AddDays(-1);
             foreach (WorkItem wi in collection)
             {
+                counter++;
+                if ((System.DateTime.Now - lastProgressUpdate).TotalSeconds > 10)
+                {
+                    Log.Debug("{0}/{1} {2}", counter, collection.Count, (1.0  * counter/collection.Count).ToString("#0.##%", System.Globalization.CultureInfo.InvariantCulture));
+                    lastProgressUpdate = DateTime.Now;
+                }
                 list.Add(wi.AsWorkItemData());
             }
+            Log.Debug("{0} Work Items loaded", collection.Count);
             return list;
         }
     }

--- a/src/MigrationTools.Clients.AzureDevops.ObjectModel/_Enginev1/Clients/TfsWorkItemQuery.cs
+++ b/src/MigrationTools.Clients.AzureDevops.ObjectModel/_Enginev1/Clients/TfsWorkItemQuery.cs
@@ -41,7 +41,9 @@ namespace MigrationTools._EngineV1.Clients
             WorkItemCollection workItemCollection;
             try
             {
+                Log.Debug("Query sent");
                 workItemCollection = wiClient.Store.Query(Query);
+                Log.Debug("{0} Work items received, verifying", workItemCollection.Count);
                 foreach (WorkItem item in workItemCollection)
                 {
                     try

--- a/src/MigrationTools.Clients.AzureDevops.Rest/Endpoints/AzureDevOpsEndpoint.cs
+++ b/src/MigrationTools.Clients.AzureDevops.Rest/Endpoints/AzureDevOpsEndpoint.cs
@@ -489,7 +489,7 @@ namespace MigrationTools.Endpoints
                 }
                 else
                 {
-                    Log.LogInformation($"Created target {typeof(DefinitionType).Name} entry for [{targetDef.Name}] in [{Options.Name}]");
+                    Log.LogInformation("Created target {0} entry for [{1}] in [{2}]", typeof(DefinitionType).Name, targetDef.Name, Options.Name);
                 }
             }
             else
@@ -504,7 +504,7 @@ namespace MigrationTools.Endpoints
                 }
                 else
                 {
-                    Log.LogInformation($"Updated target {typeof(DefinitionType).Name} entry for [{targetDef.Name}] in [{Options.Name}]");
+                    Log.LogInformation("Updated target {0} entry for [{1}] in [{2}]", typeof(DefinitionType).Name, targetDef.Name, Options.Name);
                 }
             }
 

--- a/src/MigrationTools.Clients.AzureDevops.Rest/Processors/ProcessDefinitionProcessor.cs
+++ b/src/MigrationTools.Clients.AzureDevops.Rest/Processors/ProcessDefinitionProcessor.cs
@@ -197,7 +197,7 @@ namespace MigrationTools.Processors
             {
                 if (state.StateCategory == "Completed")
                 {
-                    Log.LogWarning($"Cannot modify [Completed] category on work item state [{state.Name}] on wit type [{sourceWit.WorkItemType.ReferenceName}].");
+                    Log.LogWarning("Cannot modify [Completed] category on work item state [{0}] on wit type [{1}].", state.Name, sourceWit.WorkItemType.ReferenceName);
                 }
                 else
                 {
@@ -210,7 +210,7 @@ namespace MigrationTools.Processors
             foreach (var field in sourceWit.Fields)
             {
                 var existingField = TargetModel.WorkItemFields.Values.FirstOrDefault(x => x.ReferenceName == field.ReferenceName);
-                //if (existingField == null || (existingField != null && field.Customization != "system")) // I don't think you can modify 
+                //if (existingField == null || (existingField != null && field.Customization != "system")) // I don't think you can modify
                 //{
                     await SyncDefinitionType<WorkItemTypeField>(
                         TargetModel.WorkItemFields,
@@ -283,7 +283,7 @@ namespace MigrationTools.Processors
                                 if (sourceGroupKey.Equals(existingGroup.Key, StringComparison.OrdinalIgnoreCase))
                                 {
                                     // It's on the same page/section.. no need to move
-                                    Log.LogInformation($"Target group [{targetPage.Label}:{existingGroup.Value.Label}] located on same page/section. Skipping group location sync..");
+                                    Log.LogInformation("Target group [{0}:{1}] located on same page/section. Skipping group location sync..", targetPage.Label, existingGroup.Value.Label);
                                     finalTargetPage = targetPage;
                                     finalTargetGroup = existingGroup.Value;
                                 }
@@ -304,18 +304,18 @@ namespace MigrationTools.Processors
                                             tempTargetGroup, processId, sourceWit.WorkItemType.ReferenceName,
                                             targetPage.Id, sourceSplit[2], existingSplit[2]))
                                         {
-                                            Log.LogInformation($"Target group [{sourceGroup.Label}] located on same page but different section. Moved from [{sourceSplit[2]}] to [{existingSplit[2]}] ..");
+                                            Log.LogInformation("Target group [{0}] located on same page but different section. Moved from [{1}] to [{2}] ..", sourceGroup.Label, sourceSplit[2], existingSplit[2]);
                                         }
                                         else
                                         {
-                                            Log.LogError($"Target group [{sourceGroup.Label}] located on same page but different section. Unable to move from [{sourceSplit[2]}] to [{existingSplit[2]}] ..");
+                                            Log.LogError("Target group [{0}] located on same page but different section. Unable to move from [{1}] to [{2}] ..", sourceGroup.Label, sourceSplit[2], existingSplit[2]);
                                         }
                                         finalTargetPage = existingPage;
                                         finalTargetGroup = tempTargetGroup;
                                     }
                                     else
                                     {
-                                        
+
                                         // Its on a different page .. lets move pages
                                         var tempTargetGroup = existingGroup.Value.CloneAsNew();
                                         tempTargetGroup.Id = existingGroup.Value.Id;
@@ -323,11 +323,11 @@ namespace MigrationTools.Processors
                                             tempTargetGroup, processId, targetWit.WorkItemType.ReferenceName,
                                             targetPage.Id, sourceSplit[2], existingPage.Id, existingSplit[2]))
                                         {
-                                            Log.LogInformation($"Target group located on different page. Moved from [{sourceSplit[1]}:{sourceSplit[2]}] to [{existingSplit[1]}:{existingSplit[2]}] ..");
+                                            Log.LogInformation("Target group located on different page. Moved from [{0}:{1}] to [{2}:{3}] ..", sourceSplit[1], sourceSplit[2], existingSplit[1], existingSplit[2]);
                                         }
                                         else
                                         {
-                                            Log.LogError($"Target group located on different page. Unable to move from [{existingSplit[1]}:{existingSplit[2]}] to [{targetPage.Label}:{sourceSplit[2]}]!");
+                                            Log.LogError("Target group located on different page. Unable to move from [{0}:{1}] to [{2}:{3}]!", existingSplit[1], existingSplit[2], targetPage.Label, sourceSplit[2]);
                                         }
                                         finalTargetPage = existingPage;
                                         finalTargetGroup = tempTargetGroup;
@@ -340,7 +340,7 @@ namespace MigrationTools.Processors
                                 {
                                     if (sourceControl.ControlType == "HtmlFieldControl")
                                     {
-                                        Log.LogWarning($"Skipped HTML control sync [{sourceControl.Label}] as it should have already been migrated as part of the group sync.");
+                                        Log.LogWarning("Skipped HTML control sync [{0}] as it should have already been migrated as part of the group sync.", sourceControl.Label);
                                     }
                                     else
                                     {
@@ -364,11 +364,11 @@ namespace MigrationTools.Processors
                                             {
                                                 if (await Target.AddWorkItemControlToGroup(sourceControl.CloneAsNew(), processId, sourceWit.WorkItemType.ReferenceName, finalTargetGroup.Id, sourceControl.Id))
                                                 {
-                                                    Log.LogInformation($"Attached control [{sourceControl.Label}] to group [{finalTargetGroup.Label}].");
+                                                    Log.LogInformation("Attached control [{0}] to group [{1}].", sourceControl.Label, finalTargetGroup.Label);
                                                 }
                                                 else
                                                 {
-                                                    Log.LogError($"Failed to attach control [{sourceControl.Label}] to new group [{finalTargetGroup.Label}]!");
+                                                    Log.LogError("Failed to attach control [{0}] to new group [{1}]!", sourceControl.Label, finalTargetGroup.Label);
                                                 }
                                             }
                                             else
@@ -376,18 +376,18 @@ namespace MigrationTools.Processors
                                                 // It must be control movement between groups
                                                 if (await Target.MoveWorkItemControlToOtherGroup(sourceControl.CloneAsNew(), processId, sourceWit.WorkItemType.ReferenceName, finalTargetGroup.Id, sourceControl.Id, oldGroup.Id))
                                                 {
-                                                    Log.LogInformation($"Moved control [{sourceControl.Id}] from [{oldGroup.Label}] to existing group [{finalTargetGroup.Label}].");
+                                                    Log.LogInformation("Moved control [{0}] from [{1}] to existing group [{2}].", sourceControl.Id, oldGroup.Label, finalTargetGroup.Label);
                                                 }
                                                 else
                                                 {
-                                                    Log.LogError($"Failed to move control [{sourceControl.Id}] from [{oldGroup.Label}] to existing group [{finalTargetGroup.Label}].");
+                                                    Log.LogError("Failed to move control [{0}] from [{1}] to existing group [{2}].", sourceControl.Id, oldGroup.Label, finalTargetGroup.Label);
                                                 }
                                             }
                                         }
                                         else
                                         {
                                             {
-                                                Log.LogInformation($"Target already contains control [{sourceControl.Label}] in proper group [{finalTargetGroup.Label}].");
+                                                Log.LogInformation("Target already contains control [{0}] in proper group [{1}].", sourceControl.Label, finalTargetGroup.Label);
                                             }
                                         }
                                     }
@@ -404,11 +404,11 @@ namespace MigrationTools.Processors
                                 {
                                     if (await Target.AddWorkItemControlToGroup(sourceControl.CloneAsNew(), processId, sourceWit.WorkItemType.ReferenceName, newGroup.Id, sourceControl.Id))
                                     {
-                                        Log.LogInformation($"Attached control [{sourceControl.Label}] to new group [{newGroup.Label}].");
+                                        Log.LogInformation("Attached control [{0}] to new group [{1}].", sourceControl.Label, newGroup.Label);
                                     }
                                     else
                                     {
-                                        Log.LogError($"Failed to attach control [{sourceControl.Label}] to new group [{newGroup.Label}]!");
+                                        Log.LogError("Failed to attach control [{0}] to new group [{1}]!", sourceControl.Label, newGroup.Label);
                                     }
                                 }
                             }
@@ -441,7 +441,7 @@ namespace MigrationTools.Processors
             Log.LogInformation($"Completed sync of work item type [{Source.Options.Name}::{sourceWit.WorkItemType.Name}] in [{Target.Options.Name}::{targetWit.WorkItemType.Name}].");
         }
 
-        
+
 
         private async Task<DefinitionType> SyncDefinitionType<DefinitionType>(Dictionary<string, DefinitionType> DataDictionary, DefinitionType sourceDef, DefinitionType targetDef, params string[] routeParams)
             where DefinitionType : RestApiDefinition, ISynchronizeable<DefinitionType>, new()
@@ -463,7 +463,7 @@ namespace MigrationTools.Processors
         private async Task BuildModel(ProcessorModel model, AzureDevOpsEndpoint endpoint, bool warnOnMissing)
         {
             // Grab all the procs, then iterate over them looking for procs user has configured to be
-            // sync'd. Then grab all Work Item Types for the given process and filter those by the ones user 
+            // sync'd. Then grab all Work Item Types for the given process and filter those by the ones user
             // wants to sync.
 
             Log.LogDebug($"Loading model for [{endpoint.Options.Name}].");

--- a/src/MigrationTools/Endpoints/EndpointFactory.cs
+++ b/src/MigrationTools/Endpoints/EndpointFactory.cs
@@ -44,9 +44,15 @@ namespace MigrationTools.Endpoints
             }
             _logger.LogInformation("Creating endpoint with name {EndpointName}", name);
             EndpointFactoryOptions options = _optionsMonitor.Get(name);
-            if(options.EndpointFuncs.Count != 1)
+
+            if (options.EndpointFuncs.Count == 0)
             {
-                throw new InvalidOperationException("There is no endpoint named that or duplicates of the same name");
+                _logger.LogDebug($"Endpoint count: {_optionsMonitor.CurrentValue.EndpointFuncs.Count}");
+                throw new InvalidOperationException($"There is no endpoint named [{name}]");
+            }
+            else if (options.EndpointFuncs.Count > 1)
+            {
+                throw new InvalidOperationException($"There duplicate endpoints with name [{name}]");
             }
             return options.EndpointFuncs[0](_services);
         }

--- a/src/MigrationTools/Endpoints/EndpointFactory.cs
+++ b/src/MigrationTools/Endpoints/EndpointFactory.cs
@@ -47,7 +47,7 @@ namespace MigrationTools.Endpoints
 
             if (options.EndpointFuncs.Count == 0)
             {
-                _logger.LogDebug($"Endpoint count: {_optionsMonitor.CurrentValue.EndpointFuncs.Count}");
+                _logger.LogDebug("Endpoint count: {0}", _optionsMonitor.CurrentValue.EndpointFuncs.Count);
                 throw new InvalidOperationException($"There is no endpoint named [{name}]");
             }
             else if (options.EndpointFuncs.Count > 1)

--- a/src/MigrationTools/Processors/Processor.cs
+++ b/src/MigrationTools/Processors/Processor.cs
@@ -47,7 +47,7 @@ namespace MigrationTools.Processors
         public virtual void Configure(IProcessorOptions options)
         {
             Log.LogInformation("Processor::Configure");
-            Log.LogInformation($"Processor::Configure Processor Type {Name}");
+            Log.LogInformation("Processor::Configure Processor Type {Name}", Name);
             try
             {
                 Source = _endpointFactory.CreateEndpoint(options.SourceName);
@@ -59,7 +59,7 @@ namespace MigrationTools.Processors
             }
             catch (InvalidOperationException)
             {
-                Log.LogError($"Couldn't find a Source EndPoint with SourceName [{options.SourceName}]");
+                Log.LogError("Couldn't find a Source EndPoint with SourceName [{0}]", options.SourceName);
                 throw;
             }
 
@@ -74,7 +74,7 @@ namespace MigrationTools.Processors
             }
             catch (InvalidOperationException)
             {
-                Log.LogError($"Couldn't find a Target EndPoint with TargetName [{options.TargetName}]");
+                Log.LogError("Couldn't find a Target EndPoint with TargetName [{0}]", options.TargetName);
                 throw;
             }
             //Endpoints.ConfigureEndpoints(source, target);

--- a/src/MigrationTools/Processors/Processor.cs
+++ b/src/MigrationTools/Processors/Processor.cs
@@ -47,8 +47,36 @@ namespace MigrationTools.Processors
         public virtual void Configure(IProcessorOptions options)
         {
             Log.LogInformation("Processor::Configure");
-            Source = _endpointFactory.CreateEndpoint(options.SourceName);
-            Target = _endpointFactory.CreateEndpoint(options.TargetName);
+            Log.LogInformation($"Processor::Configure Processor Type {Name}");
+            try
+            {
+                Source = _endpointFactory.CreateEndpoint(options.SourceName);
+            }
+            catch (ArgumentNullException)
+            {
+                Log.LogError("In the Processor configuration, specify the SourceName, for example \"SourceName\" : \"mySourceName\" and make sure there's an EndPoint with that name");
+                throw;
+            }
+            catch (InvalidOperationException)
+            {
+                Log.LogError($"Couldn't find a Source EndPoint with SourceName [{options.SourceName}]");
+                throw;
+            }
+
+            try
+            {
+                Target = _endpointFactory.CreateEndpoint(options.TargetName);
+            }
+            catch (ArgumentNullException)
+            {
+                Log.LogError("In the Processor configuration, specify the TargetName, for example \"TargetName\" : \"myTargetName\" and make sure there's an EndPoint with that name");
+                throw;
+            }
+            catch (InvalidOperationException)
+            {
+                Log.LogError($"Couldn't find a Target EndPoint with TargetName [{options.TargetName}]");
+                throw;
+            }
             //Endpoints.ConfigureEndpoints(source, target);
             ProcessorEnrichers.ConfigureEnrichers(options.ProcessorEnrichers);
             _ProcessorConfigured = true;

--- a/src/MigrationTools/_EngineV1/Configuration/EngineConfigurationBuilder.cs
+++ b/src/MigrationTools/_EngineV1/Configuration/EngineConfigurationBuilder.cs
@@ -64,7 +64,14 @@ namespace MigrationTools._EngineV1.Configuration
             if (ec?.Version != appVersion)
             {
                 _logger.LogError("The config version {Version} does not match the current app version {appVersion}. There may be compatability issues and we recommend that you generate a new default config and then tranfer the settings accross.", ec.Version, appVersion);
-                throw new Exception("Version in Config does not match X.X in Application. Please check and revert.");
+                if (System.Diagnostics.Debugger.IsAttached)
+                {
+                    _logger.LogInformation("But since you're running in Debug, let's move on");
+                }
+                else
+                {
+                    throw new Exception("Version in Config does not match X.X in Application. Please check and revert.");
+                }
             }
             //#endif
             return ec;


### PR DESCRIPTION
A small change that came from a 2 day headache, trying to figure out what I needed to do - The source project name was wrong by one letter that didn't have the right case.  So I changed the function to disregard case sensitivity in the node search (area/iteration).

The rest was more oriented to logging and VS Debugging experience.  When running from VS, the version mismatch between the file and migration is disregarded.

Pat