### PR TITLE
Update and improve getting started and server configuration documentation

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -9,13 +9,13 @@ Watch the [Video Overview](https://youtu.be/RCJsST0xBCE) to get you started in 3
 In order to run the migration you will need to install the tools first.
 
 1. Install Chocolatey from [https://chocolatey.org/install](https://chocolatey.org/install)
-1. Run "**choco install vsts-sync-migrator**" to install the tools [source](https://chocolatey.org/packages/vsts-sync-migrator)
+1. Run `choco install vsts-sync-migrator` to install the tools [source](https://chocolatey.org/packages/vsts-sync-migrator)
 
-The tools are now installed. To run them you will need to switch to `c:\tools\MigrationTools\` and run `migrate.exe`.
+The tools are now installed. To run them you will need to switch to `c:\tools\MigrationTools\` and run `migration.exe`.
 
 ## Upgrade
 
-1. Run "**choco upgrade  vsts-sync-migrator**" to upgrade the tools [source](https://chocolatey.org/packages/vsts-sync-migrator)
+1. Run `choco upgrade  vsts-sync-migrator` to upgrade the tools [source](https://chocolatey.org/packages/vsts-sync-migrator)
 
 ## Server configuration and setup
 
@@ -23,9 +23,9 @@ Follow the [setup instructions](./server-configuration.md) to make sure that you
 
 ## Create a default configuration file
 
-1. Open a command prompt or PowerShell window at `c:\tools\MigrationTools\`
-2. Run "./migration.exe init" to create a default configuration
-3. Open "configuration.json" from the current directory
+1. Open a command prompt or PowerShell window at `C:\tools\MigrationTools\`
+2. Run `./migration.exe init` to create a default configuration
+3. Open `configuration.json` from the current directory
 
 You can now customise the configuration depending on what you need to do. However a basic config that you can use to migrate from one team project to another with the same process template is:
 
@@ -178,7 +178,7 @@ You can now customise the configuration depending on what you need to do. Howeve
       "MaxRevisions": 0
     }
   ],
-  "Version": "11.11",
+  "Version": "11.12",
   "workaroundForQuerySOAPBugEnabled": false,
   "WorkItemTypeDefinition": {
     "sourceWorkItemTypeName": "targetWorkItemTypeName"
@@ -204,15 +204,23 @@ The default [WorkItemMigrationConfig](./Processors/WorkItemMigrationConfig.md) p
 * Attachments
 * Links including for source code. Optionally clone the repositories before starting the migration to have links maintained on the initial pass.
 
-## Set minimum info and execute configuration.json 
+## How to execute configuration.json with minimal adjustments
 
-> Remember to add custom field ['ReflectedWorkItemId'](./server-configuration.md) to the target team project before starting migration!
+> Remember to add custom field ['ReflectedWorkItemId'](./server-configuration.md) to both, the source and the target team project before starting migration!
 
-1. Set the Source and Target Team Projects. 
-1. Set the AuthenticationMode. Prompt or AccessToken
-1. Set the field name of the Migration tracking field. I use "TfsMigrationTool.ReflectedWorkItemId" for TFS or "ReflectedWorkItemId" for VSTS or Azure DevOps
-1. Enable the 'WorkItemMigrationConfig' processor and optionally modify the WIQLQueryBit to migrate only the work items you want. The default WIQL will migrate all open workitems and revisions excluding test suites and plans.
-1. Set the ['NodeBasePaths'](./Processors/WorkItemMigrationConfig.md) of leave empty to migrate all nodes
-1. From the 'C:\tools\MigrationTools' path run "**.\migration.exe execute --config .\configuration.json**"
+1. Adjust the value of the `Collection` attribute for Source and Target
+1. Adjust the value of the `Project` attribute for Source and Target
+1. Set the `AuthenticationMode` (`Prompt` or `AccessToken`) for Source and Target
 
-**Remember** if you want a processor to run it's `Enabled` property must be set to true. 
+    If you set Authentication mode to `AccessToken`, enter a valid PAT as value for the `PersonalAccessToken` attribute
+
+1. Adjust the value of the `ReflectedWorkItemIDFieldName` attribute (field name of the migration tracking field) for Source and Target
+
+   For example: `TfsMigrationTool.ReflectedWorkItemId` for TFS, `ReflectedWorkItemId` for VSTS or `Custom.ReflectedWorkItemId` for Azure DevOps
+
+1. Enable the `WorkItemMigrationConfig` processor by setting `Enabled` to `true`
+1. [OPTIONAL] Modify the `WIQLQueryBit` to migrate only the work items you want. The default WIQL will migrate all open work items and revisions excluding test suites and plans
+1. Adjust the [`NodeBasePaths`](./Processors/WorkItemMigrationConfig.md) or leave empty to migrate all nodes
+1. From the `C:\tools\MigrationTools\` path run `.\migration.exe execute --config .\configuration.json`
+
+**Remember:** if you want a processor to run, it's `Enabled` attribute must be set to `true`. 

--- a/docs/server-configuration.md
+++ b/docs/server-configuration.md
@@ -16,8 +16,8 @@ In order to store the state for the migration you need to use a custom field, th
 
 ### Azure DevOps
 
-1. Create a custom field called 'ReflectedWorkItemId' of type 'Text (single line)' by following this [guide](https://docs.microsoft.com/en-us/azure/devops/organizations/settings/work/add-custom-field?view=azure-devops)
-1.  Add this custom field to all workflow types to be migrated eg bug, story, task, test case etc
+1. Create a custom field called `ReflectedWorkItemId` of type `Text (single line)` by following this [guide](https://docs.microsoft.com/en-us/azure/devops/organizations/settings/work/add-custom-field?view=azure-devops)
+1.  Add this custom field to all work item types to be migrated (e.g. Bug, User Story, Task, Test Case, etc)
 
 ### Team Foundation Server (TFS)
 
@@ -51,39 +51,45 @@ If you migrated a TPC to VSTS using the [VSTS Migration Tool](https://blogs.msdn
 - Once you have the .ZIP file, unpack it and edit the work item type definitions as detailed above for an on-premises installation.
 - Once the fields have been added then zip up the folder structure again and re-import it into your VSTS instance, where it will be applied to the Team Project it was exported from. 
 
-### TIP: Checking the actual name of the 'ReflectedWorkItemID' field ###
+### TIP: Checking the actual 'ReflectedWorkItemIDFieldName' ###
 
-If you are in any doubt over the full name in use for the `ReflectedWorkItemID` field on either the source or target systems, it can vary based on the type of customisation, use the following process to confirm it
+If you are in any doubt over the full name in use for the `ReflectedWorkItemIDFieldName` on either the source or target systems, it can vary based on the type of customisation, use the following process to confirm it
 
 - Open Visual Studio, connect to the customised Team Project
 - Via Team Explorer > Work, create a new work item query. Make sure the `ReflectedWorkItemId` is one of the output columns
 - Save the work item query as a file on your local PC
-- Open the resultant file in a text editor and check the actual name, it should in the form `NameOfYourCustomisedTemplate.ReflectedWorkItemId` or `TfsMigrationTool.ReflectedWorkItemId`
+- Open the resulting file in a text editor and check the actual name, it should be in the form `NameOfYourCustomisedTemplate.ReflectedWorkItemId` or `TfsMigrationTool.ReflectedWorkItemId`
 
 ### Editing the configuration ###
 
-Once you have created the `ReflectedWorkItemId` field and confirmed you have the correct full name for both the SOurce and the Target, you will need to edit `configuration.json` to match your values, you need to set the 
+Once you have created the `ReflectedWorkItemId` field and confirmed you have the correct full name for both, the Source and the Target, you will need to edit `configuration.json` to match your values:
 
 
-```json
+```JSON
 {
-    ...... other stuff
-    
-	"ReflectedWorkItemIDFieldName": "TfsMigrationTool.ReflectedWorkItemId",
+	"ChangeSetMappingFile": null,
+	"Source": {
+		...
+		"ReflectedWorkItemIDFieldName": "TfsMigrationTool.ReflectedWorkItemId",
+		...
+	},
+	"Target": {
+		...
+		"ReflectedWorkItemIDFieldName": "TfsMigrationTool.ReflectedWorkItemId",
+		...
+	},
 
-    ...... other stuff
+    	...... other stuff
 
- 	"Processors": [{
-			"$type": "WorkItemMigrationConfig",
-			"Enabled": false,
-			"PrefixProjectToNodes": true,
-			"UpdateCreatedDate": true,
-			"UpdateCreatedBy": true,
-			"QueryBit": "AND [TfsMigrationTool.ReflectedWorkItemId] = '' AND  [Microsoft.VSTS.Common.ClosedDate] = '' AND [System.WorkItemType] IN ('Shared Steps', 'Shared Parameter', 'Test Case', 'Requirement', 'Task', 'User Story', 'Bug')"
-      },
-      
-      ...... other stuff
-
+ 	"Processors": [
+		{
+			...
+			"WIQLQueryBit": "AND [TfsMigrationTool.ReflectedWorkItemId] = '' AND  [Microsoft.VSTS.Common.ClosedDate] = '' AND [System.WorkItemType] IN ('Shared Steps', 'Shared Parameter', 'Test Case', 'Requirement', 'Task', 'User Story', 'Bug')"
+			...
+		}
+	],
+	
+	...... other stuff
     
 }
 ```


### PR DESCRIPTION
# getting-started.md
- Fix name of EXE file (`migrate.exe` -> `migration.exe`)
- Adjust version of configuration.json sample to 11.12
- Change title of last section from "Set minimum info and execute configuration.json" to "How to execute configuration.json with minimal adjustments"
- Remember users, that custom field "ReflectedWorkItemId" has to be added to both, source and target team project
- Improve wording of last section for better understandability
- Formatting

# server-configuration.md
- Change "workflow types" to "work item types"
- Adjust TIP to avoid misinterpretation
- Adjust configuration sample by adding Source and Target object context, removing unnecessary attributes and changing QueryBit to WIQLQueryBit
- Fix typos
- Formatting