### PR TITLE
Migrating a YAML pipeline should not throw exceptions

### DIFF
--- a/src/MigrationTools/DataContracts/Pipelines/BuildDefinitions.cs
+++ b/src/MigrationTools/DataContracts/Pipelines/BuildDefinitions.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Dynamic;
 using System.Linq;
 using Microsoft.VisualStudio.Services.Common;
+using Newtonsoft.Json;
 
 namespace MigrationTools.DataContracts.Pipelines
 {
@@ -88,7 +89,7 @@ namespace MigrationTools.DataContracts.Pipelines
 
         public override bool HasTaskGroups()
         {
-            return Process.Phases.Any(p => p.Steps.Any(s => s.Task.DefinitionType.ToString() == "metaTask"));
+            return Process.Phases.Any(p => p.Steps.Any(s => s.Task.DefinitionType == "metaTask"));
         }
 
         public override bool HasVariableGroups()
@@ -171,8 +172,22 @@ namespace MigrationTools.DataContracts.Pipelines
     public partial class Process
     {
         public Phase[] Phases { get; set; } = new Phase[] { };
+        
+        public string YamlFilename { get; set; }
 
         public int Type { get; set; }
+
+        /// <summary>
+        /// If the value is set, then serialize it, if it isn't don't
+        /// </summary>
+        /// <returns>bool on if the YamlFilename should be serialized.</returns>
+        public bool ShouldSerializeYamlFilename() => this.Type == 2;
+
+        /// <summary>
+        /// If the type is 1 then this is a classis pipeline, so the phases should be serialized.
+        /// </summary>
+        /// <returns>bool on if the Phases should be serialized.</returns>
+        public bool ShouldSerializePhases() => this.Type == 1;
     }
 
     public partial class Phase

--- a/src/MigrationTools/DataContracts/Pipelines/BuildDefinitions.cs
+++ b/src/MigrationTools/DataContracts/Pipelines/BuildDefinitions.cs
@@ -296,7 +296,7 @@ namespace MigrationTools.DataContracts.Pipelines
 
         public string DefaultBranch { get; set; }
 
-        public bool Clean { get; set; }
+        public bool? Clean { get; set; }
 
         public bool CheckoutSubmodules { get; set; }
     }

--- a/src/MigrationTools/DataContracts/Pipelines/BuildDefinitions.cs
+++ b/src/MigrationTools/DataContracts/Pipelines/BuildDefinitions.cs
@@ -170,14 +170,14 @@ namespace MigrationTools.DataContracts.Pipelines
 
     public partial class Process
     {
-        public Phase[] Phases { get; set; }
+        public Phase[] Phases { get; set; } = new Phase[] { };
 
         public int Type { get; set; }
     }
 
     public partial class Phase
     {
-        public Step[] Steps { get; set; }
+        public Step[] Steps { get; set; } = new Step[] { };
 
         public string Name { get; set; }
 


### PR DESCRIPTION
Exception would be thrown when migrating YAML pipelines.

- `repository.clean` was set to null for YAML pipelines
- There are no `Phases` in YAML pipelines
- Missing `YamlFilename` property in the Process type.

Tests run and passing after the change. Tested migrating a Classic and YAML pipeline from one AzDo project to another AzDo project.