### PR TITLE
Fixes InvalidOperationException in TfsWorkItemLinkEnricher.CreateHyperlink(...)'s .SingleOrDefault() usage

### DIFF
--- a/src/MigrationTools.Clients.AzureDevops.ObjectModel/Enrichers/TfsWorkItemLinkEnricher.cs
+++ b/src/MigrationTools.Clients.AzureDevops.ObjectModel/Enrichers/TfsWorkItemLinkEnricher.cs
@@ -362,9 +362,9 @@ namespace MigrationTools.Enrichers
             var exist = (from hyperlink in target.ToWorkItem().Links.Cast<Link>().Where(l => l is Hyperlink).Cast<Hyperlink>()
                          let absoluteUri = GetAbsoluteUri(hyperlink)
                          where sourceLinkAbsoluteUri == absoluteUri
-                         select hyperlink).SingleOrDefault();
+                         select hyperlink).Any();
 
-            if (exist != null)
+            if (exist)
             {
                 return;
             }

--- a/src/MigrationTools.Clients.AzureDevops.ObjectModel/Enrichers/TfsWorkItemLinkEnricher.cs
+++ b/src/MigrationTools.Clients.AzureDevops.ObjectModel/Enrichers/TfsWorkItemLinkEnricher.cs
@@ -359,9 +359,9 @@ namespace MigrationTools.Enrichers
                 return;
             }
 
-            var exist = (from hyperlink in target.ToWorkItem().Links.Cast<Link>().Where(l => l is Hyperlink).Cast<Hyperlink>()
+            var exist = (from hyperlink in target.ToWorkItem().Links.OfType<Hyperlink>()
                          let absoluteUri = GetAbsoluteUri(hyperlink)
-                         where sourceLinkAbsoluteUri == absoluteUri
+                         where string.Equals(sourceLinkAbsoluteUri, absoluteUri, StringComparison.OrdinalIgnoreCase)
                          select hyperlink).Any();
 
             if (exist)


### PR DESCRIPTION
TfsWorkItemLinkEnricher.CreateHyperlink(...) uses .SingleOrDefault() which throws an InvalidOperationException if more than 1 instances exist in an enumerable.

Looking at the code (and knowing how TFS/Azure DevOps Server/Services behave when trying to add the very same Hyperlink twice) I'd _assume_ the previous code was also theoretically fine, but apparently one way or another at least one of our work item managed to get the very same hyperlink because whenever I run (v11.11.23) of the migration tools, I get the following exception:

```
[15:00:05 INF] Found 22 revisions to migrate on  Work item:32134
[15:00:05 INF] Found 0 revisions to migrate on  Work item:32134
[15:00:05 INF] [          User Story][Complete:    26/67][sid: 32134|Rev: 22][tid:  null | Links 3 | LinkMigrator:True
[15:00:05 INF] Migrating link for 32134 of type Hyperlink
[15:00:05 INF] Migrating link for 32134 of type Hyperlink
[15:00:06 ERR] System.InvalidOperationException: Sequence contains more than one element
   at System.Linq.Enumerable.SingleOrDefault[TSource](IEnumerable`1 source)
   at MigrationTools.Enrichers.TfsWorkItemLinkEnricher.CreateHyperlink(Hyperlink sourceLink, WorkItemData target) in D:\a\1\s\src\MigrationTools.Clients.AzureDevops.ObjectModel\Enrichers\TfsWorkItemLinkEnricher.cs:line 362
   at MigrationTools.Enrichers.TfsWorkItemLinkEnricher.Enrich(WorkItemData sourceWorkItemLinkStart, WorkItemData targetWorkItemLinkStart) in D:\a\1\s\src\MigrationTools.Clients.AzureDevops.ObjectModel\Enrichers\TfsWorkItemLinkEnricher.cs:line 60
   at VstsSyncMigrator.Engine.WorkItemMigrationContext.ProcessWorkItemLinks(IWorkItemMigrationClient sourceStore, IWorkItemMigrationClient targetStore, WorkItemData sourceWorkItem, WorkItemData targetWorkItem) in D:\a\1\s\src\VstsSyncMigrator.Core\Execution\MigrationContext\WorkItemMigrationContext.cs:line 452
   at VstsSyncMigrator.Engine.WorkItemMigrationContext.<ProcessWorkItemAsync>d__31.MoveNext() in D:\a\1\s\src\VstsSyncMigrator.Core\Execution\MigrationContext\WorkItemMigrationContext.cs:line 345
System.InvalidOperationException: Sequence contains more than one element
   at System.Linq.Enumerable.SingleOrDefault[TSource](IEnumerable`1 source)
   at MigrationTools.Enrichers.TfsWorkItemLinkEnricher.CreateHyperlink(Hyperlink sourceLink, WorkItemData target) in D:\a\1\s\src\MigrationTools.Clients.AzureDevops.ObjectModel\Enrichers\TfsWorkItemLinkEnricher.cs:line 362
   at MigrationTools.Enrichers.TfsWorkItemLinkEnricher.Enrich(WorkItemData sourceWorkItemLinkStart, WorkItemData targetWorkItemLinkStart) in D:\a\1\s\src\MigrationTools.Clients.AzureDevops.ObjectModel\Enrichers\TfsWorkItemLinkEnricher.cs:line 60
   at VstsSyncMigrator.Engine.WorkItemMigrationContext.ProcessWorkItemLinks(IWorkItemMigrationClient sourceStore, IWorkItemMigrationClient targetStore, WorkItemData sourceWorkItem, WorkItemData targetWorkItem) in D:\a\1\s\src\VstsSyncMigrator.Core\Execution\MigrationContext\WorkItemMigrationContext.cs:line 452
   at VstsSyncMigrator.Engine.WorkItemMigrationContext.<ProcessWorkItemAsync>d__31.MoveNext() in D:\a\1\s\src\VstsSyncMigrator.Core\Execution\MigrationContext\WorkItemMigrationContext.cs:line 345
[15:00:06 FTL] Error while running WorkItemMigration
System.AggregateException: One or more errors occurred. ---> System.InvalidOperationException: Sequence contains more than one element
   at VstsSyncMigrator.Engine.WorkItemMigrationContext.<ProcessWorkItemAsync>d__31.MoveNext() in D:\a\1\s\src\VstsSyncMigrator.Core\Execution\MigrationContext\WorkItemMigrationContext.cs:line 415
   --- End of inner exception stack trace ---
   at System.Threading.Tasks.Task.ThrowIfExceptional(Boolean includeTaskCanceledExceptions)
   at System.Threading.Tasks.Task.Wait(Int32 millisecondsTimeout, CancellationToken cancellationToken)
   at VstsSyncMigrator.Engine.WorkItemMigrationContext.InternalExecute() in D:\a\1\s\src\VstsSyncMigrator.Core\Execution\MigrationContext\WorkItemMigrationContext.cs:line 151
   at MigrationTools._EngineV1.Processors.MigrationProcessorBase.Execute() in D:\a\1\s\src\MigrationTools\_EngineV1\Processors\MigrationProcessorBase.cs:line 47
---> (Inner Exception #0) System.InvalidOperationException: Sequence contains more than one element
   at VstsSyncMigrator.Engine.WorkItemMigrationContext.<ProcessWorkItemAsync>d__31.MoveNext() in D:\a\1\s\src\VstsSyncMigrator.Core\Execution\MigrationContext\WorkItemMigrationContext.cs:line 415<---
[15:00:06 ERR] WorkItemMigration The Processor MigrationEngine entered the failed state...stopping run
[15:00:06 INF] Application is shutting down...
[15:00:06 INF] Terminating: Application forcebly closed.
[15:00:06 INF] Application Ending
[15:00:06 INF] The application ran in 00:05:46.9683380 and finished at 01/12/2022 15:00:06
```

Given that the .CreateHyperlink(...) method only uses that linq and following .SingleOrDefault() statement to check whether a hyperlink to be added already exists, a .Any() call will do the same logically but not throw.