### PR TITLE
fix: #1012

### DIFF
--- a/src/MigrationTools.Clients.AzureDevops.ObjectModel/ProcessorEnrichers/TfsNodeStructure.cs
+++ b/src/MigrationTools.Clients.AzureDevops.ObjectModel/ProcessorEnrichers/TfsNodeStructure.cs
@@ -115,11 +115,11 @@ namespace MigrationTools.Enrichers
             // Remove nodePath (Area or Iteration) from path for correct population in work item
             if (newNodeName.StartsWith(_targetProjectName + '\\' + tStructureName + '\\'))
             {
-                newNodeName = newNodeName.Remove(newNodeName.IndexOf($@"{nodeStructureType}\"), $@"{nodeStructureType}\".Length);
+                newNodeName = newNodeName.Remove(newNodeName.IndexOf($@"{tStructureName}\"), $@"{tStructureName}\".Length);
             }
             else if (newNodeName.StartsWith(_targetProjectName + '\\' + tStructureName))
             {
-                newNodeName = newNodeName.Remove(newNodeName.IndexOf($@"{nodeStructureType}"), $@"{nodeStructureType}".Length);
+                newNodeName = newNodeName.Remove(newNodeName.IndexOf($@"{tStructureName}"), $@"{tStructureName}".Length);
             }
             newNodeName = newNodeName.Replace(@"\\", @"\");
 


### PR DESCRIPTION
`GetNewNodeName` must use translated `nodeStructureType` before looking for its index

Otherwise a `System.ArgumentOutOfRangeException: StartIndex cannot be less than zero` is thrown when using a language specific `AreaPath` or `IterationPath`,

``` json
{
  "Target": {
    "$type": "TfsTeamProjectConfig",
    "LanguageMaps": {
      "AreaPath": "Área",
      "IterationPath": "Iteración"
    }
  }
}
```