### PR TITLE
Enhancement to fix inline workitem/user mention links on HTML fields as well as Comments history 

### DIFF
--- a/src/MigrationTools.Clients.AzureDevops.ObjectModel/Enrichers/TfsWorkItemEmbededLinkEnricher.cs
+++ b/src/MigrationTools.Clients.AzureDevops.ObjectModel/Enrichers/TfsWorkItemEmbededLinkEnricher.cs
@@ -1,0 +1,145 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.TeamFoundation.Client;
+using Microsoft.TeamFoundation.Framework.Client;
+using Microsoft.TeamFoundation.Framework.Common;
+using Microsoft.TeamFoundation.WorkItemTracking.Client;
+using MigrationTools.DataContracts;
+using MigrationTools.Processors;
+
+namespace MigrationTools.Enrichers
+{
+    public class TfsWorkItemEmbededLinkEnricher : WorkItemProcessorEnricher
+    {
+        private const string RegexPatternLinkAnchorTag = "<a[^>].*?(?:href=\"(?<href>[^\"]*)\".*?|(?<version>data-vss-mention=\"[^\"]*\").*?)*>(?<value>.*?)<\\/a?>";
+        private const string RegexPatternWorkItemUrl = "http[s]*://.*?/_workitems/edit/(?<id>\\d+)";
+        private readonly Lazy<List<TeamFoundationIdentity>> _targetTeamFoundationIdentities;
+
+        private IMigrationEngine Engine;
+        
+        public TfsWorkItemEmbededLinkEnricher(IServiceProvider services, ILogger<TfsWorkItemEmbededLinkEnricher> logger)
+            : base(services, logger)
+        {
+            Engine = services.GetRequiredService<IMigrationEngine>();
+            _targetTeamFoundationIdentities = new Lazy<List<TeamFoundationIdentity>>(() =>
+            {
+                TfsTeamService teamService = Engine.Target.GetService<TfsTeamService>();
+                TfsConnection connection = (TfsConnection)Engine.Target.InternalCollection;
+
+                var identityService = Engine.Target.GetService<IIdentityManagementService>();
+                var tfi = identityService.ReadIdentity(IdentitySearchFactor.General, "Project Collection Valid Users", MembershipQuery.Expanded, ReadIdentityOptions.None);
+                return identityService.ReadIdentities(tfi.Members, MembershipQuery.None, ReadIdentityOptions.None).ToList();
+            });
+        }
+
+        [Obsolete]
+        public override void Configure(bool save = false, bool filterWorkItemsThatAlreadyExistInTarget = true)
+        {
+            throw new NotImplementedException();
+        }
+
+        [Obsolete]
+        public override int Enrich(WorkItemData sourceWorkItem, WorkItemData targetWorkItem)
+        {
+            string oldTfsurl = Engine.Source.Config.AsTeamProjectConfig().Collection.ToString();
+            string newTfsurl = Engine.Target.Config.AsTeamProjectConfig().Collection.ToString();
+
+            var logTypeName = nameof(TfsWorkItemEmbededLinkEnricher);
+            Log.LogInformation($"{logTypeName}: Fixing embedded mention links on target work item {targetWorkItem.Id} from {oldTfsurl} to {newTfsurl}");
+
+            foreach (Field field in targetWorkItem.ToWorkItem().Fields)
+            {
+                if (field.Value == null
+                    || string.IsNullOrWhiteSpace(field.Value.ToString())
+                    || (field.FieldDefinition.FieldType != FieldType.Html && field.FieldDefinition.FieldType != FieldType.History))
+                {
+                    continue;
+                }
+
+                try
+                {
+                    var anchorTagMatches = Regex.Matches((string)field.Value, RegexPatternLinkAnchorTag);
+                    foreach (Match anchorTagMatch in anchorTagMatches)
+                    {
+                        if (!anchorTagMatch.Success) continue;
+
+                        var href = anchorTagMatch.Groups["href"].Value;
+                        var version = anchorTagMatch.Groups["version"].Value;
+                        var value = anchorTagMatch.Groups["value"].Value;
+
+                        if (string.IsNullOrWhiteSpace(href) || string.IsNullOrWhiteSpace(version) || string.IsNullOrWhiteSpace(value))
+                            continue;
+
+                        var workItemLinkMatch = Regex.Match(href, RegexPatternWorkItemUrl);
+                        if (workItemLinkMatch.Success)
+                        {
+                            var workItemId = workItemLinkMatch.Groups["id"].Value;
+                            Log.LogDebug($"{logTypeName}: Source work item {workItemId} mention link traced on field {field.Name} on target work item {targetWorkItem.Id}.");
+                            var sourceLinkWi = Engine.Source.WorkItems.GetWorkItem(workItemId);
+                            if (sourceLinkWi != null)
+                            {
+                                var linkWI = Engine.Target.WorkItems.FindReflectedWorkItemByReflectedWorkItemId(sourceLinkWi);
+                                if (linkWI != null)
+                                {
+                                    var replaceValue = anchorTagMatch.Value.Replace(workItemId, linkWI.Id);
+                                    field.Value = field.Value.ToString().Replace(anchorTagMatch.Value, replaceValue);
+                                    Log.LogInformation($"{logTypeName}: Source work item {workItemId} mention link was successfully replaced with target work item {linkWI.Id} mention link on field {field.Name} on target work item {targetWorkItem.Id}.");
+                                }
+                                else
+                                {
+                                    Log.LogError($"{logTypeName}: Matching target work item mention link for source work item {workItemId} mention link on field {field.Name} on target work item {targetWorkItem.Id} was not found on the target collection.");
+                                }
+                            }
+                            else
+                            {
+                                Log.LogInformation($"{logTypeName}: [SKIP] Source work item {workItemId} mention link on field {field.Name} on target work item {targetWorkItem.Id} was not found on the source collection.");
+                            }
+                        }
+                        else if ((href.StartsWith("mailto:") || href.StartsWith("#")) && value.StartsWith("@"))
+                        {
+                            var displayName = value.Substring(1);
+                            Log.LogDebug($"{logTypeName}: User identity {displayName} mention traced on field {field.Name} on target work item {targetWorkItem.Id}.");
+                            var identity = _targetTeamFoundationIdentities.Value.FirstOrDefault(i => i.DisplayName == displayName);
+                            if (identity != null)
+                            {
+                                var replaceValue = anchorTagMatch.Value.Replace(href, "#").Replace(version, $"data-vss-mention=\"version:2.0,{identity.TeamFoundationId}\"");
+                                field.Value = field.Value.ToString().Replace(anchorTagMatch.Value, replaceValue);
+                                Log.LogInformation($"{logTypeName}: User identity {displayName} mention was successfully matched on field {field.Name} on target work item {targetWorkItem.Id}.");
+                            }
+                            else
+                            {
+                                Log.LogInformation($"{logTypeName}: [SKIP] Matching user identity {displayName} mention was not found on field {field.Name} on target work item {targetWorkItem.Id}.");
+                            }
+                        }
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Log.LogError(ex, $"{logTypeName}: Unable to fix embedded mention links on field {field.Name} on target work item {targetWorkItem.Id} from {oldTfsurl} to {newTfsurl}");
+                }
+            }
+
+            return 0;
+        }
+
+        [Obsolete("v2 Archtecture: use Configure(bool save = true, bool filter = true) instead", true)]
+        public override void Configure(IProcessorEnricherOptions options)
+        {
+            throw new NotImplementedException();
+        }
+
+        protected override void RefreshForProcessorType(IProcessor processor)
+        {
+            throw new NotImplementedException();
+        }
+
+        protected override void EntryForProcessorType(IProcessor processor)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/MigrationTools.Clients.AzureDevops.ObjectModel/ServiceCollectionExtensions.cs
+++ b/src/MigrationTools.Clients.AzureDevops.ObjectModel/ServiceCollectionExtensions.cs
@@ -28,6 +28,7 @@ namespace MigrationTools
             // Enrichers
             context.AddSingleton<TfsValidateRequiredField>();
             context.AddSingleton<TfsWorkItemLinkEnricher>();
+            context.AddSingleton<TfsWorkItemEmbededLinkEnricher>();
             context.AddSingleton<TfsEmbededImagesEnricher>();
             context.AddSingleton<TfsGitRepositoryEnricher>();
             context.AddSingleton<TfsNodeStructure>();

--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemMigrationContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemMigrationContext.cs
@@ -40,6 +40,7 @@ namespace VstsSyncMigrator.Engine
         private ILogger contextLog;
         private IAttachmentMigrationEnricher attachmentEnricher;
         private IWorkItemProcessorEnricher embededImagesEnricher;
+        private IWorkItemProcessorEnricher workItemEmbededLinkEnricher;
         private TfsGitRepositoryEnricher gitRepositoryEnricher;
         private TfsNodeStructure nodeStructureEnricher;
         private TfsRevisionManager revisionManager;
@@ -86,6 +87,7 @@ namespace VstsSyncMigrator.Engine
             attachmentEnricher = new TfsAttachmentEnricher(workItemServer, _config.AttachmentWorkingPath, _config.AttachmentMaxSize);
             workItemLinkEnricher = Services.GetRequiredService<TfsWorkItemLinkEnricher>();
             embededImagesEnricher = Services.GetRequiredService<TfsEmbededImagesEnricher>();
+            workItemEmbededLinkEnricher = Services.GetRequiredService<TfsWorkItemEmbededLinkEnricher>();
             gitRepositoryEnricher = Services.GetRequiredService<TfsGitRepositoryEnricher>();
             nodeStructureEnricher = Services.GetRequiredService<TfsNodeStructure>();
             nodeStructureEnricher.Configure(new TfsNodeStructureOptions() { Enabled = _config.NodeStructureEnricherEnabled ?? true, NodeBasePaths = _config.NodeBasePaths, PrefixProjectToNodes = _config.PrefixProjectToNodes });
@@ -302,6 +304,14 @@ namespace VstsSyncMigrator.Engine
             }
         }
 
+        private void ProcessWorkItemEmbeddedLinks(WorkItemData sourceWorkItem, WorkItemData targetWorkItem)
+        {
+            if (sourceWorkItem != null && targetWorkItem != null && _config.FixHtmlAttachmentLinks)
+            {
+                workItemEmbededLinkEnricher.Enrich(sourceWorkItem, targetWorkItem);
+            }
+        }
+
         private async Task ProcessWorkItemAsync(WorkItemData sourceWorkItem, int retryLimit = 5, int retries = 0)
         {
             var witStopWatch = Stopwatch.StartNew();
@@ -340,6 +350,7 @@ namespace VstsSyncMigrator.Engine
                         {
                             ProcessWorkItemAttachments(sourceWorkItem, targetWorkItem, false);
                             ProcessWorkItemLinks(Engine.Source.WorkItems, Engine.Target.WorkItems, sourceWorkItem, targetWorkItem);
+                            ProcessWorkItemEmbeddedLinks(sourceWorkItem, targetWorkItem);
                             TraceWriteLine(LogEventLevel.Information, "Skipping as work item exists and no revisions to sync detected");
                             processWorkItemMetrics.Add("Revisions", 0);
                         }
@@ -517,6 +528,8 @@ namespace VstsSyncMigrator.Engine
                         throw ex;
                     }
                     targetWorkItem.ToWorkItem().Fields[Engine.Target.Config.AsTeamProjectConfig().ReflectedWorkItemIDFieldName].Value = reflectedUri.ToString();
+
+                    ProcessWorkItemEmbeddedLinks(sourceWorkItem, targetWorkItem);
 
                     targetWorkItem.SaveToAzureDevOps();
                     TraceWriteLine(LogEventLevel.Information,


### PR DESCRIPTION
# Description
Enhancement to fix inline workitem mention links as well as like for like person/user mentions on all the HTML fields as well as discussion comment history. It uses *FixHtmlAttachmentLinks* flag on the configuration so if true, it processes otherwise it does not.

Please note that the user mentions will flood the user with lots of notification emails. To avoid sending notification emails, remove the user from the Target Team Project but the user need to exists on the Target Organisation.

Might need documentation update but I am not sure how or where to go by updating it.

Fixes # (issue)
#416 
#115 
#587 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change may require a documentation update??

# How Has This Been Tested?
I have tested it on my production migration from Azure DevOps Server to Azure DevOps Services for inline workitem mentions as well as person/user mentions on html fields as well as discussion comment history.

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
