### PR TITLE
Enhancement added to TfsTeamSettingsProcessor to migrate team capacities

### DIFF
--- a/docs/Reference/Processors/TfsTeamSettingsProcessor.json
+++ b/docs/Reference/Processors/TfsTeamSettingsProcessor.json
@@ -3,6 +3,7 @@
   "Enabled": false,
   "MigrateTeamSettings": true,
   "UpdateTeamSettings": true,
+  "MigrateTeamCapacities": false,
   "PrefixProjectToNodes": false,
   "Teams": null,
   "ProcessorEnrichers": null,

--- a/docs/Reference/Processors/TfsTeamSettingsProcessor.md
+++ b/docs/Reference/Processors/TfsTeamSettingsProcessor.md
@@ -13,6 +13,7 @@ Native TFS Processor, does not work with any other Endpoints.
 | Enabled | Boolean | If set to `true` then the processor will run. Set to `false` and the processor will not run. | missng XML code comments |
 | MigrateTeamSettings | Boolean | Migrate original team settings after their creation on target team project | false |
 | UpdateTeamSettings | Boolean | Reset the target team settings to match the source if the team exists | false |
+| MigrateTeamCapacities | Boolean | Migrate original team member capacities after their creation on the target team project. Note: It will only migrate team member capacity if the team member with same display name exists on the target collection otherwise it will be ignored. | false |
 | PrefixProjectToNodes | Boolean | Prefix your iterations and areas with the project name. If you have enabled this in `NodeStructuresMigrationConfig` you must do it here too. | false |
 | Teams | List | List of Teams to process. If this is `null` then all teams will be processed. | missng XML code comments |
 | ProcessorEnrichers | List | List of Enrichers that can be used to add more features to this processor. Only works with Native Processors and not legacy Processors. | missng XML code comments |
@@ -29,6 +30,7 @@ Native TFS Processor, does not work with any other Endpoints.
   "Enabled": false,
   "MigrateTeamSettings": true,
   "UpdateTeamSettings": true,
+  "MigrateTeamCapacities": false,
   "PrefixProjectToNodes": false,
   "Teams": null,
   "ProcessorEnrichers": null,

--- a/src/MigrationTools.Clients.AzureDevops.ObjectModel/Endpoints/TfsTeamSettingsEndpoint.cs
+++ b/src/MigrationTools.Clients.AzureDevops.ObjectModel/Endpoints/TfsTeamSettingsEndpoint.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Extensions.Logging;
 using Microsoft.TeamFoundation.Client;
 using Microsoft.TeamFoundation.ProcessConfiguration.Client;
+using Microsoft.TeamFoundation.Work.WebApi;
 using MigrationTools.EndpointEnrichers;
 
 namespace MigrationTools.Endpoints
@@ -15,5 +16,7 @@ namespace MigrationTools.Endpoints
         public TfsTeamService TfsTeamService { get { return TfsCollection.GetService<TfsTeamService>(); } }
 
         public TeamSettingsConfigurationService TfsTeamSettingsService { get { return TfsCollection.GetService<TeamSettingsConfigurationService>(); } }
+
+        public WorkHttpClient WorkHttpClient { get { return TfsCollection.GetClient<WorkHttpClient>(); } }
     }
 }

--- a/src/MigrationTools.Clients.AzureDevops.ObjectModel/Processors/TfsTeamSettingsProcessorOptions.cs
+++ b/src/MigrationTools.Clients.AzureDevops.ObjectModel/Processors/TfsTeamSettingsProcessorOptions.cs
@@ -24,6 +24,12 @@ namespace MigrationTools.Processors
         public bool PrefixProjectToNodes { get; set; }
 
         /// <summary>
+        /// Migrate original team member capacities after their creation on the target team project. Note: It will only migrate team member capacity if the team member with same display name exists on the target collection otherwise it will be ignored.
+        /// </summary>
+        /// <default>false</default>
+        public bool MigrateTeamCapacities { get; set; }
+
+        /// <summary>
         /// List of Teams to process. If this is `null` then all teams will be processed.
         /// </summary>
         public List<string> Teams { get; set; }


### PR DESCRIPTION
# Description
Enhancement added to `TfsTeamSettingsProcessor` to migrate team capacities. A new boolean option `MigrateTeamCapacities` is also added to `TfsTeamSettingsProcessorOptions`. And relevant documentation updated too.

Please note that It will only migrate team member capacity if the team member with same display name exists on the target collection otherwise it will be ignored.

It might fix part of #868 

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
I have tested it on my production migration from Azure DevOps Server to Azure DevOps Services.

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
