### PR TITLE
fixes that work for my migrations

### DIFF
--- a/docs/Reference/Generated/MigrationTools.Clients.AzureDevops.ObjectModel.xml
+++ b/docs/Reference/Generated/MigrationTools.Clients.AzureDevops.ObjectModel.xml
@@ -4,7 +4,7 @@
         <name>MigrationTools.Clients.AzureDevops.ObjectModel</name>
     </assembly>
     <members>
-        <member name="M:MigrationTools.Enrichers.TfsEmbededImagesEnricher.FixEmbededImages(MigrationTools._EngineV1.DataContracts.WorkItemData,System.String,System.String,System.String)">
+        <member name="M:MigrationTools.Enrichers.TfsEmbededImagesEnricher.FixEmbededImages(MigrationTools._EngineV1.DataContracts.WorkItemData,System.String,System.String,Microsoft.TeamFoundation.WorkItemTracking.WebApi.WorkItemTrackingHttpClient,System.String,System.String)">
             from https://gist.github.com/pietergheysens/792ed505f09557e77ddfc1b83531e4fb
         </member>
         <member name="M:MigrationTools.Enrichers.TfsNodeStructureEnricher.ShouldCreateNode(Microsoft.TeamFoundation.Server.NodeInfo,System.String)">

--- a/src/MigrationTools.Clients.AzureDevops.ObjectModel/Enrichers/TfsEmbededImagesEnricher.cs
+++ b/src/MigrationTools.Clients.AzureDevops.ObjectModel/Enrichers/TfsEmbededImagesEnricher.cs
@@ -97,7 +97,15 @@ namespace MigrationTools.Enrichers
                                 field.Value = field.Value.ToString().Replace(match.Value, newImageLink);
                                 wi.ToWorkItem().Attachments.RemoveAt(attachmentIndex);
                                 wi.SaveToAzureDevOps();
-                                File.Delete(fullImageFilePath);
+                                try
+                                {
+                                    File.Delete(fullImageFilePath);
+                                }
+                                catch (Exception)
+                                {
+                                    
+                                }
+                                
                             }
                         }
                     }

--- a/src/MigrationTools.Clients.AzureDevops.ObjectModel/Enrichers/TfsEmbededImagesEnricher.cs
+++ b/src/MigrationTools.Clients.AzureDevops.ObjectModel/Enrichers/TfsEmbededImagesEnricher.cs
@@ -1,13 +1,21 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text.RegularExpressions;
 using Microsoft.Extensions.Logging;
 using Microsoft.TeamFoundation.WorkItemTracking.Client;
+using Microsoft.TeamFoundation.WorkItemTracking.WebApi;
+using Microsoft.TeamFoundation.WorkItemTracking.WebApi.Models;
+using MigrationTools._EngineV1.Clients;
 using MigrationTools._EngineV1.DataContracts;
 using MigrationTools._EngineV1.Enrichers;
+using FieldType = Microsoft.TeamFoundation.WorkItemTracking.Client.FieldType;
+using Link = Microsoft.TeamFoundation.WorkItemTracking.Client.Link;
+using WorkItemLink = Microsoft.TeamFoundation.WorkItemTracking.Client.WorkItemLink;
 
 namespace MigrationTools.Enrichers
 {
@@ -28,9 +36,9 @@ namespace MigrationTools.Enrichers
             throw new NotImplementedException();
         }
 
-        public override int Enrich(WorkItemData sourceWorkItem, WorkItemData targetWorkItem)
+        public override int Enrich(WorkItemData sourceWorkItem, WorkItemData targetWorkItem, WorkItemTrackingHttpClient witClient, string project)
         {
-            FixEmbededImages(targetWorkItem, Engine.Source.Config.AsTeamProjectConfig().Collection.ToString(), Engine.Target.Config.AsTeamProjectConfig().Collection.ToString(), Engine.Source.Config.AsTeamProjectConfig().PersonalAccessToken);
+            FixEmbededImages(targetWorkItem, Engine.Source.Config.AsTeamProjectConfig().Collection.ToString(), Engine.Target.Config.AsTeamProjectConfig().Collection.ToString(), witClient, project, Engine.Source.Config.AsTeamProjectConfig().PersonalAccessToken);
             return 0;
         }
 
@@ -38,12 +46,19 @@ namespace MigrationTools.Enrichers
       *  from https://gist.github.com/pietergheysens/792ed505f09557e77ddfc1b83531e4fb
       */
 
-        protected override void FixEmbededImages(WorkItemData wi, string oldTfsurl, string newTfsurl, string sourcePersonalAccessToken = "")
+        protected override void FixEmbededImages(WorkItemData wi, string oldTfsurl, string newTfsurl,
+            WorkItemTrackingHttpClient witClient, string project, string sourcePersonalAccessToken = "")
         {
             Log.LogInformation("EmbededImagesRepairEnricher: Fixing HTML field attachments for work item {Id} from {OldTfsurl} to {NewTfsUrl}", wi.Id, oldTfsurl, GetUrlWithOppositeSchema(oldTfsurl));
 
             var oldTfsurlOppositeSchema = GetUrlWithOppositeSchema(oldTfsurl);
             string regExSearchForImageUrl = "(?<=<img.*src=\")[^\"]*";
+
+            var linkList = new List<Link>();
+            foreach (Link link in wi.ToWorkItem().Links)
+            {
+                linkList.Add(link);
+            }
 
             foreach (Field field in wi.ToWorkItem().Fields)
             {
@@ -96,6 +111,7 @@ namespace MigrationTools.Enrichers
 
                                 field.Value = field.Value.ToString().Replace(match.Value, newImageLink);
                                 wi.ToWorkItem().Attachments.RemoveAt(attachmentIndex);
+                                //wi.ToWorkItem().Fields["System.ChangedDate"].Value = lastRevChangedDate;
                                 wi.SaveToAzureDevOps();
                                 try
                                 {
@@ -103,13 +119,253 @@ namespace MigrationTools.Enrichers
                                 }
                                 catch (Exception)
                                 {
-                                    
+
                                 }
-                                
+
                             }
                         }
                     }
+
+                    //find links in field, match #12345
+                    //<!--<a href="https://dev.azure.com/GEBmanDEV/b88f3c69-ad72-476f-aec4-25cdd6db838d/_workitems/edit/11933" data-vss-mention="version:1.0">#188</a>-->
+                    string regExSearchForIssueUrl = "(?<=#)[0-9]*";
+                    matches = Regex.Matches((string)field.Value, regExSearchForIssueUrl);
+                    
+                    foreach (Match match in matches)
+                    {
+
+                        foreach (Link item in linkList)
+                        {
+                            try
+                            {
+                                Log.LogInformation("Migrating link for {sourceWorkItemLinkStartId} of type {ItemGetTypeName}", wi.Id, item.GetType().Name);
+                                if (item is RelatedLink rlink)
+                                {
+                                    var workItem = Engine.Target.WorkItems.GetWorkItem(rlink.RelatedWorkItemId);
+                                    var reflectedWorkItemId = Engine.Target.WorkItems.GetReflectedWorkItemId(workItem) as TfsReflectedWorkItemId;
+                                    if (string.Equals(reflectedWorkItemId?.WorkItemId, match.Value))
+                                    {
+                                        field.Value = Regex.Replace(field.Value.ToString(), $"(?<=href=\"){oldTfsurl}.*?" + $"/{match.Value}/?(?=\")", new TfsReflectedWorkItemId(workItem).ToString(),RegexOptions.IgnoreCase);
+
+                                        field.Value = Regex.Replace(field.Value.ToString(), "(?<=#)"+match.Value, workItem.Id);
+                                        wi.SaveToAzureDevOps();
+                                    }
+                                }
+                                else
+                                {
+                                    Log.LogError($"Not implemented Link conversion for {match.Value} [{item.BaseType.ToString()}]");
+                                }
+                            }
+                            catch (Exception ex)
+                            {
+                                Log.LogError(ex, $"[UnexpectedErrorException] Replacing Link for {match.Value}");
+                            }
+                        }
+                    }
+
+                    var oldProject = Engine.Config.Source.AsTeamProjectConfig().Project;
+                    string regExSearchForIssueLinkUncert = $"(?<={oldTfsurl}/?{oldProject}/_workitems/edit/)";
+                    string regExSearchForIssueLink = regExSearchForIssueLinkUncert + $"[0-9]*";
+                    matches = Regex.Matches((string)field.Value, regExSearchForIssueLink);
+
+                    foreach (Match match in matches)
+                    {
+
+                        foreach (Link item in linkList)
+                        {
+                            try
+                            {
+                                Log.LogInformation("Migrating link for {sourceWorkItemLinkStartId} of type {ItemGetTypeName}", wi.Id, item.GetType().Name);
+                                if (item is RelatedLink rlink)
+                                {
+                                    var workItem = Engine.Target.WorkItems.GetWorkItem(rlink.RelatedWorkItemId);
+                                    var reflectedWorkItemId = Engine.Target.WorkItems.GetReflectedWorkItemId(workItem) as TfsReflectedWorkItemId;
+                                    if (string.Equals(reflectedWorkItemId?.WorkItemId, match.Value))
+                                    {
+                                        field.Value = Regex.Replace(field.Value.ToString(), reflectedWorkItemId.ToString(), new TfsReflectedWorkItemId(workItem).ToString());
+
+                                        field.Value = Regex.Replace(field.Value.ToString(), "(?<=<a.*?)" + match.Value + "(?=.*?</a>)", rlink.RelatedWorkItemId.ToString());
+                                        wi.SaveToAzureDevOps();
+                                    }
+                                }
+                                else
+                                {
+                                    Log.LogError($"Not implemented Link conversion for {match.Value} [{item.BaseType.ToString()}]");
+                                }
+                            }
+                            catch (Exception ex)
+                            {
+                                Log.LogError(ex, $"[UnexpectedErrorException] Replacing Link for {match.Value}");
+                            }
+                        }
+                    }
+
                 }
+            }
+
+            var comments = witClient.GetCommentsAsync(project, int.Parse(wi.Id)).Result;
+
+            var attIndices = new List<Tuple<Attachment, string, string>>();
+
+            foreach (Comment comment in comments.Comments)
+            {
+                MatchCollection matches = Regex.Matches((string)comment.Text, regExSearchForImageUrl);
+                var commentUpdate = new CommentUpdate();
+                commentUpdate.Text = comment.Text;
+                string regExSearchFileName = "(?<=FileName=)[^=]*";
+                foreach (Match match in matches)
+                {
+                    if (match.Value.ToLower().Contains(oldTfsurl.ToLower()) || match.Value.ToLower().Contains(oldTfsurlOppositeSchema.ToLower()))
+                    {
+                        //save image locally and upload as attachment
+                        Match newFileNameMatch = Regex.Match(match.Value, regExSearchFileName, RegexOptions.IgnoreCase);
+                        if (newFileNameMatch.Success)
+                        {
+                            Log.LogDebug("EmbededImagesRepairEnricher: History has match: {matchValue}", System.Net.WebUtility.HtmlDecode(match.Value));
+                            string fullImageFilePath = Path.GetTempPath() + Guid.NewGuid().ToString("N") + Path.GetExtension(newFileNameMatch.Value);//newFileNameMatch.Value;
+
+                            using (var httpClient = new HttpClient(_httpClientHandler, false))
+                            {
+                                if (!string.IsNullOrEmpty(sourcePersonalAccessToken))
+                                {
+                                    httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", Convert.ToBase64String(System.Text.ASCIIEncoding.ASCII.GetBytes(string.Format("{0}:{1}", "", sourcePersonalAccessToken))));
+                                }
+                                var result = DownloadFile(httpClient, match.Value, fullImageFilePath);
+                                if (!result.IsSuccessStatusCode)
+                                {
+                                    if (_ignore404Errors && result.StatusCode == HttpStatusCode.NotFound)
+                                    {
+                                        Log.LogDebug("EmbededImagesRepairEnricher: Image {MatchValue} could not be found in WorkItem {WorkItemId}, Field History", match.Value, wi.Id);
+                                        continue;
+                                    }
+                                    else
+                                    {
+                                        result.EnsureSuccessStatusCode();
+                                    }
+                                }
+                            }
+
+                            if (GetImageFormat(File.ReadAllBytes(fullImageFilePath)) == ImageFormat.unknown)
+                            {
+                                throw new Exception($"Downloaded image [{fullImageFilePath}] from Work Item [{wi.ToWorkItem().Id}] Field: History could not be identified as an image. Authentication issue?");
+                            }
+
+                            var attachment = new Attachment(fullImageFilePath);
+                            int attachmentIndex = wi.ToWorkItem().Attachments.Add(attachment);
+                            attIndices.Add(new Tuple<Attachment, string, string>(attachment, match.Value, fullImageFilePath));
+
+                        }
+                    }
+                }
+
+                if (matches.Count > 0)
+                {
+                    wi.SaveToAzureDevOps();
+                    // TODO: 2D Array for attindices, this cycles all the attachments for the comments, not just for the comment, but it is minor
+                    foreach (var attIndex in attIndices)
+                    {
+                        var newImageLink = attIndex.Item1.Uri.ToString();
+
+                        commentUpdate.Text = commentUpdate.Text.Replace(attIndex.Item2, newImageLink);
+                    }
+                }
+
+                //find links in field, match #12345
+                //<!--<a href="https://dev.azure.com/GEBmanDEV/b88f3c69-ad72-476f-aec4-25cdd6db838d/_workitems/edit/11933" data-vss-mention="version:1.0">#188</a>-->
+                string regExSearchForIssueUrl = "(?<=#)[0-9]*";
+                matches = Regex.Matches(comment.Text, regExSearchForIssueUrl);
+
+                foreach (Match match in matches)
+                {
+
+                    foreach (Link item in linkList)
+                    {
+                        try
+                        {
+                            Log.LogInformation("Migrating link for {sourceWorkItemLinkStartId} of type {ItemGetTypeName}", wi.Id, item.GetType().Name);
+                            if (item is RelatedLink rlink)
+                            {
+                                var workItem = Engine.Target.WorkItems.GetWorkItem(rlink.RelatedWorkItemId);
+                                var reflectedWorkItemId = Engine.Target.WorkItems.GetReflectedWorkItemId(workItem) as TfsReflectedWorkItemId;
+                                if (string.Equals(reflectedWorkItemId?.WorkItemId, match.Value))
+                                {
+                                    commentUpdate.Text = Regex.Replace(commentUpdate.Text, $"(?<=href=\"){oldTfsurl}.*?" + $"/{match.Value}/?(?=\")", new TfsReflectedWorkItemId(workItem).ToString(), RegexOptions.IgnoreCase);
+
+                                    commentUpdate.Text = Regex.Replace(commentUpdate.Text, "(?<=#)" + match.Value, workItem.Id);
+                                }
+                            }
+                            else
+                            {
+                                Log.LogError($"Not implemented Link conversion for {match.Value} [{item.BaseType.ToString()}]");
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            Log.LogError(ex, $"[UnexpectedErrorException] Replacing Link for {match.Value}");
+                        }
+                    }
+                }
+
+                var oldProject = Engine.Config.Source.AsTeamProjectConfig().Project;
+                string regExSearchForIssueLinkUncert = $"(?<={oldTfsurl}/?{oldProject}/_workitems/edit/)";
+                string regExSearchForIssueLink = regExSearchForIssueLinkUncert + $"[0-9]*";
+                matches = Regex.Matches(comment.Text, regExSearchForIssueLink);
+
+                foreach (Match match in matches)
+                {
+
+                    foreach (Link item in linkList)
+                    {
+                        try
+                        {
+                            Log.LogInformation("Migrating link for {sourceWorkItemLinkStartId} of type {ItemGetTypeName}", wi.Id, item.GetType().Name);
+                            if (item is RelatedLink rlink)
+                            {
+                                var workItem = Engine.Target.WorkItems.GetWorkItem(rlink.RelatedWorkItemId);
+                                var reflectedWorkItemId = Engine.Target.WorkItems.GetReflectedWorkItemId(workItem) as TfsReflectedWorkItemId;
+                                if (string.Equals(reflectedWorkItemId?.WorkItemId, match.Value))
+                                {
+                                    commentUpdate.Text = Regex.Replace(commentUpdate.Text, reflectedWorkItemId.ToString(), new TfsReflectedWorkItemId(workItem).ToString());
+
+                                    commentUpdate.Text = Regex.Replace(commentUpdate.Text, "(?<=<a.*?)" + match.Value + "(?=.*?</a>)", rlink.RelatedWorkItemId.ToString());
+                                }
+                            }
+                            else
+                            {
+                                Log.LogError($"Not implemented Link conversion for {match.Value} [{item.BaseType.ToString()}]");
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            Log.LogError(ex, $"[UnexpectedErrorException] Replacing Link for {match.Value}");
+                        }
+                    }
+                }
+
+                if(!string.Equals(commentUpdate.Text,comment.Text))
+                    witClient.UpdateCommentAsync(commentUpdate, project, int.Parse(wi.Id), comment.Id).Wait();
+            }
+            if (attIndices.Any())
+            {
+
+                foreach (var attIndex in attIndices)
+                {
+                    wi.ToWorkItem().Attachments.Remove(attIndex.Item1);
+                }
+                wi.SaveToAzureDevOps();
+                foreach (var attIndex in attIndices)
+                {
+
+                    try
+                    {
+                        File.Delete(attIndex.Item3);
+                    }
+                    catch (Exception)
+                    {
+
+                    }
+                }
+
             }
         }
     }

--- a/src/MigrationTools.Clients.AzureDevops.ObjectModel/Enrichers/TfsGitRepositoryEnricher.cs
+++ b/src/MigrationTools.Clients.AzureDevops.ObjectModel/Enrichers/TfsGitRepositoryEnricher.cs
@@ -7,6 +7,7 @@ using Microsoft.TeamFoundation;
 using Microsoft.TeamFoundation.Git.Client;
 using Microsoft.TeamFoundation.SourceControl.WebApi;
 using Microsoft.TeamFoundation.WorkItemTracking.Client;
+using Microsoft.TeamFoundation.WorkItemTracking.WebApi;
 using MigrationTools._EngineV1.Clients;
 using MigrationTools._EngineV1.DataContracts;
 
@@ -53,7 +54,8 @@ namespace MigrationTools.Enrichers
             _save = save;
         }
 
-        public override int Enrich(WorkItemData sourceWorkItem, WorkItemData targetWorkItem)
+        public override int Enrich(WorkItemData sourceWorkItem, WorkItemData targetWorkItem,
+            WorkItemTrackingHttpClient witClient, string project)
         {
             if (sourceWorkItem is null)
             {

--- a/src/MigrationTools.Clients.AzureDevops.ObjectModel/Enrichers/TfsNodeStructureEnricher.cs
+++ b/src/MigrationTools.Clients.AzureDevops.ObjectModel/Enrichers/TfsNodeStructureEnricher.cs
@@ -5,6 +5,7 @@ using System.Text.RegularExpressions;
 using System.Xml;
 using Microsoft.Extensions.Logging;
 using Microsoft.TeamFoundation.Server;
+using Microsoft.TeamFoundation.WorkItemTracking.WebApi;
 using MigrationTools._EngineV1.Clients;
 using MigrationTools._EngineV1.DataContracts;
 
@@ -44,7 +45,8 @@ namespace MigrationTools.Enrichers
             throw new NotImplementedException();
         }
 
-        public override int Enrich(WorkItemData sourceWorkItem, WorkItemData targetWorkItem)
+        public override int Enrich(WorkItemData sourceWorkItem, WorkItemData targetWorkItem,
+            WorkItemTrackingHttpClient witClient, string project)
         {
             throw new NotImplementedException();
             return 0;

--- a/src/MigrationTools.Clients.AzureDevops.ObjectModel/Enrichers/TfsWorkItemLinkEnricher.cs
+++ b/src/MigrationTools.Clients.AzureDevops.ObjectModel/Enrichers/TfsWorkItemLinkEnricher.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using Microsoft.Extensions.Logging;
 using Microsoft.TeamFoundation.WorkItemTracking.Client;
+using Microsoft.TeamFoundation.WorkItemTracking.WebApi;
 using MigrationTools._EngineV1.Clients;
 using MigrationTools._EngineV1.DataContracts;
 using MigrationTools.Exceptions;
@@ -25,7 +26,8 @@ namespace MigrationTools.Enrichers
             _filterWorkItemsThatAlreadyExistInTarget = filterWorkItemsThatAlreadyExistInTarget;
         }
 
-        public override int Enrich(WorkItemData sourceWorkItemLinkStart, WorkItemData targetWorkItemLinkStart)
+        public override int Enrich(WorkItemData sourceWorkItemLinkStart, WorkItemData targetWorkItemLinkStart,
+            WorkItemTrackingHttpClient witClient, string project)
         {
             if (sourceWorkItemLinkStart is null)
             {

--- a/src/MigrationTools.Clients.AzureDevops.ObjectModel/FieldMaps/FieldToFieldMap.cs
+++ b/src/MigrationTools.Clients.AzureDevops.ObjectModel/FieldMaps/FieldToFieldMap.cs
@@ -24,7 +24,7 @@ namespace MigrationTools.FieldMaps.AzureDevops.ObjectModel
             if (source.Fields.Contains(Config.sourceField) && target.Fields.Contains(Config.targetField))
             {
                 var value = source.Fields[Config.sourceField].Value;
-                if ((value as string is null || value as string == "") && Config.defaultValue != null)
+                if (!(value is bool) && (value as string is null || value as string == "") && Config.defaultValue != null)
                 {
                     value = Config.defaultValue;
                 }

--- a/src/MigrationTools.Clients.AzureDevops.ObjectModel/MigrationTools.Clients.AzureDevops.ObjectModel.csproj
+++ b/src/MigrationTools.Clients.AzureDevops.ObjectModel/MigrationTools.Clients.AzureDevops.ObjectModel.csproj
@@ -11,7 +11,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Ben.Demystifier" Version="0.1.6" />
     <PackageReference Include="Microsoft.TeamFoundationServer.ExtendedClient" Version="16.153.0" />
   </ItemGroup>
 

--- a/src/MigrationTools.Clients.AzureDevops.ObjectModel/TfsExtensions.cs
+++ b/src/MigrationTools.Clients.AzureDevops.ObjectModel/TfsExtensions.cs
@@ -94,7 +94,7 @@ namespace MigrationTools
             // We only need to fill the revisions object if we create a WorkItemData object for the whole WorkItem and
             // we sort it here by Number using a SortedDictionary
      
-            context.Revisions = fieldsOfRevision == null ? new Dictionary<int, RevisionItem>(workItem.Revisions
+            context.Revisions = fieldsOfRevision == null ? new SortedDictionary<int, RevisionItem>(workItem.Revisions
                 .Cast<Revision>()
                 .OrderByDescending(x => (DateTime) x.Fields["System.ChangedDate"].Value)
                 .Select(x => new RevisionItem()

--- a/src/MigrationTools.Clients.AzureDevops.ObjectModel/_Enginev1/Clients/TfsReflectedWorkItemId.cs
+++ b/src/MigrationTools.Clients.AzureDevops.ObjectModel/_Enginev1/Clients/TfsReflectedWorkItemId.cs
@@ -10,10 +10,9 @@ namespace MigrationTools._EngineV1.Clients
     {
         private Uri _Connection;
         private string _ProjectName;
-        private string _WorkItemId;
         private static readonly Regex ReflectedIdRegex = new Regex(@"^(?<org>[\S ]+)\/(?<project>[\S ]+)\/_workitems\/edit\/(?<id>\d+)", RegexOptions.Compiled);
 
-        public TfsReflectedWorkItemId(WorkItemData workItem) : base(workItem.Id)
+        public TfsReflectedWorkItemId(WorkItemData workItem)
         {
             if (workItem is null)
             {
@@ -25,7 +24,7 @@ namespace MigrationTools._EngineV1.Clients
             _Connection = workItem.ToWorkItem().Store.TeamProjectCollection.Uri;
         }
 
-        public TfsReflectedWorkItemId(string ReflectedWorkItemId) : base(ReflectedWorkItemId)
+        public TfsReflectedWorkItemId(string ReflectedWorkItemId)
         {
             if (ReflectedWorkItemId is null)
             {

--- a/src/MigrationTools.Clients.AzureDevops.Rest/Enrichers/EmbededImagesRepairEnricher.cs
+++ b/src/MigrationTools.Clients.AzureDevops.Rest/Enrichers/EmbededImagesRepairEnricher.cs
@@ -22,12 +22,14 @@ namespace MigrationTools.Clients.AzureDevops.Rest.Enrichers
             throw new NotImplementedException();
         }
 
-        public override int Enrich(WorkItemData sourceWorkItem, WorkItemData targetWorkItem)
+        public override int Enrich(WorkItemData sourceWorkItem, WorkItemData targetWorkItem,
+            WorkItemTrackingHttpClient witClient)
         {
             throw new NotImplementedException();
         }
 
-        protected override void FixEmbededImages(WorkItemData wi, string oldTfsurl, string newTfsurl, string sourcePersonalAccessToken = "")
+        protected override void FixEmbededImages(WorkItemData wi, string oldTfsurl, string newTfsurl,
+            string sourcePersonalAccessToken = "", WorkItemTrackingHttpClient witClient)
         {
             throw new NotImplementedException();
         }

--- a/src/MigrationTools.ConsoleFull/MigrationTools.ConsoleFull.csproj
+++ b/src/MigrationTools.ConsoleFull/MigrationTools.ConsoleFull.csproj
@@ -6,6 +6,11 @@
     <Product>Azure DevOps Migration Tools [Object Model]</Product>
     <AssemblyName>migration</AssemblyName>
     <PlatformTarget>AnyCPU</PlatformTarget>
+	<AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <OutputPath>c:\tools\MigrationTools44vertigis\</OutputPath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/MigrationTools.ConsoleFull/Properties/launchSettings.json
+++ b/src/MigrationTools.ConsoleFull/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "execute": {
       "commandName": "Project",
-      "commandLineArgs": "execute -c configuration.json"
+      "commandLineArgs": " execute -c C:\\tools\\c_full_geooffice.json"
     },
     "init": {
       "commandName": "Project",

--- a/src/MigrationTools.ConsoleFull/Properties/launchSettings.json
+++ b/src/MigrationTools.ConsoleFull/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "execute": {
       "commandName": "Project",
-      "commandLineArgs": " execute -c C:\\tools\\c_full_geooffice.json"
+      "commandLineArgs": "execute -c configuration.json"
     },
     "init": {
       "commandName": "Project",

--- a/src/MigrationTools/MigrationTools.csproj
+++ b/src/MigrationTools/MigrationTools.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="3.1.9" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="3.1.9" />
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.2.8" />
+    <PackageReference Include="Microsoft.TeamFoundationServer.Client" Version="16.153.0" />
     <PackageReference Include="Microsoft.VisualStudio.Services.Client" Version="16.153.0" />
 
     <PackageReference Include="Serilog" Version="2.10.0" />

--- a/src/MigrationTools/ProcessorEnrichers/PauseAfterEachItem.cs
+++ b/src/MigrationTools/ProcessorEnrichers/PauseAfterEachItem.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using Microsoft.Extensions.Logging;
+using Microsoft.TeamFoundation.WorkItemTracking.WebApi;
+using MigrationTools._EngineV1.DataContracts;
 using MigrationTools.Processors;
 
 namespace MigrationTools.Enrichers
@@ -29,7 +31,8 @@ namespace MigrationTools.Enrichers
         }
 
         [Obsolete("Old v1 arch: this is a v2 class", true)]
-        public override int Enrich(_EngineV1.DataContracts.WorkItemData sourceWorkItem, _EngineV1.DataContracts.WorkItemData targetWorkItem)
+        public override int Enrich(WorkItemData sourceWorkItem, WorkItemData targetWorkItem,
+            WorkItemTrackingHttpClient witClient, string project)
         {
             throw new System.NotImplementedException();
         }

--- a/src/MigrationTools/ProcessorEnrichers/WorkItemProcessorEnrichers/AppendMigrationToolSignatureFooter.cs
+++ b/src/MigrationTools/ProcessorEnrichers/WorkItemProcessorEnrichers/AppendMigrationToolSignatureFooter.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Microsoft.Extensions.Logging;
+using Microsoft.TeamFoundation.WorkItemTracking.WebApi;
 using MigrationTools._EngineV1.DataContracts;
 
 namespace MigrationTools.Enrichers
@@ -29,7 +30,8 @@ namespace MigrationTools.Enrichers
         }
 
         [Obsolete("Old v1 arch: this is a v2 class", true)]
-        public override int Enrich(WorkItemData sourceWorkItem, WorkItemData targetWorkItem)
+        public override int Enrich(WorkItemData sourceWorkItem, WorkItemData targetWorkItem,
+            WorkItemTrackingHttpClient witClient, string project)
         {
             throw new System.NotImplementedException();
         }

--- a/src/MigrationTools/ProcessorEnrichers/WorkItemProcessorEnrichers/FilterWorkItemsThatAlreadyExistInTarget.cs
+++ b/src/MigrationTools/ProcessorEnrichers/WorkItemProcessorEnrichers/FilterWorkItemsThatAlreadyExistInTarget.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Microsoft.Extensions.Logging;
+using Microsoft.TeamFoundation.WorkItemTracking.WebApi;
 using MigrationTools._EngineV1.DataContracts;
 
 namespace MigrationTools.Enrichers
@@ -23,7 +24,8 @@ namespace MigrationTools.Enrichers
         }
 
         [Obsolete("Old v1 arch: this is a v2 class", true)]
-        public override int Enrich(WorkItemData sourceWorkItem, WorkItemData targetWorkItem)
+        public override int Enrich(WorkItemData sourceWorkItem, WorkItemData targetWorkItem,
+            WorkItemTrackingHttpClient witClient, string project)
         {
             throw new System.NotImplementedException();
         }

--- a/src/MigrationTools/ProcessorEnrichers/WorkItemProcessorEnrichers/IWorkItemProcessorEnricher.cs
+++ b/src/MigrationTools/ProcessorEnrichers/WorkItemProcessorEnrichers/IWorkItemProcessorEnricher.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Microsoft.TeamFoundation.WorkItemTracking.WebApi;
 using MigrationTools._EngineV1.DataContracts;
 
 namespace MigrationTools.Enrichers
@@ -8,6 +9,7 @@ namespace MigrationTools.Enrichers
         void Configure(bool save = true, bool filter = true);
 
         [Obsolete("We are migrating to a new model. This is the old one.")]
-        int Enrich(WorkItemData sourceWorkItem, WorkItemData targetWorkItem);
+        int Enrich(WorkItemData sourceWorkItem, WorkItemData targetWorkItem, WorkItemTrackingHttpClient witClient,
+            string project);
     }
 }

--- a/src/MigrationTools/ProcessorEnrichers/WorkItemProcessorEnrichers/SkipToFinalRevisedWorkItemType.cs
+++ b/src/MigrationTools/ProcessorEnrichers/WorkItemProcessorEnrichers/SkipToFinalRevisedWorkItemType.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Microsoft.Extensions.Logging;
+using Microsoft.TeamFoundation.WorkItemTracking.WebApi;
 using MigrationTools._EngineV1.DataContracts;
 
 namespace MigrationTools.Enrichers
@@ -29,7 +30,8 @@ namespace MigrationTools.Enrichers
         }
 
         [Obsolete("Old v1 arch: this is a v2 class", true)]
-        public override int Enrich(WorkItemData sourceWorkItem, WorkItemData targetWorkItem)
+        public override int Enrich(WorkItemData sourceWorkItem, WorkItemData targetWorkItem,
+            WorkItemTrackingHttpClient witClient, string project)
         {
             throw new System.NotImplementedException();
         }

--- a/src/MigrationTools/ProcessorEnrichers/WorkItemProcessorEnrichers/WorkItemProcessorEnricher.cs
+++ b/src/MigrationTools/ProcessorEnrichers/WorkItemProcessorEnrichers/WorkItemProcessorEnricher.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using Microsoft.Extensions.Logging;
+using Microsoft.TeamFoundation.WorkItemTracking.WebApi;
+using MigrationTools._EngineV1.DataContracts;
 using MigrationTools.Processors;
 
 namespace MigrationTools.Enrichers
@@ -25,7 +27,8 @@ namespace MigrationTools.Enrichers
         public abstract void Configure(IProcessorEnricherOptions options);
 
         [Obsolete("v1 Architecture: Here to support migration, use PhaseEnrichers: BeforeLoadData, AfterLoadData, etc", false)]
-        public virtual int Enrich(_EngineV1.DataContracts.WorkItemData sourceWorkItem, _EngineV1.DataContracts.WorkItemData targetWorkItem)
+        public virtual int Enrich(WorkItemData sourceWorkItem, WorkItemData targetWorkItem,
+            WorkItemTrackingHttpClient witClient, string project)
         {
             throw new InvalidOperationException("This is invalid for this Enricher type");
         }

--- a/src/MigrationTools/_EngineV1/Clients/ReflectedWorkItemId.cs
+++ b/src/MigrationTools/_EngineV1/Clients/ReflectedWorkItemId.cs
@@ -5,7 +5,7 @@ namespace MigrationTools._EngineV1.Clients
 {
     public abstract class ReflectedWorkItemId
     {
-        private string _WorkItemId;
+        protected string _WorkItemId;
 
         public ReflectedWorkItemId(WorkItemData workItem)
         {
@@ -24,6 +24,10 @@ namespace MigrationTools._EngineV1.Clients
                 throw new ArgumentNullException(nameof(ReflectedWorkItemId));
             }
             _WorkItemId = ReflectedWorkItemId;
+        }
+
+        protected ReflectedWorkItemId()
+        {
         }
 
         public override string ToString()

--- a/src/MigrationTools/_EngineV1/Configuration/Processing/WorkItemMigrationConfig.cs
+++ b/src/MigrationTools/_EngineV1/Configuration/Processing/WorkItemMigrationConfig.cs
@@ -25,6 +25,7 @@ namespace MigrationTools._EngineV1.Configuration.Processing
         public string AttachmentWorkingPath { get; set; }
 
         public bool FixHtmlAttachmentLinks { get; set; }
+        public bool FixTargetOnly { get; set; }
 
         public bool SkipToFinalRevisedWorkItemType { get; set; }
 
@@ -57,6 +58,7 @@ namespace MigrationTools._EngineV1.Configuration.Processing
             LinkMigration = true;
             AttachmentMigration = true;
             FixHtmlAttachmentLinks = false;
+            FixTargetOnly = false;
             AttachmentWorkingPath = "c:\\temp\\WorkItemAttachmentWorkingFolder\\";
             AttachmentMaxSize = 480000000;
             UpdateCreatedBy = true;

--- a/src/MigrationTools/_EngineV1/DataContracts/WorkItemData.cs
+++ b/src/MigrationTools/_EngineV1/DataContracts/WorkItemData.cs
@@ -22,31 +22,31 @@ namespace MigrationTools._EngineV1.DataContracts
                     return _id;
                 }
 
-                _id = GetField<string>("ID");
+                _id = GetField("ID")?.ToString();
                 return _id;
             }
             set
             {
                 var val = int.Parse(value);
                 _id = value;
-                SetField<int>("ID", val);
+                SetField("ID", val);
             }
         }
 
         public string Type
         {
-            get => GetField<string>("Work Item Type");
+            get => GetField("Work Item Type")?.ToString();
             set => SetField("Work Item Type", value);
         }
 
         public string Title
         {
-            get => GetField<string>("Title");
+            get => GetField("Title")?.ToString();
             set => SetField("Title", value);
         }
 
-        public int Rev => GetField<int>("Rev");
-        public DateTime RevisedDate => GetField<DateTime>("Revised Date");
+        public int Rev => (int)GetField("Rev");
+        public DateTime RevisedDate => (DateTime)GetField("Revised Date");
         public string ProjectName { get; set; }
 
         [JsonIgnore]
@@ -61,7 +61,7 @@ namespace MigrationTools._EngineV1.DataContracts
 
         public IReadOnlyDictionary<int, RevisionItem> Revisions { get; set; }
 
-        private T GetField<T>(string field)
+        private object GetField(string field)
         {
             if (Fields is null)
             {
@@ -71,10 +71,10 @@ namespace MigrationTools._EngineV1.DataContracts
             {
                 return default;
             }
-            return (T)this.Fields[field];
+            return this.Fields[field];
         }
 
-        private void SetField<T>(string field, T value)
+        private void SetField(string field, object value)
         {
             if (Fields is null)
             {

--- a/src/MigrationTools/_EngineV1/Enrichers/EmbededImagesRepairEnricherBase.cs
+++ b/src/MigrationTools/_EngineV1/Enrichers/EmbededImagesRepairEnricherBase.cs
@@ -5,6 +5,7 @@ using System.Net;
 using System.Net.Http;
 using System.Text;
 using Microsoft.Extensions.Logging;
+using Microsoft.TeamFoundation.WorkItemTracking.WebApi;
 using MigrationTools._EngineV1.DataContracts;
 using MigrationTools.Enrichers;
 
@@ -25,9 +26,13 @@ namespace MigrationTools._EngineV1.Enrichers
 
         public override abstract void Configure(bool save = true, bool filter = true);
 
-        public override abstract int Enrich(WorkItemData sourceWorkItem, WorkItemData targetWorkItem);
+        public override abstract int Enrich(WorkItemData sourceWorkItem, WorkItemData targetWorkItem,
+            WorkItemTrackingHttpClient witClient, string project);
 
-        protected abstract void FixEmbededImages(WorkItemData wi, string oldTfsurl, string newTfsurl, string sourcePersonalAccessToken = "");
+        protected abstract void FixEmbededImages(WorkItemData wi, string oldTfsurl, string newTfsurl,
+            WorkItemTrackingHttpClient witClient,
+            string project,
+            string sourcePersonalAccessToken = "");
 
         protected static HttpResponseMessage DownloadFile(HttpClient httpClient, string url, string destinationPath)
         {

--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemMigrationContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemMigrationContext.cs
@@ -299,8 +299,9 @@ namespace VstsSyncMigrator.Engine
 
             foreach (Field f in oldWorkItem.Fields)
             {
-                if (newWorkItem.Fields.Contains(f.ReferenceName) && !_ignore.Contains(f.ReferenceName) && (!newWorkItem.Fields[f.ReferenceName].IsChangedInRevision || newWorkItem.Fields[f.ReferenceName].IsEditable))
+                if (newWorkItem.Fields.Contains(f.ReferenceName) && !_ignore.Contains(f.ReferenceName) && (!newWorkItem.Fields[f.ReferenceName].IsChangedInRevision || newWorkItem.Fields[f.ReferenceName].IsEditable) && oldWorkItem.Fields[f.ReferenceName].Value != newWorkItem.Fields[f.ReferenceName].Value)
                 {
+                    Log.LogDebug("PopulateWorkItem:FieldUpdate: {ReferenceName} | Old:{OldReferenceValue} New:{NewReferenceValue}", f.ReferenceName, oldWorkItem.Fields[f.ReferenceName].Value, newWorkItem.Fields[f.ReferenceName].Value);
                     newWorkItem.Fields[f.ReferenceName].Value = oldWorkItem.Fields[f.ReferenceName].Value;
                 }
             }
@@ -593,7 +594,8 @@ namespace VstsSyncMigrator.Engine
                 if (targetWorkItem != null)
                 {
                     ProcessWorkItemAttachments(sourceWorkItem, targetWorkItem, false);
-                    ProcessWorkItemLinks(Engine.Source.WorkItems, Engine.Target.WorkItems, sourceWorkItem, targetWorkItem);
+                    if (!string.IsNullOrEmpty(targetWorkItem.Id))
+                        ProcessWorkItemLinks(Engine.Source.WorkItems, Engine.Target.WorkItems, sourceWorkItem, targetWorkItem);
 
                     if (_config.GenerateMigrationComment)
                     {

--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemMigrationContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemMigrationContext.cs
@@ -589,8 +589,8 @@ namespace VstsSyncMigrator.Engine
                     PopulateWorkItem(currentRevisionWorkItem, targetWorkItem, destType);
                     Engine.FieldMaps.ApplyFieldMappings(currentRevisionWorkItem, targetWorkItem);
 
-                    targetWorkItem.ToWorkItem().Fields["System.ChangedBy"].Value =
-                        currentRevisionWorkItem.ToWorkItem().Revisions[revision.Index].Fields["System.ChangedBy"].Value;
+                    //this here to keep authors in historical revisions, otherwise owner of PAT will be everywhere.
+                    targetWorkItem.ToWorkItem().Fields["System.ChangedBy"].Value = currentRevisionWorkItem.ToWorkItem().Revisions[revision.Index].Fields["System.ChangedBy"].Value;
 
                     targetWorkItem.ToWorkItem().Fields["System.History"].Value =
                         currentRevisionWorkItem.ToWorkItem().Revisions[revision.Index].Fields["System.History"].Value;

--- a/src/VstsSyncMigrator.Core/Execution/ProcessingContext/FixGitCommitLinks.cs
+++ b/src/VstsSyncMigrator.Core/Execution/ProcessingContext/FixGitCommitLinks.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.TeamFoundation.WorkItemTracking.WebApi;
 using MigrationTools;
 using MigrationTools._EngineV1.Configuration;
 using MigrationTools._EngineV1.Configuration.Processing;
@@ -60,7 +61,7 @@ namespace VstsSyncMigrator.Engine
                 Stopwatch witstopwatch = Stopwatch.StartNew();
                 workitem.ToWorkItem().Open();
 
-                _GitRepositoryEnricher.Enrich(null, workitem);
+                _GitRepositoryEnricher.Enrich((WorkItemData)null, workitem, null, Engine.Target.WorkItems.Project.Name);
 
                 if (workitem.ToWorkItem().IsDirty)
                 {

--- a/src/VstsSyncMigrator.Core/VstsSyncMigrator.Core.csproj
+++ b/src/VstsSyncMigrator.Core/VstsSyncMigrator.Core.csproj
@@ -14,7 +14,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Ben.Demystifier" Version="0.1.6" />
     <PackageReference Include="CsvHelper" Version="15.0.9" />
     <PackageReference Include="Microsoft.TeamFoundationServer.ExtendedClient" Version="16.153.0">
       <IncludeAssets>all</IncludeAssets>


### PR DESCRIPTION
I had to create some changes that make my migrations work (azdo and also onprem azdo to azdo.)
* issue fixed #923 
* fixed when revisions are missing or duplicate after migrating azdo that was once migrated from tfs.
* fixed service unavailable stopper by 5 retries in revision migration
* fixed mapping of bool value
* removed unused reference of Ben.Demystifer
* fixed weird casting of field getters and setters

my appologies for somewhat different spacings