### PR TITLE
adjusted naming from old VSTS to ADO, removed 404 link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 ## Contributing Issues
 
 ### Before Submitting an Issue
-First, please do a search in [open issues](https://github.com/nkdAgility/vsts-sync-migration/issues) to see if the issue or feature request has already been filed. Use this [query](https://github.com/nkdAgility/vsts-sync-migration/issues?q=is%3Aopen+is%3Aissue+label%3Afeature-request+sort%3Areactions-%2B1-desc) to search for the most popular feature requests.
+First, please do a search in [open issues](https://github.com/nkdAgility/azure-devops-migration-tools/issues) to see if the issue or feature request has already been filed. Use this [query](https://github.com/nkdAgility/azure-devops-migration-tools/issues?q=is%3Aopen+is%3Aissue+sort%3Areactions-%2B1-desc+) to search for the most popular feature requests.
 
 If you find your issue already exists, make relevant comments and add your [reaction](https://github.com/blog/2119-add-reactions-to-pull-requests-issues-and-comments). Use a reaction in place of a "+1" comment.
 
@@ -9,9 +9,9 @@ If you find your issue already exists, make relevant comments and add your [reac
 
 👎 - downvote
 
-The entire codebase for the VSTS Sync Migrator project is stored in this repository.
+The entire codebase for the Azure DevOps Migration Tools project is stored in this repository.
 
-If your issue is a question then please ask the question on [Stack Overflow](https://stackoverflow.com/questions/tagged/vsts-sync-migrator) using the tag `vsts-sync-migrator`.
+If your issue is a question then please ask the question on [Stack Overflow](https://stackoverflow.com/questions/tagged/azure-devops-migration-tools) using the tag `azure-devops-migration-tools`.
 
 If you cannot find an existing issue that describes your bug or feature, submit an issue using the guidelines below.
 
@@ -26,8 +26,8 @@ The more information you can provide, the more likely someone will be successful
 
 Please include the following with each issue. 
 
-* Version of VSTS Sync Migrator
-* Version of the source and target VSTS/TFS instances 
+* Version of Azure DevOps Migration Tools
+* Version of the source and target ADO/VSTS/TFS instances 
 
 * Reproducible steps (1... 2... 3...) and what you expected versus what you actually got.
 * The Session ID from your migration run that had a problem (this lets us look up telemitery).
@@ -42,7 +42,7 @@ Don't feel bad if we can't reproduce the issue and ask for more information!
 
 ## Contributing Fixes
 
-VSTS Sync Migrator accepts both bug fixes and feature enhancements as Pull Requests. When contibuting please try to minimise the number of files that you touch, and do not arbitrarily change large amounts of the files without justification. This will help keep the fix or feature as simple and easy as posible to review and incorporate. If you are a long term contributor you may request access to the VSTS repository that houses the core code and provide direct contributions there.
+Azure DevOps Migration Tools accepts both bug fixes and feature enhancements as Pull Requests. When contibuting please try to minimise the number of files that you touch, and do not arbitrarily change large amounts of the files without justification. This will help keep the fix or feature as simple and easy as posible to review and incorporate. If you are a long term contributor you may request access to the git repository that houses the core code and provide direct contributions there.
 
 # Instructions for Contributing Code
 
@@ -54,7 +54,7 @@ Bugs are things that cause exceptions and failures. Please keep fixes simple and
 
 ## Contributing features
 
-Features (things that add new or improved functionality to TypeScript) may be accepted.
+Features (things that add new or improved functionality to Azure DevOps Migration Tools) may be accepted.
 
 ## Housekeeping
 
@@ -71,7 +71,5 @@ Your pull request should:
     * Tests should include reasonable permutations of the target fix/change
     * Include baseline changes with your change
     * All changed code must have 100% code coverage
-* Follow the code conventions described in [Coding guidelines](https://github.com/nkdAgility/vstssyncmigrator/wiki/Coding-guidelines)
+* Follow the code conventions described in _Coding Guidelines_ (link lost)
 * To avoid line ending issues, set `autocrlf = input` and `whitespace = cr-at-eol` in your git configuration
-, please submit a PR to  https://github.com/Microsoft/TSJS-lib-generator
-


### PR DESCRIPTION
I was looking into the code and was considering attempting to make some changes to the codebase and so I read the contribution file and found some issues that I figured I would try and fix first.

Lots of references to the old name of VSTS Sync Migration. Changed github and stackoverflow links using the new Azure Dev OPs naming.

There was a link to a coding guidelines document that doesn't exist. I didn't delete the _"requirement"_ but removed the link and changed with a placeholder. For anyone managing this pull request, if you feel like you want to add back the coding guidelines or remove the requirement in the markdown or another option that is fine.

Also, there was a reference to posting PRs to a TypeScript repo, so I removed that.
