### PR TITLE
Implement selecting build/release pipelines for migration

### DIFF
--- a/docs/Reference/Generated/MigrationTools.Clients.AzureDevops.Rest.xml
+++ b/docs/Reference/Generated/MigrationTools.Clients.AzureDevops.Rest.xml
@@ -182,6 +182,15 @@
             <param name="sourceDefinitions"></param>
             <returns>List of sorted Definitions</returns>
         </member>
+        <member name="M:MigrationTools.Processors.AzureDevOpsPipelineProcessor.GetSelectedDefinitionsFromEndpointAsync``1(MigrationTools.Endpoints.AzureDevOpsEndpoint,System.Collections.Generic.List{System.String})">
+            <summary>
+            Retrieve the selected pipeline definitions from the Azure DevOps Endpoint for the <typeparamref name="DefinitionType"/> type.
+            </summary>
+            <typeparam name="DefinitionType">The type of Pipeline definition to query. The type must inherit from <see cref="T:MigrationTools.DataContracts.RestApiDefinition"/>.</typeparam>
+            <param name="endpoint">The <see cref="T:MigrationTools.Endpoints.AzureDevOpsEndpoint"/> to query against.</param>
+            <param name="definitionNames">The list of definitions to query for. If the value is <c>null</c> or an empty list, all definitions will be queried.</param>
+            <returns></returns>
+        </member>
         <member name="P:MigrationTools.Processors.AzureDevOpsPipelineProcessorOptions.MigrateBuildPipelines">
             <summary>
             Migrate Build Pipelines
@@ -214,12 +223,12 @@
         </member>
         <member name="P:MigrationTools.Processors.AzureDevOpsPipelineProcessorOptions.BuildPipelines">
             <summary>
-            List of Build Pipelines to process. If this is `null` then all Build Pipelines will be processed. **Not implemented yet**
+            List of Build Pipelines to process. If this is `null` then all Build Pipelines will be processed.
             </summary>
         </member>
         <member name="P:MigrationTools.Processors.AzureDevOpsPipelineProcessorOptions.ReleasePipelines">
             <summary>
-            List of Release Pipelines to process. If this is `null` then all Release Pipelines will be processed. **Not implemented yet**
+            List of Release Pipelines to process. If this is `null` then all Release Pipelines will be processed.
             </summary>
         </member>
         <member name="T:MigrationTools.Processors.ProcessorModel">

--- a/src/MigrationTools.Clients.AzureDevops.Rest.Tests/Processors/AzureDevOpsPipelineProcessorTests.cs
+++ b/src/MigrationTools.Clients.AzureDevops.Rest.Tests/Processors/AzureDevOpsPipelineProcessorTests.cs
@@ -1,6 +1,10 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Serilog.Events;
+using Serilog.Sinks.InMemory;
 
 namespace MigrationTools.Processors.Tests
 {
@@ -53,7 +57,7 @@ namespace MigrationTools.Processors.Tests
             Assert.AreEqual(ProcessingStatus.Complete, processor.Status);
         }
 
-        [TestMethod, TestCategory("L3"), TestCategory("AzureDevOps.REST")]
+        [TestMethod, TestCategory("L3"), TestCategory("AzureDevOps.REST")]        
         public void AzureDevOpsPipelineProcessorSelectedBuildDefinitionsTest()
         {
             var config = new AzureDevOpsPipelineProcessorOptions
@@ -70,6 +74,51 @@ namespace MigrationTools.Processors.Tests
             processor.Execute();
 
             Assert.AreEqual(ProcessingStatus.Complete, processor.Status);
+
+            Func<LogEvent, bool> migrationMessageFilter = (LogEvent le) =>
+                le.MessageTemplate.Text == "{ObjectsToBeMigrated} of {TotalObjects} source {DefinitionType}(s) are going to be migrated.." &&
+                    GetValueFromProperty(le.Properties["DefinitionType"]).ToString() == nameof(DataContracts.Pipelines.BuildDefinition) &&
+                    GetValueFromProperty(le.Properties["ObjectsToBeMigrated"]).ToString() == "0" &&
+                    GetValueFromProperty(le.Properties["TotalObjects"]).ToString() == "0";
+            Func<LogEvent, bool> configuredMessageFilter = (LogEvent le) =>
+                le.MessageTemplate.Text == "Configured {Definition} definitions: {DefinitionList}" &&
+                    GetValueFromProperty(le.Properties["Definition"]).ToString() == nameof(DataContracts.Pipelines.BuildDefinition) &&
+                    GetValueFromProperty(le.Properties["DefinitionList"]).ToString() == "Test1;Test2";
+
+            Assert.AreEqual(1, InMemorySink.Instance.LogEvents.Count(migrationMessageFilter));
+            Assert.AreEqual(2, InMemorySink.Instance.LogEvents.Count(configuredMessageFilter));
+        }
+
+        [TestMethod, TestCategory("L3"), TestCategory("AzureDevOps.REST")]
+        public void AzureDevOpsPipelineProcessorSelectedReleaseDefinitionsTest()
+        {
+            var config = new AzureDevOpsPipelineProcessorOptions
+            {
+                ReleasePipelines = new List<string> { "Test1", "New release pipeline", "Test3" },
+                MigrateReleasePipelines = true,
+                Enabled = true,
+                SourceName = "Source",
+                TargetName = "Target",
+            };
+            var processor = Services.GetRequiredService<AzureDevOpsPipelineProcessor>();
+            processor.Configure(config);
+
+            processor.Execute();
+
+            Assert.AreEqual(ProcessingStatus.Complete, processor.Status);
+
+            Func<LogEvent, bool> migrationMessageFilter = (LogEvent le) =>
+                le.MessageTemplate.Text == "{ObjectsToBeMigrated} of {TotalObjects} source {DefinitionType}(s) are going to be migrated.." &&
+                    GetValueFromProperty(le.Properties["DefinitionType"]).ToString() == nameof(DataContracts.Pipelines.ReleaseDefinition) &&
+                    GetValueFromProperty(le.Properties["ObjectsToBeMigrated"]).ToString() == "0" &&
+                    GetValueFromProperty(le.Properties["TotalObjects"]).ToString() == "1";
+            Func<LogEvent, bool> configuredMessageFilter = (LogEvent le) =>
+                le.MessageTemplate.Text == "Configured {Definition} definitions: {DefinitionList}" &&
+                    GetValueFromProperty(le.Properties["Definition"]).ToString() == nameof(DataContracts.Pipelines.ReleaseDefinition) &&
+                    GetValueFromProperty(le.Properties["DefinitionList"]).ToString() == "Test1;New release pipeline;Test3";
+
+            Assert.AreEqual(1, InMemorySink.Instance.LogEvents.Count(migrationMessageFilter));
+            Assert.AreEqual(2, InMemorySink.Instance.LogEvents.Count(configuredMessageFilter));         
         }
     }
 }

--- a/src/MigrationTools.Clients.AzureDevops.Rest.Tests/Processors/AzureDevOpsPipelineProcessorTests.cs
+++ b/src/MigrationTools.Clients.AzureDevops.Rest.Tests/Processors/AzureDevOpsPipelineProcessorTests.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+﻿using System.Collections.Generic;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace MigrationTools.Processors.Tests
@@ -49,6 +50,25 @@ namespace MigrationTools.Processors.Tests
             var processor = Services.GetRequiredService<AzureDevOpsPipelineProcessor>();
             processor.Configure(migrationConfig);
             processor.Execute();
+            Assert.AreEqual(ProcessingStatus.Complete, processor.Status);
+        }
+
+        [TestMethod, TestCategory("L3"), TestCategory("AzureDevOps.REST")]
+        public void AzureDevOpsPipelineProcessorSelectedBuildDefinitionsTest()
+        {
+            var config = new AzureDevOpsPipelineProcessorOptions
+            {
+                BuildPipelines = new List<string> { "Test1", "Test2"},
+                MigrateBuildPipelines = true,
+                Enabled = true,
+                SourceName = "Source",
+                TargetName = "Target",
+            };
+            var processor = Services.GetRequiredService<AzureDevOpsPipelineProcessor>();
+            processor.Configure(config);
+
+            processor.Execute();
+
             Assert.AreEqual(ProcessingStatus.Complete, processor.Status);
         }
     }

--- a/src/MigrationTools.Clients.AzureDevops.Rest.Tests/Processors/AzureDevOpsProcessorTests.cs
+++ b/src/MigrationTools.Clients.AzureDevops.Rest.Tests/Processors/AzureDevOpsProcessorTests.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using MigrationTools.Tests;
+using Serilog.Events;
 
 namespace MigrationTools.Processors.Tests
 {
@@ -27,5 +28,12 @@ namespace MigrationTools.Processors.Tests
             };
             return migrationConfig;
         }
+
+        public static object GetValueFromProperty(LogEventPropertyValue value) =>
+            value switch
+        {
+            ScalarValue v => v.Value,
+            _ => value.ToString(),
+        };
     }
 }

--- a/src/MigrationTools.Clients.AzureDevops.Rest.Tests/Processors/AzureDevOpsProcessorTests.cs
+++ b/src/MigrationTools.Clients.AzureDevops.Rest.Tests/Processors/AzureDevOpsProcessorTests.cs
@@ -12,6 +12,7 @@ namespace MigrationTools.Processors.Tests
         [TestInitialize]
         public void Setup()
         {
+            Serilog.Sinks.InMemory.InMemorySink.Instance?.Dispose();            
         }
 
         protected static AzureDevOpsPipelineProcessorOptions GetAzureDevOpsPipelineProcessorOptions()

--- a/src/MigrationTools.Clients.AzureDevops.Rest/Processors/AzureDevOpsPipelineProcessorOptions.cs
+++ b/src/MigrationTools.Clients.AzureDevops.Rest/Processors/AzureDevOpsPipelineProcessorOptions.cs
@@ -37,12 +37,12 @@ namespace MigrationTools.Processors
         public bool MigrateServiceConnections { get; set; }
 
         /// <summary>
-        /// List of Build Pipelines to process. If this is `null` then all Build Pipelines will be processed. **Not implemented yet**
+        /// List of Build Pipelines to process. If this is `null` then all Build Pipelines will be processed.
         /// </summary>
         public List<string> BuildPipelines { get; set; }
 
         /// <summary>
-        /// List of Release Pipelines to process. If this is `null` then all Release Pipelines will be processed. **Not implemented yet**
+        /// List of Release Pipelines to process. If this is `null` then all Release Pipelines will be processed.
         /// </summary>
         public List<string> ReleasePipelines { get; set; }
 

--- a/src/MigrationTools.TestExtensions/MigrationTools.TestExtensions.csproj
+++ b/src/MigrationTools.TestExtensions/MigrationTools.TestExtensions.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0" />
     <PackageReference Include="Serilog.Sinks.Debug" Version="2.0.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />
+    <PackageReference Include="Serilog.Sinks.InMemory" Version="0.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MigrationTools.TestExtensions/ServiceCollectionExtensions.cs
+++ b/src/MigrationTools.TestExtensions/ServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@
 using Microsoft.Extensions.DependencyInjection;
 using Serilog;
 using Serilog.Events;
+using Serilog.Sinks.InMemory;
 
 namespace MigrationTools.TestExtensions
 {
@@ -19,7 +20,9 @@ namespace MigrationTools.TestExtensions
             // Logging for Unit Tests
             var loggers = new LoggerConfiguration().MinimumLevel.Verbose().Enrich.FromLogContext();
             loggers.WriteTo.Logger(logger => logger
-              .WriteTo.Debug(restrictedToMinimumLevel: LogEventLevel.Verbose));
+              .WriteTo.Debug(restrictedToMinimumLevel: LogEventLevel.Verbose))
+              .WriteTo.InMemory();
+
             Log.Logger = loggers.CreateLogger();
             Log.Logger.Information("Logger is initialized");
             context.AddLogging(loggingBuilder => loggingBuilder.AddSerilog(dispose: true));


### PR DESCRIPTION
This enables the ability to select the build and/or release pipelines to be migrated. It builds a list of query tasks based on the list provided in the configuration and tries to migrate them like before. If the configuration is not set or an empty list is provided, then then it queries for all the definitions like before. 

Also sets the repository query not to get additional details as they did not appear to be used and in the case of disabled repositories, will throw an error and stop the migration of the pipelines even if they aren't the ones being referenced in the build definitions.

Added a couple of tests as well as the [InMemory Serilog](https://github.com/serilog-contrib/SerilogSinksInMemory) package to make asserting for the correct logs easier. 

Tested via a DevOps Service to DevOps Service migration