### PR TITLE
Fix for Inline Images In Comments

### DIFF
--- a/src/MigrationTools.Clients.AzureDevops.ObjectModel/Enrichers/TfsEmbededImagesEnricher.cs
+++ b/src/MigrationTools.Clients.AzureDevops.ObjectModel/Enrichers/TfsEmbededImagesEnricher.cs
@@ -52,7 +52,8 @@ namespace MigrationTools.Enrichers
             Log.LogInformation($"{logTypeName}: Fixing HTML field attachments for work item {wi.Id} from {oldTfsurl} to {newTfsurl}");
 
             var oldTfsurlOppositeSchema = GetUrlWithOppositeSchema(oldTfsurl);
-            string regExSearchForImageUrl = "(?<=<img.*src=\")[^\"]*";
+            const string regExSearchForImageUrl = "(?<=<img.*src=\")[^\"]*";
+            const string regExSearchFileName = "(?<=FileName=)[^=]*";
 
             foreach (Field field in wi.ToWorkItem().Fields)
             {
@@ -65,7 +66,6 @@ namespace MigrationTools.Enrichers
                 {
                     MatchCollection matches = Regex.Matches((string)field.Value, regExSearchForImageUrl);
 
-                    string regExSearchFileName = "(?<=FileName=)[^=]*";
                     foreach (Match match in matches)
                     {
                         if (!match.Value.ToLower().Contains(oldTfsurl.ToLower()) && !match.Value.ToLower().Contains(oldTfsurlOppositeSchema.ToLower()))

--- a/src/MigrationTools/DataContracts/Pipelines/BuildDefinitions.cs
+++ b/src/MigrationTools/DataContracts/Pipelines/BuildDefinitions.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Dynamic;
 using System.Linq;
 using Microsoft.VisualStudio.Services.Common;
+using Newtonsoft.Json;
 
 namespace MigrationTools.DataContracts.Pipelines
 {
@@ -88,7 +89,7 @@ namespace MigrationTools.DataContracts.Pipelines
 
         public override bool HasTaskGroups()
         {
-            return Process.Phases.Any(p => p.Steps.Any(s => s.Task.DefinitionType.ToString() == "metaTask"));
+            return Process.Phases.Any(p => p.Steps.Any(s => s.Task.DefinitionType == "metaTask"));
         }
 
         public override bool HasVariableGroups()
@@ -170,14 +171,28 @@ namespace MigrationTools.DataContracts.Pipelines
 
     public partial class Process
     {
-        public Phase[] Phases { get; set; }
+        public Phase[] Phases { get; set; } = new Phase[] { };
+        
+        public string YamlFilename { get; set; }
 
         public int Type { get; set; }
+
+        /// <summary>
+        /// If the value is set, then serialize it, if it isn't don't
+        /// </summary>
+        /// <returns>bool on if the YamlFilename should be serialized.</returns>
+        public bool ShouldSerializeYamlFilename() => this.Type == 2;
+
+        /// <summary>
+        /// If the type is 1 then this is a classis pipeline, so the phases should be serialized.
+        /// </summary>
+        /// <returns>bool on if the Phases should be serialized.</returns>
+        public bool ShouldSerializePhases() => this.Type == 1;
     }
 
     public partial class Phase
     {
-        public Step[] Steps { get; set; }
+        public Step[] Steps { get; set; } = new Step[] { };
 
         public string Name { get; set; }
 
@@ -296,7 +311,7 @@ namespace MigrationTools.DataContracts.Pipelines
 
         public string DefaultBranch { get; set; }
 
-        public bool Clean { get; set; }
+        public bool? Clean { get; set; }
 
         public bool CheckoutSubmodules { get; set; }
     }

--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemMigrationContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemMigrationContext.cs
@@ -340,6 +340,7 @@ namespace VstsSyncMigrator.Engine
                         {
                             ProcessWorkItemAttachments(sourceWorkItem, targetWorkItem, false);
                             ProcessWorkItemLinks(Engine.Source.WorkItems, Engine.Target.WorkItems, sourceWorkItem, targetWorkItem);
+                            ProcessHTMLFieldAttachements(targetWorkItem);
                             TraceWriteLine(LogEventLevel.Information, "Skipping as work item exists and no revisions to sync detected");
                             processWorkItemMetrics.Add("Revisions", 0);
                         }
@@ -357,10 +358,7 @@ namespace VstsSyncMigrator.Engine
                         }
                     }
                     AddParameter("TargetWorkItem", processWorkItemParamiters, targetWorkItem.ToWorkItem().Revisions.Count.ToString());
-                    ///////////////////////////////////////////////
-                    ProcessHTMLFieldAttachements(targetWorkItem);
-                    ///////////////////////////////////////////////
-                    ///////////////////////////////////////////////////////
+
                     if (targetWorkItem != null && targetWorkItem.ToWorkItem().IsDirty)
                     {
                         targetWorkItem.SaveToAzureDevOps();
@@ -517,6 +515,8 @@ namespace VstsSyncMigrator.Engine
                         throw ex;
                     }
                     targetWorkItem.ToWorkItem().Fields[Engine.Target.Config.AsTeamProjectConfig().ReflectedWorkItemIDFieldName].Value = reflectedUri.ToString();
+
+                    ProcessHTMLFieldAttachements(targetWorkItem);
 
                     targetWorkItem.SaveToAzureDevOps();
                     TraceWriteLine(LogEventLevel.Information,


### PR DESCRIPTION
# Description
Made some changes on `TfsEmbededImagesEnricher` to replaced the hack of uploading an image as attachment on workitem, saving workitem, removing the attachment and saving again with just the attachment upload api without needing to save the work item. 

Also enhanced this `TfsEmbededImagesEnricher` in addition with `WorkItemMigrationContext` to be able to make it work on discussion history comments as it was not working for history comments. 

Fixes # (issue)
#424 
May be also fixes #276 ?

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change may require a documentation update??

# How Has This Been Tested?
I have tested it on my production migration from Azure DevOps Server to Azure DevOps Services for inline images in all the HTML fields as well as discussion comments history.

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
