### PR TITLE
WIQLQueryBit Area Path & Iteration Path replacing source project with target project fix and enhancement

### DIFF
--- a/src/VstsSyncMigrator.Core.Tests/WorkItemMigrationTests.cs
+++ b/src/VstsSyncMigrator.Core.Tests/WorkItemMigrationTests.cs
@@ -7,82 +7,78 @@ namespace VstsSyncMigrator.Core.Tests
     public class WorkItemMigrationTests
     {        
         [TestMethod]
-        public void TestFixAreaPath_WhenNoAreaPathOrNodeBasePaths_DoesntChangeQuery()
+        public void TestFixAreaPath_WhenNoAreaPathOrIterationPath_DoesntChangeQuery()
         {
             string WIQLQueryBit = @"AND  [Microsoft.VSTS.Common.ClosedDate] = '' AND [System.WorkItemType] NOT IN ('Test Suite', 'Test Plan')";
 
-            string[] nodeBasePaths = null;
-            string targetWIQLQueryBit = WorkItemMigrationContext.FixAreaPathInTargetQuery(WIQLQueryBit, "SourceServer", "TargetServer", nodeBasePaths, null);
+            string targetWIQLQueryBit = WorkItemMigrationContext.FixAreaPathAndIterationPathForTargetQuery(WIQLQueryBit, "SourceServer", "TargetServer", null);
 
             Assert.AreEqual(WIQLQueryBit, targetWIQLQueryBit);
         }
 
+        
         [TestMethod]
-        public void TestFixAreaPath_WhenNoAreaPathAndOneNodeBasePaths_DoesntChangeQuery()
-        {
-            string WIQLQueryBit = @"AND  [Microsoft.VSTS.Common.ClosedDate] = '' AND [System.WorkItemType] NOT IN ('Test Suite', 'Test Plan')";
-
-            string[] nodeBasePaths = { "SourceServer\\Area\\Path1" };
-            string targetWIQLQueryBit = WorkItemMigrationContext.FixAreaPathInTargetQuery(WIQLQueryBit, "SourceServer", "TargetServer", nodeBasePaths, null);
-
-            Assert.AreEqual(WIQLQueryBit, targetWIQLQueryBit);
-        }
-
-        [TestMethod]
-        public void TestFixAreaPath_WhenNoAreaPathAndTwoNodeBasePaths_DoesntChangeQuery()
-        {
-            string WIQLQueryBit = @"AND  [Microsoft.VSTS.Common.ClosedDate] = '' AND [System.WorkItemType] NOT IN ('Test Suite', 'Test Plan')";
-
-            string[] nodeBasePaths = { "SourceServer\\Area\\Path1", "SourceServer\\Area\\Path1" };
-            string targetWIQLQueryBit = WorkItemMigrationContext.FixAreaPathInTargetQuery(WIQLQueryBit, "SourceServer", "TargetServer", nodeBasePaths, null);
-
-            Assert.AreEqual(WIQLQueryBit, targetWIQLQueryBit);
-        }
-
-
-        [TestMethod]
-        public void TestFixAreaPath_WhenAreaPathInQueryAndNodeBasePaths_ChangesQuery()
+        public void TestFixAreaPath_WhenAreaPathInQuery_ChangesQuery()
         {
             string WIQLQueryBit =         @"AND [System.AreaPath] = 'SourceServer\Area\Path1' AND   [Microsoft.VSTS.Common.ClosedDate] = '' AND [System.WorkItemType] NOT IN ('Test Suite', 'Test Plan')";
             string expectTargetQueryBit = @"AND [System.AreaPath] = 'TargetServer\Area\Path1' AND   [Microsoft.VSTS.Common.ClosedDate] = '' AND [System.WorkItemType] NOT IN ('Test Suite', 'Test Plan')";
-            string[] nodeBasePaths = { "SourceServer\\Area\\Path1" };
 
-            string targetWIQLQueryBit = WorkItemMigrationContext.FixAreaPathInTargetQuery(WIQLQueryBit, "SourceServer", "TargetServer", nodeBasePaths, null);
+            string targetWIQLQueryBit = WorkItemMigrationContext.FixAreaPathAndIterationPathForTargetQuery(WIQLQueryBit, "SourceServer", "TargetServer", null);
 
             Assert.AreEqual(expectTargetQueryBit, targetWIQLQueryBit);
         }
 
         [TestMethod]
-        public void TestFixAreaPath_WhenAreaPathInQueryAndTwoNodeBasePaths_ChangesQuery()
+        public void TestFixAreaPath_WhenMultipleAreaPathInQuery_ChangesQuery()
         {
             string WIQLQueryBit =         @"AND [System.AreaPath] = 'SourceServer\Area\Path1' OR [System.AreaPath] = 'SourceServer\Area\Path2' AND [Microsoft.VSTS.Common.ClosedDate] = '' AND [System.WorkItemType] NOT IN ('Test Suite', 'Test Plan')";
             string expectTargetQueryBit = @"AND [System.AreaPath] = 'TargetServer\Area\Path1' OR [System.AreaPath] = 'TargetServer\Area\Path2' AND [Microsoft.VSTS.Common.ClosedDate] = '' AND [System.WorkItemType] NOT IN ('Test Suite', 'Test Plan')";
-            string[] nodeBasePaths = { "SourceServer\\Area\\Path1", "SourceServer\\Area\\Path2" };
 
-            string targetWIQLQueryBit = WorkItemMigrationContext.FixAreaPathInTargetQuery(WIQLQueryBit, "SourceServer", "TargetServer", nodeBasePaths, null);
+            string targetWIQLQueryBit = WorkItemMigrationContext.FixAreaPathAndIterationPathForTargetQuery(WIQLQueryBit, "SourceServer", "TargetServer", null);
 
             Assert.AreEqual(expectTargetQueryBit, targetWIQLQueryBit);
         }
 
         [TestMethod]
-        public void TestFixAreaPath_WhenAreaPathInQueryAndNodeBasePathsIsMoreSpecific_DoesntChangeQuery()
-        {
-            string WIQLQueryBit = @"AND [System.AreaPath] = 'SourceServer\Area\' AND [Microsoft.VSTS.Common.ClosedDate] = '' AND [System.WorkItemType] NOT IN ('Test Suite', 'Test Plan')";            
-            string[] nodeBasePaths = { "SourceServer\\Area\\Path1", "SourceServer\\Area\\Path2" };
-
-            string targetWIQLQueryBit = WorkItemMigrationContext.FixAreaPathInTargetQuery(WIQLQueryBit, "SourceServer", "TargetServer", nodeBasePaths, null);
-
-            Assert.AreEqual(WIQLQueryBit, targetWIQLQueryBit);
-        }
-
-        [TestMethod]
-        public void TestFixAreaPath_WhenAreaPathAtEndOfQueryAndNodeBasePaths_ChangesQuery()
+        public void TestFixAreaPath_WhenAreaPathAtEndOfQuery_ChangesQuery()
         {
             string WIQLQueryBit =         @"AND [Microsoft.VSTS.Common.ClosedDate] = '' AND [System.WorkItemType] NOT IN ('Test Suite', 'Test Plan') AND [System.AreaPath] = 'SourceServer\Area\Path1'";
             string expectTargetQueryBit = @"AND [Microsoft.VSTS.Common.ClosedDate] = '' AND [System.WorkItemType] NOT IN ('Test Suite', 'Test Plan') AND [System.AreaPath] = 'TargetServer\Area\Path1'";
-            string[] nodeBasePaths = { "SourceServer\\Area\\Path1" };
 
-            string targetWIQLQueryBit = WorkItemMigrationContext.FixAreaPathInTargetQuery(WIQLQueryBit, "SourceServer", "TargetServer", nodeBasePaths, null);
+            string targetWIQLQueryBit = WorkItemMigrationContext.FixAreaPathAndIterationPathForTargetQuery(WIQLQueryBit, "SourceServer", "TargetServer", null);
+
+            Assert.AreEqual(expectTargetQueryBit, targetWIQLQueryBit);
+        }
+
+        [TestMethod]
+        public void TestFixIterationPath_WhenInQuery_ChangesQuery()
+        {
+            string WIQLQueryBit = @"AND [System.IterationPath] = 'SourceServer\Iteration\Path1' AND   [Microsoft.VSTS.Common.ClosedDate] = '' AND [System.WorkItemType] NOT IN ('Test Suite', 'Test Plan')";
+            string expectTargetQueryBit = @"AND [System.IterationPath] = 'TargetServer\Iteration\Path1' AND   [Microsoft.VSTS.Common.ClosedDate] = '' AND [System.WorkItemType] NOT IN ('Test Suite', 'Test Plan')";
+
+            string targetWIQLQueryBit = WorkItemMigrationContext.FixAreaPathAndIterationPathForTargetQuery(WIQLQueryBit, "SourceServer", "TargetServer", null);
+
+            Assert.AreEqual(expectTargetQueryBit, targetWIQLQueryBit);
+        }
+
+        [TestMethod]
+        public void TestFixAreaPathAndIteration_WhenMultipleOccuranceInQuery_ChangesQuery()
+        {
+            string WIQLQueryBit = @"AND ([System.AreaPath] = 'SourceServer\Area\Path1' OR [System.AreaPath] = 'SourceServer\Area\Path2') AND ([System.IterationPath] = 'SourceServer\Iteration\Path1' OR [System.IterationPath] = 'SourceServer\Iteration\Path2') AND [Microsoft.VSTS.Common.ClosedDate] = '' AND [System.WorkItemType] NOT IN ('Test Suite', 'Test Plan')";
+            string expectTargetQueryBit = @"AND ([System.AreaPath] = 'TargetServer\Area\Path1' OR [System.AreaPath] = 'TargetServer\Area\Path2') AND ([System.IterationPath] = 'TargetServer\Iteration\Path1' OR [System.IterationPath] = 'TargetServer\Iteration\Path2') AND [Microsoft.VSTS.Common.ClosedDate] = '' AND [System.WorkItemType] NOT IN ('Test Suite', 'Test Plan')";
+
+            string targetWIQLQueryBit = WorkItemMigrationContext.FixAreaPathAndIterationPathForTargetQuery(WIQLQueryBit, "SourceServer", "TargetServer", null);
+
+            Assert.AreEqual(expectTargetQueryBit, targetWIQLQueryBit);
+        }
+
+        [TestMethod]
+        public void TestFixAreaPathAndIteration_WhenMultipleOccuranceWithMixtureOrEqualAndUnderOperatorsInQuery_ChangesQuery()
+        {
+            string WIQLQueryBit = @"AND ([System.AreaPath] = 'SourceServer\Area\Path1' OR [System.AreaPath] UNDER 'SourceServer\Area\Path2') AND ([System.IterationPath] UNDER 'SourceServer\Iteration\Path1' OR [System.IterationPath] = 'SourceServer\Iteration\Path2') AND [Microsoft.VSTS.Common.ClosedDate] = '' AND [System.WorkItemType] NOT IN ('Test Suite', 'Test Plan')";
+            string expectTargetQueryBit = @"AND ([System.AreaPath] = 'TargetServer\Area\Path1' OR [System.AreaPath] UNDER 'TargetServer\Area\Path2') AND ([System.IterationPath] UNDER 'TargetServer\Iteration\Path1' OR [System.IterationPath] = 'TargetServer\Iteration\Path2') AND [Microsoft.VSTS.Common.ClosedDate] = '' AND [System.WorkItemType] NOT IN ('Test Suite', 'Test Plan')";
+
+            string targetWIQLQueryBit = WorkItemMigrationContext.FixAreaPathAndIterationPathForTargetQuery(WIQLQueryBit, "SourceServer", "TargetServer", null);
 
             Assert.AreEqual(expectTargetQueryBit, targetWIQLQueryBit);
         }


### PR DESCRIPTION
# Description
There was a problem with the existing code where it tries to replace the source project name with target project name for System.AreaPath filter WIQLQueryBit. 

Before this change, the code only worked for AreaPath filter. Also it was dependent on NodeBasePaths which seems wrong. It did not work when using UNDER operator.

The above is fixed with this change. An enhancement is added so that it also works for IterationPath filter and it no longer depends on NodeBasePaths. Existing unit tests are updated and couple new added.

Might need documentation update but I am not sure how or where to go by updating it.

Fixes #396 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change may require a documentation update??

# How Has This Been Tested?
I have tested it on my production migration from Azure DevOps Server to Azure DevOps Services when using System.AreaPath and System.IterationPath filters on the WIQLQueryBit.

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
