### PR TITLE
Implement area and iteration remapping

### DIFF
--- a/docs/Processors/TestPlansAndSuitesMigrationConfig.md
+++ b/docs/Processors/TestPlansAndSuitesMigrationConfig.md
@@ -4,10 +4,12 @@ This processor migrate test suites and test plans. This should be run after `Tes
 
 > Warning: This migration can result in data lost because unsafe links are not able to migrate! (see description for parameter `RemoveInvalidTestSuiteLinks` or [this issue](https://github.com/nkdAgility/azure-devops-migration-tools/issues/178).)
 
-| Parameter name                | Type    | Description                              | Default Value                            |
-|-------------------------------|---------|------------------------------------------|------------------------------------------|
-| `Enabled`                     | Boolean | Active the processor if it true.         | false                                    |
-| `$type`                  | string  | The name of the processor                | TestPlansAndSuitesMigrationConfig |
-| `PrefixProjectToNodes`        | Boolean | Prefix the nodes with the new project name. | false                                    |
-| `OnlyElementsWithTag`         | string  | The tag name that is present on all elements that must be migrated. If this option isn't present this processor will migrate all. | null                                     |
-| `RemoveInvalidTestSuiteLinks` | Boolean | This option will skip invalid links. That is usually happened if in a test plan is a link to a tfvc changeset in the test case.<br>If that option is false you get an error if you have unsaved links like this in your test plan. If it true you only get a warning. | false                                    |
+| Parameter name                | Type    | Description                                 | Default Value                            |
+|-------------------------------|---------|---------------------------------------------|------------------------------------------|
+| `Enabled`                     | Boolean | Active the processor if it true.            | false
+| `$type`                       | string  | The name of the processor                   | TestPlansAndSuitesMigrationConfig
+| `PrefixProjectToNodes`        | Boolean | Prefix the nodes with the new project name. | false
+| `OnlyElementsWithTag`         | string  | The tag name that is present on all elements that must be migrated. If this option isn't present this processor will migrate all. | null
+| `RemoveInvalidTestSuiteLinks` | Boolean | This option will skip invalid links. That is usually happened if in a test plan is a link to a tfvc changeset in the test case.<br>If that option is false you get an error if you have unsaved links like this in your test plan. If it true you only get a warning. | false
+| `TestPlanQueryBit`            | string  | Filtering conditions to decide whether to migrate a test plan or not. When provided, this partial query is added after `Select * From TestPlan Where` when selecting test plans. Among filtering options, `AreaPath`, `PlanName` and `PlanState` are known to work. There is unfortunately no documentation regarding the available fields. | null
+

--- a/docs/Processors/TestPlansAndSuitesMigrationConfig.md
+++ b/docs/Processors/TestPlansAndSuitesMigrationConfig.md
@@ -4,12 +4,16 @@ This processor migrate test suites and test plans. This should be run after `Tes
 
 > Warning: This migration can result in data lost because unsafe links are not able to migrate! (see description for parameter `RemoveInvalidTestSuiteLinks` or [this issue](https://github.com/nkdAgility/azure-devops-migration-tools/issues/178).)
 
-| Parameter name                | Type    | Description                                 | Default Value                            |
-|-------------------------------|---------|---------------------------------------------|------------------------------------------|
-| `Enabled`                     | Boolean | Active the processor if it true.            | false
-| `$type`                       | string  | The name of the processor                   | TestPlansAndSuitesMigrationConfig
-| `PrefixProjectToNodes`        | Boolean | Prefix the nodes with the new project name. | false
-| `OnlyElementsWithTag`         | string  | The tag name that is present on all elements that must be migrated. If this option isn't present this processor will migrate all. | null
-| `RemoveInvalidTestSuiteLinks` | Boolean | This option will skip invalid links. That is usually happened if in a test plan is a link to a tfvc changeset in the test case.<br>If that option is false you get an error if you have unsaved links like this in your test plan. If it true you only get a warning. | false
-| `TestPlanQueryBit`            | string  | Filtering conditions to decide whether to migrate a test plan or not. When provided, this partial query is added after `Select * From TestPlan Where` when selecting test plans. Among filtering options, `AreaPath`, `PlanName` and `PlanState` are known to work. There is unfortunately no documentation regarding the available fields. | null
-
+| Parameter name                         | Type     | Description                                 | Default Value                            |
+|----------------------------------------|----------|---------------------------------------------|------------------------------------------|
+| `Enabled`                              | Boolean  | Active the processor if it true.            | false
+| `$type`                                | string   | The name of the processor                   | TestPlansAndSuitesMigrationConfig
+| `PrefixProjectToNodes`                 | Boolean  | Prefix the nodes with the new project name. | false
+| `OnlyElementsWithTag`                  | string   | The tag name that is present on all elements that must be migrated. If this option isn't present this processor will migrate all. | null
+| `RemoveInvalidTestSuiteLinks`          | Boolean  | This option will skip invalid links. That is usually happened if in a test plan is a link to a tfvc changeset in the test case.<br>If that option is false you get an error if you have unsaved links like this in your test plan. If it true you only get a warning. | false
+| `TestPlanQueryBit`                     | string   | Filtering conditions to decide whether to migrate a test plan or not. When provided, this partial query is added after `Select * From TestPlan Where` when selecting test plans. Among filtering options, `AreaPath`, `PlanName` and `PlanState` are known to work. There is unfortunately no documentation regarding the available fields. | null
+| `RemoveAllLinks`                       | bool
+| `UseCommonNodeStructureEnricherConfig` | bool     | Indicates whether the configuration for node structure transformation should be taken from the common enricher configs. Otherwise the configuration elements below are used | false
+| `NodeBasePaths`                        | string[] | See documentation for [NodeStructure](Reference/WorkItemMigrationConfig.md)
+| `AreaMaps`                             | Dictionnary[string,string] | See documentation for [NodeStructure](WorkItemMigrationConfig.md)
+| `IterationMaps`                        | Dictionnary[string,string] | See documentation for [NodeStructure](WorkItemMigrationConfig.md)

--- a/docs/Processors/WorkItemMigrationConfig.md
+++ b/docs/Processors/WorkItemMigrationConfig.md
@@ -34,6 +34,7 @@ WorkItemMigrationConfig is the main processor used to Migrate Work Items, Links,
 | `CollapseRevisions`                       | Boolean         | If enabled, all revisions except the most recent are collapsed into a JSON format and attached as an attachment. Requires ReplayRevisions to be enabled.                                                                                                                       | false                                                                        |
 | `PauseAfterEachWorkItem`                  | Boolean         | Pause after each work item is migrated                                                                                                                                                                                                                                         | false                                                                        |
 | `GenerateMigrationComment`                | Boolean         | If enabled, adds a comment recording the migration                                                                                                                                                                                                                             | true                                                                         |
+| `UseCommonNodeStructureEnricherConfig`    | bool     | Indicates whether the configuration for node structure transformation should be taken from the common enricher configs. Otherwise the configuration elements below are used | false
 | `NodeBasePaths`                           | Array`<string`> | The root paths of the Ares / Iterations you want migrate. See [NodeBasePath Configuration](#NodeBasePath)                                                                                                                                                                      | ["/"]                                                                        |
 | `AreaMaps`                                | Dictionary`<string,string>` | Remapping rules for area paths, implemented with regular expressions. The rules apply with a higher priority than the `PrefixProjectToNodes`, that is, if no rule matches the path and the `PrefixProjectToNodes` option is enabled, then the old `PrefixProjectToNodes` behavior is applied. | {} |
 | `IterationMaps`                           | Dictionary`<string,string>` | Remapping rules for iteration paths, implemented with regular expressions. The rules apply with a higher priority than the `PrefixProjectToNodes`, that is, if no rule matches the path and the `PrefixProjectToNodes` option is enabled, then the old `PrefixProjectToNodes` behavior is applied. | {} |
@@ -41,7 +42,7 @@ WorkItemMigrationConfig is the main processor used to Migrate Work Items, Links,
 
 ## <a name="WIQLQueryBits"></a>WIQL Query Bits
 
-The Work Item queries are all built using Work Item [Query Language (WIQL)](https://docs.microsoft.com/en-us/azure/devops/boards/queries/wiql-syntax). 
+The Work Item queries are all built using Work Item [Query Language (WIQL)](https://docs.microsoft.com/en-us/azure/devops/boards/queries/wiql-syntax).
 
 > Note: A useful Azure DevOps Extension to explore WIQL is the [WIQL Editor](https://marketplace.visualstudio.com/items?itemName=ottostreifel.wiql-editor)
 
@@ -52,7 +53,7 @@ You can use the [WIQL Editor](https://marketplace.visualstudio.com/items?itemNam
 Typical way that queries are built:
 
 ```
- var targetQuery = 
+ var targetQuery =
      string.Format(
          @"SELECT [System.Id], [{ReflectedWorkItemIDFieldName}] FROM WorkItems WHERE [System.TeamProject] = @TeamProject {WIQLQueryBit} ORDER BY {WIQLOrderBit}",
          Engine.Target.Config.ReflectedWorkItemIDFieldName,
@@ -80,7 +81,7 @@ Scope to Area Path (Team data):
 "WIQLOrderBit": "[System.ChangedDate] desc",
 ```
 
-## <a name="NodeBasePath"></a>NodeBasePath Configuration ## 
+## <a name="NodeBasePath"></a>NodeBasePath Configuration ##
 The `NodeBasePaths` entry allows the filtering of the nodes to be replicated on the target projects. To try to explain the correct usage let us assume that we have a source team project `SourceProj` with the following node structures
 
 - AreaPath

--- a/docs/Processors/WorkItemMigrationConfig.md
+++ b/docs/Processors/WorkItemMigrationConfig.md
@@ -113,7 +113,7 @@ These remapping rules are applied both while creating path nodes in the target
 project and when migrating work items.
 
 These remapping rules are applied with a higher priority than the
-`PrevixProjectToNodes` option. This means that if no declared rule matches the
+`PrefixProjectToNodes` option. This means that if no declared rule matches the
 path and the `PrefixProjectToNodes` option is enabled, then the old behavior is
 used.
 

--- a/docs/Reference/Generated/MigrationTools.Clients.AzureDevops.ObjectModel.xml
+++ b/docs/Reference/Generated/MigrationTools.Clients.AzureDevops.ObjectModel.xml
@@ -7,12 +7,11 @@
         <member name="M:MigrationTools.Enrichers.TfsEmbededImagesEnricher.FixEmbededImages(MigrationTools.DataContracts.WorkItemData,System.String,System.String,System.String)">
             from https://gist.github.com/pietergheysens/792ed505f09557e77ddfc1b83531e4fb
         </member>
-        <member name="M:MigrationTools.Enrichers.TfsNodeStructure.ShouldCreateNode(Microsoft.TeamFoundation.Server.NodeInfo,System.String)">
+        <member name="M:MigrationTools.Enrichers.TfsNodeStructure.ShouldCreateNode(System.String)">
             <summary>
             Checks node-to-be-created with allowed BasePath's
             </summary>
-            <param name="parentPath">Parent Node</param>
-            <param name="newNodeName">Node to be created</param>
+            <param name="sourceNodePath">The path of the source node</param>
             <returns>true/false</returns>
         </member>
         <member name="T:MigrationTools.Processors.TfsAreaAndIterationProcessor">

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -311,7 +311,7 @@ These remapping rules are applied both while creating path nodes in the target
 project and when migrating work items.
 
 These remapping rules are applied with a higher priority than the
-`PrevixProjectToNodes` option. This means that if no declared rule matches the
+`PrefixProjectToNodes` option. This means that if no declared rule matches the
 path and the `PrefixProjectToNodes` option is enabled, then the old behavior is
 used.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -131,6 +131,26 @@ The global configuration created by the `init` command look like this:
       "timeTravel": 1
     }
   ],
+  "CommonEnrichersConfig": [
+    {
+      "$type": "TfsNodeStructureOptions",
+      "Enabled": false,
+      "PrefixProjectToNodes": false,
+      "NodeBasePaths": [
+        "Product\\Area\\Path1",
+        "Product\\Area\\Path2"
+      ],
+      "IterationMaps": {
+        "^OriginalProject\\\\Path1(?=\\\\Sprint 2022)": "TargetProject\\AnotherPath\\NewTeam",
+        "^OriginalProject\\\\Path1(?=\\\\Sprint 2020)": "TargetProject\\AnotherPath\\Archives\\Sprints 2020",
+        "^OriginalProject\\\\Path2": "TargetProject\\YetAnotherPath\\Path2"
+      },
+      "AreaMaps": {
+        "^OriginalProject\\\\(DescopeThis|DescopeThat)": "TargetProject\\Archive\\Descoped\\",
+        "^OriginalProject\\\\(?!DescopeThis|DescopeThat)": "TargetProject\\NewArea\\"
+      },
+    }
+  ],
   "GitRepoMapping": null,
   "LogLevel": "Information",
   "Processors": [
@@ -158,6 +178,7 @@ The global configuration created by the `init` command look like this:
       "AttachmentMaxSize": 480000000,
       "LinkMigrationSaveEachAsAdded": false,
       "GenerateMigrationComment": true,
+      "UseCommonNodeStructureEnricherConfig": false,
       "NodeBasePaths": [
         "Product\\Area\\Path1",
         "Product\\Area\\Path2"
@@ -172,6 +193,30 @@ The global configuration created by the `init` command look like this:
         "^OriginalProject\\\\(?!DescopeThis|DescopeThat)": "TargetProject\\NewArea\\"
       },
       "WorkItemIDs": null
+    },
+    {
+      "$type": "TestConfigurationsMigrationConfig",
+      "Enabled": false
+    },
+    {
+        "$type": "TestPlansAndSuitesMigrationConfig",
+        "Enabled": false,
+        "RemoveInvalidTestSuiteLinks": true,
+        "TestPlanQueryBit": "AreaPath UNDER 'Project1' AND PlanName CONTAINS 'Title' AND TestState NOT IN ('Inactive')",
+        "UseCommonNodeStructureEnricherConfig": false,
+        "NodeBasePaths": [
+          "Product\\Area\\Path1",
+          "Product\\Area\\Path2"
+        ],
+        "IterationMaps": {
+          "^OriginalProject\\\\Path1(?=\\\\Sprint 2022)": "TargetProject\\AnotherPath\\NewTeam",
+          "^OriginalProject\\\\Path1(?=\\\\Sprint 2020)": "TargetProject\\AnotherPath\\Archives\\Sprints 2020",
+          "^OriginalProject\\\\Path2": "TargetProject\\YetAnotherPath\\Path2"
+        },
+        "AreaMaps": {
+          "^OriginalProject\\\\(DescopeThis|DescopeThat)": "TargetProject\\Archive\\Descoped\\",
+          "^OriginalProject\\\\(?!DescopeThis|DescopeThat)": "TargetProject\\NewArea\\"
+        }
     }
   ],
   "Version": "11.6",
@@ -197,7 +242,13 @@ For multi Language support you can add the name used in the source and target fo
 
 ### ReflectedWorkItemIDFieldName
 
-This is the field that will be used to store the state for the migration . See [Server Configuration](server-configuration.md)  
+This is the field that will be used to store the state for the migration . See [Server Configuration](server-configuration.md)
+
+### CommonEnrichersConfig
+
+This configuration allows to set the configuration for some enrichers at the global level, and the configuration can
+then be re-used in processors. Currently supported only by `TfsNodeStructureOption`, to be re-used in
+`WorkItemMigrationConfig` and `TestPlansAndSuitesMigrationConfig`.
 
 ### WorkItemMigrationConfig
 You can specify BasePaths for Areas/Iterations to migrate. The area/iteration has to start with that string to be eligible for migration.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -162,6 +162,15 @@ The global configuration created by the `init` command look like this:
         "Product\\Area\\Path1",
         "Product\\Area\\Path2"
       ],
+      "IterationMaps": {
+        "^OriginalProject\\\\Path1(?=\\\\Sprint 2022)": "TargetProject\\AnotherPath\\NewTeam",
+        "^OriginalProject\\\\Path1(?=\\\\Sprint 2020)": "TargetProject\\AnotherPath\\Archives\\Sprints 2020",
+        "^OriginalProject\\\\Path2": "TargetProject\\YetAnotherPath\\Path2"
+      },
+      "AreaMaps": {
+        "^OriginalProject\\\\(DescopeThis|DescopeThat)": "TargetProject\\Archive\\Descoped\\",
+        "^OriginalProject\\\\(?!DescopeThis|DescopeThat)": "TargetProject\\NewArea\\"
+      },
       "WorkItemIDs": null
     }
   ],
@@ -291,3 +300,101 @@ There are a number of field maps available for when you need to change the data 
     }
   ],
   ```
+
+### Iteration Maps and Area Maps
+
+These two configuration elements apply after the `NodeBasePaths` selector, i.e.
+only on Areas and Iterations that have been selected for migration. They allow
+to change the area path, respectively the iteration path, of migrated work items.
+
+These remapping rules are applied both while creating path nodes in the target
+project and when migrating work items.
+
+These remapping rules are applied with a higher priority than the
+`PrevixProjectToNodes` option. This means that if no declared rule matches the
+path and the `PrefixProjectToNodes` option is enabled, then the old behavior is
+used.
+
+The syntax is a dictionary of regular expressions and the replacement text.
+
+*Warning*: These follow the
+[.net regular expression language](https://docs.microsoft.com/en-us/dotnet/standard/base-types/regular-expression-language-quick-reference).
+The key in the dictionary is a regular expression search pattern, while the
+value is a regular expression replacement pattern. It is therefore possible to
+use back-references in the replacement string.
+
+*Warning*: Special characters in the acceptation of regular expressions _and_
+json both need to be escaped. For a key, this means, for example, that a
+litteral backslash must be escaped for the regular expression language `\\`
+_and_ each of these backslashes must then be escaped for the json encoding:
+`\\\\`. In the replacement string, a litteral `$` must be escaped with an
+additional `$` if it is followed by a number (due to the special meaning in
+regular expression replacement strings), while a backslash must be escaped
+(`\\`) due to the special meaning in json.
+
+*Advice*: To avoid unexpected results, always match terminating backslashes in
+the search pattern and replacement string: if a search pattern ends with a
+backslash, you should also put one in the replacement string, and if the search
+pattern does not include a terminating backslash, then none should be included
+in the replacement string.
+
+#### Examples explained
+
+```json
+"IterationMaps": {
+  "^OriginalProject\\\\Path1(?=\\\\Sprint 2022)": "TargetProject\\AnotherPath\\NewTeam",
+  "^OriginalProject\\\\Path1(?=\\\\Sprint 2020)": "TargetProject\\AnotherPath\\Archives\\Sprints 2020",
+  "^OriginalProject\\\\Path2": "TargetProject\\YetAnotherPath\\Path2",
+},
+"AreaMaps": {
+  "^OriginalProject\\\\(DescopeThis|DescopeThat)": "TargetProject\\Archive\\Descoped\\",
+  "^OriginalProject\\\\(?!DescopeThis|DescopeThat)": "TargetProject\\NewArea\\",
+}
+```
+
+- `"^OriginalProject\\\\Path1(?=\\\\Sprint 2022)": "TargetProject\\AnotherPath\\NewTeam",`
+
+  In an iteration path, `OriginalProject\Path1` found at the beginning of the
+  path, when followed by `\Sprint 2022`, will be replaced by
+  `TargetProject\AnotherPath\NewTeam`.
+
+  `OriginalProject\Path1\Sprint 2022\Sprint 01` will become
+  `TargetProject\AnotherPath\NewTeam\Sprint 2022\Sprint 01` but
+  `OriginalProject\Path1\Sprint 2020\Sprint 03` will _not_ be transformed by
+  this rule.
+
+- `"^OriginalProject\\\\Path1(?=\\\\Sprint 2020)": "TargetProject\\AnotherPath\\Archives\\Sprints 2020",`
+
+  In an iteration path, `OriginalProject\Path1` found at the beginning of the
+  path, when followed by `\Sprint 2020`, will be replaced by
+  `TargetProject\AnotherPath\Archives\\Sprints 2020`.
+
+  `OriginalProject\Path1\Sprint 2020\Sprint 01` will become
+  `TargetProject\AnotherPath\Archives\Sprint 2020\Sprint 01` but
+  `OriginalProject\Path1\Sprint 2021\Sprint 03` will _not_ be transformed by
+  this rule.
+
+- `"^OriginalProject\\\\Path2": "TargetProject\\YetAnotherPath\\Path2",`
+
+  In an iteration path, `OriginalProject\Path2` will be replaced by
+  `TargetProject\YetAnotherPath\Path2`.
+
+- `"^OriginalProject\\\\(DescopeThis|DescopeThat)": "TargetProject\\Archive\\Descoped\\",`
+
+  In an area path, `OriginalProject\` found at the beginning of the path, when
+  followed by either `DescopeThis` or `DescopeThat` will be replaced by `TargetProject\Archive\Descoped\`.
+
+  `OriginalProject\DescopeThis\Area` will be transformed to
+  `TargetProject\Archive\Descoped\DescopeThis\Area`.
+  `OriginalProject\DescopeThat\Product` will be transformed to
+  `TargetProject\Archive\Descoped\DescopeThat\Product`.
+
+- `"^OriginalProject\\\\(?!DescopeThis|DescopeThat)": "TargetProject\\NewArea\\",`
+
+  In an area path, `OriginalProject\` found at the beginning of the path will be
+  replaced by `TargetProject\NewArea\` unless it is followed by `DescopeThis` or
+  `DescopeThat`.
+
+  `OriginalProject\ValidArea\` would be replaced by
+  `TargetProject\NewArea\ValidArea\` but `OriginalProject\DescopeThis` would not
+  be modified by this rule.

--- a/src/MigrationTools.Clients.AzureDevops.ObjectModel.Tests/ProcessorEnrichers/TfsNodeStructureTests.cs
+++ b/src/MigrationTools.Clients.AzureDevops.ObjectModel.Tests/ProcessorEnrichers/TfsNodeStructureTests.cs
@@ -23,9 +23,6 @@ namespace MigrationTools.ProcessorEnrichers.Tests
         {
             var nodeStructure = _services.GetRequiredService<TfsNodeStructure>();
 
-            const string targetStructureName = "Area\\test";
-            const string sourceStructureName = "Area";
-
             nodeStructure.ApplySettings(new TfsNodeStructureSettings
             {
                 SourceProjectName = "SourceProject",
@@ -36,11 +33,15 @@ namespace MigrationTools.ProcessorEnrichers.Tests
                 }
             });
 
+            var options = new TfsNodeStructureOptions();
+            options.SetDefaults();
+            options.AreaMaps[@"^SourceProject\\PUL"] = "TargetProject\\test\\PUL";
+            nodeStructure.Configure(options);
+
             const string sourceNodeName = @"SourceProject\PUL";
             const TfsNodeStructureType nodeStructureType = TfsNodeStructureType.Area;
 
-
-            var newNodeName = nodeStructure.GetNewNodeName(sourceNodeName, nodeStructureType, targetStructureName, sourceStructureName);
+            var newNodeName = nodeStructure.GetNewNodeName(sourceNodeName, nodeStructureType);
 
             Assert.AreEqual(newNodeName, @"TargetProject\test\PUL");
 

--- a/src/MigrationTools.Clients.AzureDevops.ObjectModel.Tests/ServiceProviderHelper.cs
+++ b/src/MigrationTools.Clients.AzureDevops.ObjectModel.Tests/ServiceProviderHelper.cs
@@ -5,9 +5,9 @@ using MigrationTools.TestExtensions;
 
 namespace MigrationTools.Tests
 {
-    internal static class ServiceProviderHelper
+    public static class ServiceProviderHelper
     {
-        internal static ServiceProvider GetServices()
+        public static ServiceProvider GetServices()
         {
             var configuration = new ConfigurationBuilder().Build();
             var services = new ServiceCollection();
@@ -16,6 +16,7 @@ namespace MigrationTools.Tests
             services.AddMigrationToolServices();
             services.AddMigrationToolServicesForClientAzureDevOpsObjectModel(configuration);
             services.AddMigrationToolServicesForClientLegacyAzureDevOpsObjectModel();
+            services.AddMigrationToolServicesLegacy();
             AddTfsEndpoint(services, "Source", "migrationSource1");
             AddTfsEndpoint(services, "Target", "migrationTarget1");
 

--- a/src/MigrationTools.Clients.AzureDevops.ObjectModel/ProcessorEnrichers/TfsNodeStructure.cs
+++ b/src/MigrationTools.Clients.AzureDevops.ObjectModel/ProcessorEnrichers/TfsNodeStructure.cs
@@ -30,11 +30,9 @@ namespace MigrationTools.Enrichers
 
     public class TfsNodeStructure : WorkItemProcessorEnricher
     {
-        private Dictionary<string, bool> _foundNodes = new Dictionary<string, bool>();
+        private readonly Dictionary<string, NodeInfo> _pathToKnownNodeMap = new Dictionary<string, NodeInfo>();
         private string[] _nodeBasePaths;
         private TfsNodeStructureOptions _Options;
-
-        private bool _prefixProjectToNodes = false;
 
         private ICommonStructureService4 _sourceCommonStructureService;
 
@@ -46,6 +44,7 @@ namespace MigrationTools.Enrichers
         private ICommonStructureService4 _targetCommonStructureService;
         private TfsLanguageMapOptions _targetLanguageMaps;
         private string _targetProjectName;
+        private KeyValuePair<string, string>? _lastResortRemapRule;
 
         public TfsNodeStructure(IServiceProvider services, ILogger<TfsNodeStructure> logger)
             : base(services, logger)
@@ -66,14 +65,12 @@ namespace MigrationTools.Enrichers
         public override void Configure(IProcessorEnricherOptions options)
         {
             _Options = (TfsNodeStructureOptions)options;
-
         }
 
         public void ApplySettings(TfsNodeStructureSettings settings)
         {
             _sourceProjectName = settings.SourceProjectName;
             _targetProjectName = settings.TargetProjectName;
-            _foundNodes = settings.FoundNodes;
         }
 
         [Obsolete("Old v1 arch: this is a v2 class", true)]
@@ -82,49 +79,141 @@ namespace MigrationTools.Enrichers
             throw new NotImplementedException();
         }
 
-        public string GetNewNodeName(string sourceNodeName, TfsNodeStructureType nodeStructureType, string targetStructureName = null, string sourceStructureName = null)
+        public string GetNewNodeName(string sourceNodePath, TfsNodeStructureType nodeStructureType)
         {
-            Log.LogDebug("NodeStructureEnricher.GetNewNodeName({sourceNodeName}, {nodeStructureType})", sourceNodeName, nodeStructureType.ToString());
-            var tStructureName = targetStructureName ?? NodeStructureTypeToLanguageSpecificName(_targetLanguageMaps, nodeStructureType);
-            var sStructureName = sourceStructureName ?? NodeStructureTypeToLanguageSpecificName(_sourceLanguageMaps, nodeStructureType);
-            // Replace project name with new name (if necessary) and inject nodePath (Area or Iteration) into path for node validation
-            string newNodeName;
-            if (_prefixProjectToNodes)
+            Log.LogDebug("NodeStructureEnricher.GetNewNodeName({sourceNodePath}, {nodeStructureType})", sourceNodePath, nodeStructureType.ToString());
+
+            var mappers = GetMaps(nodeStructureType);
+            var lastResortRule = GetLastResortRemappingRule();
+
+            foreach (var mapper in mappers)
             {
-                newNodeName = $@"{_targetProjectName}\{tStructureName}\{sourceNodeName}";
-            }
-            else
-            {
-                var regex = new Regex(Regex.Escape(_sourceProjectName));
-                if (sourceNodeName.StartsWith($@"{_sourceProjectName}\{sStructureName}\"))
+                if (Regex.IsMatch(sourceNodePath, mapper.Key))
                 {
-                    newNodeName = regex.Replace(sourceNodeName, _targetProjectName, 1);
+                    return Regex.Replace(sourceNodePath, mapper.Key, mapper.Value);
+                }
+            }
+
+            if (!Regex.IsMatch(sourceNodePath, lastResortRule.Key))
+            {
+                throw new InvalidOperationException($"This path is not anchored in the source project name: {sourceNodePath}");
+            }
+
+            return Regex.Replace(sourceNodePath, lastResortRule.Key, lastResortRule.Value);
+        }
+
+        private KeyValuePair<string, string> GetLastResortRemappingRule()
+        {
+            if (_lastResortRemapRule == null)
+            {
+                var escapedSourceProjectName = Regex.Escape(_sourceProjectName);
+                var escapedTargetProjectName = Regex.Escape(_targetProjectName);
+                _lastResortRemapRule = _Options.PrefixProjectToNodes
+                    ? new KeyValuePair<string, string>($"^{escapedSourceProjectName}", $"{escapedTargetProjectName}\\{escapedSourceProjectName}")
+                    : new KeyValuePair<string, string>($"^{escapedSourceProjectName}", $"{escapedTargetProjectName}");
+            }
+
+            return _lastResortRemapRule.Value;
+        }
+
+        private NodeInfo GetOrCreateNode(string nodePath, DateTime? startDate, DateTime? finishDate)
+        {
+            Log.LogInformation(" Processing Node: {0}, start date: {1}, finish date: {2}", nodePath, startDate, finishDate);
+            if (_pathToKnownNodeMap.TryGetValue(nodePath, out var info))
+            {
+                return info;
+            }
+
+            // We don't know the node yet, so try to find the closest existing ancestor for the node
+            var currentAncestorPath = nodePath;
+            var pathSegments = new Stack<string>();
+            NodeInfo parentNode = null;
+            do
+            {
+                var match = Regex.Match(currentAncestorPath, @"(?<parentPath>^.+)?\\(?<nodeName>[^\\]+)\\?$");
+                if (match.Success)
+                {
+                    var nodeName = match.Groups["nodeName"].Value;
+
+                    // Store the list of nodes to creates on the way down
+                    pathSegments.Push(nodeName);
+
+                    // Move up the path
+                    currentAncestorPath = match.Groups["parentPath"].Success
+                        ? match.Groups["parentPath"].Value
+                        : string.Empty;
+                    _pathToKnownNodeMap.TryGetValue(currentAncestorPath, out parentNode);
                 }
                 else
                 {
-                    newNodeName = regex.Replace(sourceNodeName, $@"{_targetProjectName}\{tStructureName}", 1);
+                    throw new InvalidOperationException($"This does not look like a valid area or iteration path: {currentAncestorPath}");
                 }
+            } while (parentNode == null && !string.IsNullOrEmpty(currentAncestorPath));
+
+            if (parentNode == null)
+            {
+                throw new InvalidOperationException(
+                    $"Path {nodePath} is not anchored in the target project, it cannot be created.");
             }
 
-            // Validate the node exists
-            if (!TargetNodeExists(newNodeName))
+            // Now that we have a parent, we can start creating nodes down the tree from that point
+            do
             {
-                Log.LogWarning("The Node '{newNodeName}' does not exist, leaving as '{newProjectName}'. This may be because it has been renamed or moved and no longer exists, or that you have not migrateed the Node Structure yet.", newNodeName, _targetProjectName);
-                newNodeName = _targetProjectName;
-            }
+                var currentNodeName = pathSegments.Pop();
+                var currentNodePath = $@"{parentNode.Path}\{currentNodeName}";
+                try
+                {
+                    parentNode = _targetCommonStructureService.GetNodeFromPath(currentNodePath);
+                    _pathToKnownNodeMap[parentNode.Path] = parentNode;
+                    Log.LogDebug("  Node {node} already exists", currentNodePath);
+                    Log.LogTrace("{node}", parentNode);
+                }
+                catch (CommonStructureSubsystemException ex)
+                {
+                    try
+                    {
+                        var newPathUri = _targetCommonStructureService.CreateNode(currentNodeName, parentNode.Uri);
+                        Log.LogDebug("  Node {newPathUri} has been created", newPathUri);
+                        parentNode = _targetCommonStructureService.GetNode(newPathUri);
+                        _pathToKnownNodeMap[parentNode.Path] = parentNode;
+                    }
+                    catch
+                    {
+                        Log.LogError(ex, "Creating Node");
+                        throw;
+                    }
+                }
 
-            // Remove nodePath (Area or Iteration) from path for correct population in work item
-            if (newNodeName.StartsWith(_targetProjectName + '\\' + tStructureName + '\\'))
-            {
-                newNodeName = newNodeName.Remove(newNodeName.IndexOf($@"{nodeStructureType}\"), $@"{nodeStructureType}\".Length);
-            }
-            else if (newNodeName.StartsWith(_targetProjectName + '\\' + tStructureName))
-            {
-                newNodeName = newNodeName.Remove(newNodeName.IndexOf($@"{nodeStructureType}"), $@"{nodeStructureType}".Length);
-            }
-            newNodeName = newNodeName.Replace(@"\\", @"\");
+                if (startDate != null && finishDate != null)
+                {
+                    try
+                    {
+                        _targetCommonStructureService.SetIterationDates(parentNode.Uri, startDate, finishDate);
+                        Log.LogDebug("  Node {node} has been assigned {startDate} / {finishDate}", currentNodePath,
+                            startDate, finishDate);
+                    }
+                    catch (CommonStructureSubsystemException ex)
+                    {
+                        Log.LogWarning(ex, " Unable to set {node}dates of {startDate} / {finishDate}", currentNodePath,
+                            startDate, finishDate);
+                    }
+                }
+            } while (parentNode.Path != nodePath);
 
-            return newNodeName;
+            return parentNode;
+        }
+
+        private Dictionary<string, string> GetMaps(TfsNodeStructureType nodeStructureType)
+        {
+            switch (nodeStructureType)
+            {
+                case TfsNodeStructureType.Area:
+                    return _Options.AreaMaps;
+                case TfsNodeStructureType.Iteration:
+                    return _Options.IterationMaps;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(nodeStructureType), nodeStructureType, null);
+            }
         }
 
         public override void ProcessorExecutionBegin(IProcessor processor)
@@ -193,62 +282,19 @@ namespace MigrationTools.Enrichers
             }
         }
 
-        private NodeInfo CreateNode(string name, NodeInfo parent, DateTime? startDate, DateTime? finishDate)
+        private void CreateNodes(XmlNodeList nodeList, string treeType, TfsNodeStructureType nodeStructureType)
         {
-            string nodePath = string.Format(@"{0}\{1}", parent.Path, name);
-            NodeInfo node;
-            Log.LogInformation(" Processing Node: {0}, start date: {1}, finish date: {2}", nodePath, startDate, finishDate);
-            try
+            foreach (var item in nodeList.OfType<XmlElement>())
             {
-                node = _targetCommonStructureService.GetNodeFromPath(nodePath);
-                Log.LogDebug("  Node {node} already exists", nodePath);
-                Log.LogTrace("{node}", node);
-            }
-            catch (CommonStructureSubsystemException ex)
-            {
-                try
-                {
-                    string newPathUri = _targetCommonStructureService.CreateNode(name, parent.Uri);
-                    Log.LogDebug("  Node {newPathUri} has been created", newPathUri);
-                    node = _targetCommonStructureService.GetNode(newPathUri);
-                }
-                catch
-                {
-                    Log.LogError(ex, "Creating Node");
-                    throw;
-                }
-            }
-            if (startDate != null && finishDate != null)
-            {
-                try
-                {
-                    _targetCommonStructureService.SetIterationDates(node.Uri, startDate, finishDate);
-                    Log.LogDebug("  Node {node} has been assigned {startDate} / {finishDate}", nodePath, startDate, finishDate);
-                }
-                catch (CommonStructureSubsystemException ex)
-                {
-                    Log.LogWarning(ex, " Unable to set {node}dates of {startDate} / {finishDate}", nodePath, startDate, finishDate);
-                }
-            }
-            return node;
-        }
-
-        private void CreateNodes(XmlNodeList nodeList, NodeInfo parentPath, string treeType)
-        {
-            foreach (XmlNode item in nodeList)
-            {
-                string newNodeName = item.Attributes["Name"].Value;
-
-                if (!ShouldCreateNode(parentPath, newNodeName))
+                if (!ShouldCreateNode(item.Attributes["Path"].Value))
                 {
                     continue;
                 }
 
-                NodeInfo targetNode;
+                DateTime? startDate = null;
+                DateTime? finishDate = null;
                 if (treeType == "Iteration")
                 {
-                    DateTime? startDate = null;
-                    DateTime? finishDate = null;
                     if (item.Attributes["StartDate"] != null)
                     {
                         startDate = DateTime.Parse(item.Attributes["StartDate"].Value);
@@ -257,52 +303,79 @@ namespace MigrationTools.Enrichers
                     {
                         finishDate = DateTime.Parse(item.Attributes["FinishDate"].Value);
                     }
+                }
 
-                    targetNode = CreateNode(newNodeName, parentPath, startDate, finishDate);
-                }
-                else
-                {
-                    targetNode = CreateNode(newNodeName, parentPath, null, null);
-                }
+                // We work on the system paths, but user-friendly paths are used in maps
+                var userFriendlyPath = GetUserFriendlyPath(item.Attributes["Path"].Value);
+                var newUserPath = GetNewNodeName(userFriendlyPath, nodeStructureType);
+                var newSystemPath = GetSystemPath(newUserPath, nodeStructureType);
+
+                var targetNode = GetOrCreateNode(newSystemPath, startDate, finishDate);
+                _pathToKnownNodeMap[targetNode.Path] = targetNode;
+
                 if (item.HasChildNodes)
                 {
-                    CreateNodes(item.ChildNodes[0].ChildNodes, targetNode, treeType);
+                    // Again, ...Parent/Children/ActualChildNode... in the XML, so we skip Children
+                    CreateNodes(item.ChildNodes[0].ChildNodes, treeType, nodeStructureType);
                 }
             }
         }
 
+        private string GetSystemPath(string newUserPath, TfsNodeStructureType structureType)
+        {
+            var match = Regex.Match(newUserPath, @"^(?<projectName>[^\\]+)\\(?<restOfThePath>.*)$");
+            if (!match.Success)
+            {
+                throw new InvalidOperationException($"This path is not a valid area or iteration path: {newUserPath}");
+            }
+
+            var structureName = GetTargetLocalizedNodeStructureTypeName(structureType);
+
+            return $"\\{match.Groups["projectName"].Value}\\{structureName}\\{match.Groups["restOfThePath"]}";
+        }
+
+        private static string GetUserFriendlyPath(string systemNodePath)
+        {
+            // Shape of the path is \SourceProject\StructureType\Rest\Of\The\Path, user-friendly shape skips StructureType and initial \
+            var match = Regex.Match(systemNodePath, @"^\\(?<sourceProject>[^\\]+)\\[^\\]+\\(?<restOfThePath>.*)$");
+            if (!match.Success)
+            {
+                throw new InvalidOperationException($"This path is not a valid area or iteration path: {systemNodePath}");
+            }
+
+            return $"{match.Groups["sourceProject"].Value}\\{match.Groups["restOfThePath"].Value}";
+        }
+
         private void MigrateAllNodeStructures()
         {
-            _prefixProjectToNodes = Options.PrefixProjectToNodes;
             _nodeBasePaths = Options.NodeBasePaths;
 
-            Log.LogDebug("NodeStructureEnricher.MigrateAllNodeStructures({prefixProjectToNodes}, {nodeBasePaths})", _prefixProjectToNodes, _nodeBasePaths);
+            Log.LogDebug("NodeStructureEnricher.MigrateAllNodeStructures({nodeBasePaths}, {areaMaps}, {iterationMaps})", _nodeBasePaths, _Options.AreaMaps, _Options.IterationMaps);
             //////////////////////////////////////////////////
-            ProcessCommonStructure(_sourceLanguageMaps.AreaPath, _sourceProjectName, _targetLanguageMaps.AreaPath, _targetProjectName);
+            ProcessCommonStructure(_sourceLanguageMaps.AreaPath, _targetLanguageMaps.AreaPath, _targetProjectName, TfsNodeStructureType.Area);
             //////////////////////////////////////////////////
-            ProcessCommonStructure(_sourceLanguageMaps.IterationPath, _sourceProjectName, _targetLanguageMaps.IterationPath, _targetProjectName);
+            ProcessCommonStructure(_sourceLanguageMaps.IterationPath, _targetLanguageMaps.IterationPath, _targetProjectName, TfsNodeStructureType.Iteration);
             //////////////////////////////////////////////////
         }
 
-        private string NodeStructureTypeToLanguageSpecificName(TfsLanguageMapOptions languageMaps, TfsNodeStructureType value)
+        private string GetTargetLocalizedNodeStructureTypeName(TfsNodeStructureType value)
         {
-            // insert switch statement here
             switch (value)
             {
                 case TfsNodeStructureType.Area:
-                    return languageMaps.AreaPath;
+                    return _targetLanguageMaps.AreaPath;
 
                 case TfsNodeStructureType.Iteration:
-                    return languageMaps.IterationPath;
+                    return _targetLanguageMaps.IterationPath;
 
                 default:
                     throw new InvalidOperationException("Not a valid NodeStructureType ");
             }
         }
 
-        private void ProcessCommonStructure(string treeTypeSource, string sourceTarget, string treeTypeTarget, string projectTarget)
+        private void ProcessCommonStructure(string treeTypeSource, string localizedTreeTypeName, string projectTarget, TfsNodeStructureType nodeStructureType)
         {
-            Log.LogDebug("NodeStructureEnricher.ProcessCommonStructure({treeTypeSource}, {treeTypeTarget})", treeTypeSource, treeTypeTarget);
+            Log.LogDebug("NodeStructureEnricher.ProcessCommonStructure({treeTypeSource}, {treeTypeTarget})", treeTypeSource, localizedTreeTypeName);
 
             var startPath = ("\\" + this._sourceProjectName + "\\" + treeTypeSource).ToLower();
             Log.LogDebug("Source Node Path StartsWith [{startPath}]", startPath);
@@ -329,79 +402,46 @@ namespace MigrationTools.Enrichers
             NodeInfo structureParent;
             try // May run into language problems!!! This is to try and detect that
             {
-                structureParent = _targetCommonStructureService.GetNodeFromPath(string.Format("\\{0}\\{1}", projectTarget, treeTypeTarget));
+                structureParent = _targetCommonStructureService.GetNodeFromPath(string.Format("\\{0}\\{1}", projectTarget, localizedTreeTypeName));
             }
             catch (Exception ex)
             {
-                Exception ex2 = new Exception(string.Format("Unable to load Common Structure for Target.This is usually due to diferent language versions. Validate that '{0}' is the correct name in your version. ", treeTypeTarget), ex);
+                Exception ex2 = new Exception(string.Format("Unable to load Common Structure for Target.This is usually due to diferent language versions. Validate that '{0}' is the correct name in your version. ", localizedTreeTypeName), ex);
                 Log.LogError(ex2, "Unable to load Common Structure for Target.");
                 throw ex2;
             }
-            if (_prefixProjectToNodes)
-            {
-                structureParent = CreateNode(sourceTarget, structureParent, null, null);
-            }
+
+            _pathToKnownNodeMap[structureParent.Path] = structureParent;
+
             if (sourceTree.ChildNodes[0].HasChildNodes)
             {
-                CreateNodes(sourceTree.ChildNodes[0].ChildNodes[0].ChildNodes, structureParent, treeTypeTarget);
+                // The XPath would look like this: /Nodes/Node[Name=Area]/Children/...
+                // The Path attributes however look like that for the children of the Area node: /SourceProject/Area/SourceArea
+                CreateNodes(sourceTree.ChildNodes[0].ChildNodes[0].ChildNodes, localizedTreeTypeName, nodeStructureType);
             }
         }
 
         /// <summary>
         /// Checks node-to-be-created with allowed BasePath's
         /// </summary>
-        /// <param name="parentPath">Parent Node</param>
-        /// <param name="newNodeName">Node to be created</param>
+        /// <param name="sourceNodePath">The path of the source node</param>
         /// <returns>true/false</returns>
-        private bool ShouldCreateNode(NodeInfo parentPath, string newNodeName)
+        private bool ShouldCreateNode(string sourceNodePath)
         {
-            string nodePath = string.Format(@"{0}\{1}", parentPath.Path, newNodeName);
-
-            if (_nodeBasePaths != null && _nodeBasePaths.Any())
+            if (_nodeBasePaths == null || _nodeBasePaths.Length == 0)
             {
-                var split = nodePath.Split('\\');
-                var removeProjectAndType = split.Skip(3);
-                var path = string.Join(@"\", removeProjectAndType);
-
-                // We need to check if the path is a parent path of one of the base paths, as we need those
-                foreach (var basePath in _nodeBasePaths)
-                {
-                    var splitBase = basePath.Split('\\');
-
-                    for (int i = 0; i < splitBase.Length; i++)
-                    {
-                        if (string.Equals(path, string.Join(@"\", splitBase.Take(i)), StringComparison.InvariantCultureIgnoreCase))
-                        {
-                            return true;
-                        }
-                    }
-                }
-
-                if (!_nodeBasePaths.Any(p => path.StartsWith(p, StringComparison.InvariantCultureIgnoreCase)))
-                {
-                    Log.LogWarning("The node {nodePath} is being excluded due to your basePath setting. ", nodePath);
-                    return false;
-                }
+                return true;
             }
 
-            return true;
-        }
+            var userFriendlyPath = GetUserFriendlyPath(sourceNodePath);
 
-        private bool TargetNodeExists(string nodePath)
-        {
-            if (!_foundNodes.ContainsKey(nodePath))
+            if (_nodeBasePaths.Any(oneBasePath => userFriendlyPath.StartsWith(oneBasePath)))
             {
-                try
-                {
-                    var node = _targetCommonStructureService.GetNodeFromPath(nodePath);
-                    _foundNodes.Add(nodePath, true);
-                }
-                catch
-                {
-                    _foundNodes.Add(nodePath, false);
-                }
+                return true;
             }
-            return _foundNodes[nodePath];
+
+            Log.LogWarning("The node {nodePath} is being excluded due to your basePath setting. ", sourceNodePath);
+            return false;
         }
     }
 }

--- a/src/MigrationTools.Clients.AzureDevops.ObjectModel/ProcessorEnrichers/TfsNodeStructure.cs
+++ b/src/MigrationTools.Clients.AzureDevops.ObjectModel/ProcessorEnrichers/TfsNodeStructure.cs
@@ -118,11 +118,13 @@ namespace MigrationTools.Enrichers
 
         private NodeInfo GetOrCreateNode(string nodePath, DateTime? startDate, DateTime? finishDate)
         {
-            Log.LogInformation(" Processing Node: {0}, start date: {1}, finish date: {2}", nodePath, startDate, finishDate);
             if (_pathToKnownNodeMap.TryGetValue(nodePath, out var info))
             {
+                Log.LogInformation(" Node {0} already migrated, nothing to do", nodePath);
                 return info;
             }
+
+            Log.LogInformation(" Processing Node: {0}, start date: {1}, finish date: {2}", nodePath, startDate, finishDate);
 
             // We don't know the node yet, so try to find the closest existing ancestor for the node
             var currentAncestorPath = nodePath;
@@ -380,21 +382,18 @@ namespace MigrationTools.Enrichers
             var startPath = ("\\" + this._sourceProjectName + "\\" + treeTypeSource).ToLower();
             Log.LogDebug("Source Node Path StartsWith [{startPath}]", startPath);
 
-            var nodes = _sourceRootNodes.Where((n) =>
-            {
-                // (i.e. "\CoolProject\Area" )
-                return n.Path.ToLower().StartsWith(startPath);
-            });
+            // (i.e. "\CoolProject\Area" )
+            var nodes = _sourceRootNodes.Where(n => n.Path.ToLower().StartsWith(startPath));
             if (nodes.Count() > 1)
             {
                 Exception ex = new Exception(string.Format("Unable to load Common Structure for Source because more than one node path matches \"{0}\". {1}", treeTypeSource, JsonConvert.SerializeObject(nodes.Select(x => x.Path))));
                 Log.LogError(ex, "Unable to load Common Structure for Source.");
                 throw ex;
             }
-            NodeInfo sourceNode = nodes.First();
+            NodeInfo sourceNode = nodes.FirstOrDefault();
             if (sourceNode == null) // May run into language problems!!! This is to try and detect that
             {
-                Exception ex = new Exception(string.Format("Unable to load Common Structure for Source. This is usually due to diferent language versions. Validate that '{0}' is the correct name in your version. ", treeTypeSource));
+                Exception ex = new Exception(string.Format("Unable to load Common Structure for Source. This is usually due to different language versions. Validate that '{0}' is the correct name in your version. ", treeTypeSource));
                 Log.LogError(ex, "Unable to load Common Structure for Source.");
                 throw ex;
             }
@@ -406,7 +405,7 @@ namespace MigrationTools.Enrichers
             }
             catch (Exception ex)
             {
-                Exception ex2 = new Exception(string.Format("Unable to load Common Structure for Target.This is usually due to diferent language versions. Validate that '{0}' is the correct name in your version. ", localizedTreeTypeName), ex);
+                Exception ex2 = new Exception(string.Format("Unable to load Common Structure for Target.This is usually due to different language versions. Validate that '{0}' is the correct name in your version. ", localizedTreeTypeName), ex);
                 Log.LogError(ex2, "Unable to load Common Structure for Target.");
                 throw ex2;
             }

--- a/src/MigrationTools.Clients.AzureDevops.ObjectModel/ProcessorEnrichers/TfsNodeStructureOptions.cs
+++ b/src/MigrationTools.Clients.AzureDevops.ObjectModel/ProcessorEnrichers/TfsNodeStructureOptions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 
 namespace MigrationTools.Enrichers
 {
@@ -8,10 +9,14 @@ namespace MigrationTools.Enrichers
 
         public bool PrefixProjectToNodes { get; set; }
         public string[] NodeBasePaths { get; set; }
+        public Dictionary<string, string> AreaMaps { get; set; }
+        public Dictionary<string, string> IterationMaps { get; set; }
 
         public override void SetDefaults()
         {
             Enabled = true;
+            AreaMaps = new Dictionary<string, string>();
+            IterationMaps = new Dictionary<string, string>();
         }
     }
 
@@ -19,5 +24,7 @@ namespace MigrationTools.Enrichers
     {
         public bool PrefixProjectToNodes { get; set; }
         public string[] NodeBasePaths { get; set; }
+        public Dictionary<string, string> AreaMaps { get; set; }
+        public Dictionary<string, string> IterationMaps { get; set; }
     }
 }

--- a/src/MigrationTools.Clients.AzureDevops.ObjectModel/Processors/TfsAreaAndIterationProcessor.cs
+++ b/src/MigrationTools.Clients.AzureDevops.ObjectModel/Processors/TfsAreaAndIterationProcessor.cs
@@ -41,7 +41,9 @@ namespace MigrationTools.Processors
                                         {
                                             Enabled = true,
                                             NodeBasePaths = _options.NodeBasePaths,
-                                            PrefixProjectToNodes = _options.PrefixProjectToNodes
+                                            PrefixProjectToNodes = _options.PrefixProjectToNodes,
+                                            AreaMaps = _options.AreaMaps,
+                                            IterationMaps = _options.IterationMaps,
                                         };
             _nodeStructureEnricher.Configure(nodeStructurOptions);
             _nodeStructureEnricher.ProcessorExecutionBegin(null);

--- a/src/MigrationTools.Clients.AzureDevops.ObjectModel/Processors/TfsAreaAndIterationProcessorOptions.cs
+++ b/src/MigrationTools.Clients.AzureDevops.ObjectModel/Processors/TfsAreaAndIterationProcessorOptions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using MigrationTools.Enrichers;
 
 namespace MigrationTools.Processors
@@ -12,6 +13,8 @@ namespace MigrationTools.Processors
         public bool PrefixProjectToNodes { get; set; }
 
         public string[] NodeBasePaths { get; set; }
+        public Dictionary<string, string> AreaMaps { get; set; }
+        public Dictionary<string, string> IterationMaps { get; set; }
 
         public override Type ToConfigure => typeof(TfsAreaAndIterationProcessor);
 
@@ -25,6 +28,8 @@ namespace MigrationTools.Processors
             PrefixProjectToNodes = false;
             SourceName = "sourceName";
             TargetName = "targetName";
+            AreaMaps = new Dictionary<string, string>();
+            IterationMaps = new Dictionary<string, string>();
         }
     }
 }

--- a/src/MigrationTools.ConsoleFull/Properties/launchSettings.json
+++ b/src/MigrationTools.ConsoleFull/Properties/launchSettings.json
@@ -2,7 +2,10 @@
   "profiles": {
     "execute": {
       "commandName": "Project",
-      "commandLineArgs": "execute -c configuration.json"
+      "commandLineArgs": "execute -c \"C:\\SwissTiming\\src\\Architecture\\Overview\\docs\\devops-cloudmigration\\workitems-configurations\\STDK\\configuration-stdk-4.json\"",
+      "environmentVariables": {
+        "SourcePat": "%SourcePat%;TargetPat=%TargetPat%"
+      }
     },
     "init": {
       "commandName": "Project",

--- a/src/MigrationTools.Host/MigrationToolHost.cs
+++ b/src/MigrationTools.Host/MigrationToolHost.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using MigrationTools._EngineV1.Configuration;
 using MigrationTools.Host.CommandLine;
 using MigrationTools.Host.CustomDiagnostics;
@@ -82,6 +83,7 @@ namespace MigrationTools.Host
                      config.ChangeSetMappingFile = parsed.ChangeSetMappingFile;
                      config.FieldMaps = parsed.FieldMaps;
                      config.GitRepoMapping = parsed.GitRepoMapping;
+                     config.CommonEnrichersConfig = parsed.CommonEnrichersConfig;
                      config.Processors = parsed.Processors;
                      config.Source = parsed.Source;
                      config.Target = parsed.Target;

--- a/src/MigrationTools/MigrationEngine.cs
+++ b/src/MigrationTools/MigrationEngine.cs
@@ -146,7 +146,7 @@ namespace MigrationTools
         private NetworkCredential CheckForNetworkCredentials(Credentials credentials)
         {
             NetworkCredential networkCredentials = null;
-            if (!string.IsNullOrWhiteSpace(credentials.UserName) && !string.IsNullOrWhiteSpace(credentials.Password))
+            if (!string.IsNullOrWhiteSpace(credentials?.UserName) && !string.IsNullOrWhiteSpace(credentials?.Password))
             {
                 networkCredentials = new NetworkCredential(credentials.UserName, credentials.Password, credentials.Domain);
             }

--- a/src/MigrationTools/_EngineV1/Configuration/EngineConfiguration.cs
+++ b/src/MigrationTools/_EngineV1/Configuration/EngineConfiguration.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using MigrationTools.Enrichers;
 
 namespace MigrationTools._EngineV1.Configuration
 {
@@ -16,7 +17,7 @@ namespace MigrationTools._EngineV1.Configuration
         public Dictionary<string, string> GitRepoMapping { get; set; }
 
         public string LogLevel { get; private set; }
-
+        public List<IProcessorEnricherOptions> CommonEnrichersConfig { get; set; }
         public List<IProcessorConfig> Processors { get; set; }
         public string Version { get; set; }
         public bool workaroundForQuerySOAPBugEnabled { get; set; }

--- a/src/MigrationTools/_EngineV1/Configuration/Processing/TestPlansAndSuitesMigrationConfig.cs
+++ b/src/MigrationTools/_EngineV1/Configuration/Processing/TestPlansAndSuitesMigrationConfig.cs
@@ -7,10 +7,14 @@ namespace MigrationTools._EngineV1.Configuration.Processing
         public bool PrefixProjectToNodes { get; set; }
         public bool Enabled { get; set; }
         public string OnlyElementsWithTag { get; set; }
-        public string OnlyElementsUnderAreaPath { get; set; }
         public string TestPlanQueryBit { get; set; }
         public bool RemoveAllLinks { get; set; }
         public int MigrationDelay { get; set; }
+
+        public bool UseCommonNodeStructureEnricherConfig { get; set; }
+        public string[] NodeBasePaths { get; set; }
+        public Dictionary<string, string> AreaMaps { get; set; }
+        public Dictionary<string, string> IterationMaps { get; set; }
 
         public string Processor
         {

--- a/src/MigrationTools/_EngineV1/Configuration/Processing/WorkItemMigrationConfig.cs
+++ b/src/MigrationTools/_EngineV1/Configuration/Processing/WorkItemMigrationConfig.cs
@@ -40,6 +40,9 @@ namespace MigrationTools._EngineV1.Configuration.Processing
         public IList<int> WorkItemIDs { get; set; }
         public int MaxRevisions { get; set; }
 
+        public Dictionary<string, string> AreaMaps { get; set; }
+        public Dictionary<string, string> IterationMaps { get; set; }
+
         /// <inheritdoc />
         public bool IsProcessorCompatible(IReadOnlyList<IProcessorConfig> otherProcessors)
         {
@@ -70,6 +73,8 @@ namespace MigrationTools._EngineV1.Configuration.Processing
             WIQLOrderBit = "[System.ChangedDate] desc";
             MaxRevisions = 0;
             AttachRevisionHistory = false;
+            AreaMaps = new Dictionary<string, string>();
+            IterationMaps = new Dictionary<string, string>();
         }
     }
 }

--- a/src/MigrationTools/_EngineV1/Configuration/Processing/WorkItemMigrationConfig.cs
+++ b/src/MigrationTools/_EngineV1/Configuration/Processing/WorkItemMigrationConfig.cs
@@ -35,11 +35,12 @@ namespace MigrationTools._EngineV1.Configuration.Processing
         public bool AttachRevisionHistory { get; set; }
         public bool LinkMigrationSaveEachAsAdded { get; set; }
         public bool GenerateMigrationComment { get; set; }
-        public bool? NodeStructureEnricherEnabled { get; set; }
-        public string[] NodeBasePaths { get; set; }
         public IList<int> WorkItemIDs { get; set; }
         public int MaxRevisions { get; set; }
 
+        public bool? NodeStructureEnricherEnabled { get; set; }
+        public bool UseCommonNodeStructureEnricherConfig { get; set; }
+        public string[] NodeBasePaths { get; set; }
         public Dictionary<string, string> AreaMaps { get; set; }
         public Dictionary<string, string> IterationMaps { get; set; }
 

--- a/src/VstsSyncMigrator.Core.Tests/VstsSyncMigrator.Core.Tests.csproj
+++ b/src/VstsSyncMigrator.Core.Tests/VstsSyncMigrator.Core.Tests.csproj
@@ -8,6 +8,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.19.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="Moq" Version="4.17.2" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
     <PackageReference Include="coverlet.collector" Version="3.1.0">
@@ -17,6 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\MigrationTools.Clients.AzureDevops.ObjectModel.Tests\MigrationTools.Clients.AzureDevops.ObjectModel.Tests.csproj" />
     <ProjectReference Include="..\MigrationTools.Clients.AzureDevops.ObjectModel\MigrationTools.Clients.AzureDevops.ObjectModel.csproj" />
     <ProjectReference Include="..\MigrationTools.TestExtensions\MigrationTools.TestExtensions.csproj" />
     <ProjectReference Include="..\VstsSyncMigrator.Core\VstsSyncMigrator.Core.csproj" />

--- a/src/VstsSyncMigrator.Core.Tests/WorkItemMigrationTests.cs
+++ b/src/VstsSyncMigrator.Core.Tests/WorkItemMigrationTests.cs
@@ -1,29 +1,79 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using System.Collections.Generic;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MigrationTools;
+using MigrationTools._EngineV1.Configuration.Processing;
+using MigrationTools.Enrichers;
+using MigrationTools.Processors;
+using MigrationTools.Tests;
 using VstsSyncMigrator.Engine;
 
 namespace VstsSyncMigrator.Core.Tests
 {
     [TestClass]
     public class WorkItemMigrationTests
-    {        
+    {
+        private ServiceProvider _services;
+        private WorkItemMigrationContext _underTest;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _services = ServiceProviderHelper.GetServices();
+            var nodeStructure = _services.GetRequiredService<TfsNodeStructure>();
+            nodeStructure.ApplySettings(new TfsNodeStructureSettings
+            {
+                FoundNodes = new Dictionary<string, bool>(),
+                SourceProjectName = "Path1",
+                TargetProjectName = "Path1",
+            });
+            nodeStructure.Configure(new TfsNodeStructureOptions
+            {
+                AreaMaps = new Dictionary<string, string>
+                {
+                    { "SourceServer", "TargetServer" }
+                },
+                IterationMaps = new Dictionary<string, string>
+                {
+                    { "SourceServer", "TargetServer" }
+                },
+            });
+
+            _underTest = new WorkItemMigrationContext(_services.GetRequiredService<IMigrationEngine>(), _services,
+                _services.GetRequiredService<ITelemetryLogger>(),
+                _services.GetRequiredService<ILogger<WorkItemMigrationContext>>());
+            _underTest.Configure(new WorkItemMigrationConfig
+            {
+                AreaMaps = new Dictionary<string, string>
+                {
+                    {"SourceServer", "TargetServer"}
+                },
+                IterationMaps = new Dictionary<string, string>
+                {
+                    {"SourceServer", "TargetServer"}
+                },
+            });
+        }
+
         [TestMethod]
         public void TestFixAreaPath_WhenNoAreaPathOrIterationPath_DoesntChangeQuery()
         {
             string WIQLQueryBit = @"AND  [Microsoft.VSTS.Common.ClosedDate] = '' AND [System.WorkItemType] NOT IN ('Test Suite', 'Test Plan')";
 
-            string targetWIQLQueryBit = WorkItemMigrationContext.FixAreaPathAndIterationPathForTargetQuery(WIQLQueryBit, "SourceServer", "TargetServer", null);
+            string targetWIQLQueryBit = _underTest.FixAreaPathAndIterationPathForTargetQuery(WIQLQueryBit, "SourceServer", "TargetServer", null);
 
             Assert.AreEqual(WIQLQueryBit, targetWIQLQueryBit);
         }
 
-        
+
         [TestMethod]
         public void TestFixAreaPath_WhenAreaPathInQuery_ChangesQuery()
         {
             string WIQLQueryBit =         @"AND [System.AreaPath] = 'SourceServer\Area\Path1' AND   [Microsoft.VSTS.Common.ClosedDate] = '' AND [System.WorkItemType] NOT IN ('Test Suite', 'Test Plan')";
             string expectTargetQueryBit = @"AND [System.AreaPath] = 'TargetServer\Area\Path1' AND   [Microsoft.VSTS.Common.ClosedDate] = '' AND [System.WorkItemType] NOT IN ('Test Suite', 'Test Plan')";
 
-            string targetWIQLQueryBit = WorkItemMigrationContext.FixAreaPathAndIterationPathForTargetQuery(WIQLQueryBit, "SourceServer", "TargetServer", null);
+            string targetWIQLQueryBit = _underTest.FixAreaPathAndIterationPathForTargetQuery(WIQLQueryBit, "SourceServer", "TargetServer", null);
 
             Assert.AreEqual(expectTargetQueryBit, targetWIQLQueryBit);
         }
@@ -34,7 +84,7 @@ namespace VstsSyncMigrator.Core.Tests
             string WIQLQueryBit =         @"AND [System.AreaPath] = 'SourceServer\Area\Path1' OR [System.AreaPath] = 'SourceServer\Area\Path2' AND [Microsoft.VSTS.Common.ClosedDate] = '' AND [System.WorkItemType] NOT IN ('Test Suite', 'Test Plan')";
             string expectTargetQueryBit = @"AND [System.AreaPath] = 'TargetServer\Area\Path1' OR [System.AreaPath] = 'TargetServer\Area\Path2' AND [Microsoft.VSTS.Common.ClosedDate] = '' AND [System.WorkItemType] NOT IN ('Test Suite', 'Test Plan')";
 
-            string targetWIQLQueryBit = WorkItemMigrationContext.FixAreaPathAndIterationPathForTargetQuery(WIQLQueryBit, "SourceServer", "TargetServer", null);
+            string targetWIQLQueryBit = _underTest.FixAreaPathAndIterationPathForTargetQuery(WIQLQueryBit, "SourceServer", "TargetServer", null);
 
             Assert.AreEqual(expectTargetQueryBit, targetWIQLQueryBit);
         }
@@ -45,7 +95,7 @@ namespace VstsSyncMigrator.Core.Tests
             string WIQLQueryBit =         @"AND [Microsoft.VSTS.Common.ClosedDate] = '' AND [System.WorkItemType] NOT IN ('Test Suite', 'Test Plan') AND [System.AreaPath] = 'SourceServer\Area\Path1'";
             string expectTargetQueryBit = @"AND [Microsoft.VSTS.Common.ClosedDate] = '' AND [System.WorkItemType] NOT IN ('Test Suite', 'Test Plan') AND [System.AreaPath] = 'TargetServer\Area\Path1'";
 
-            string targetWIQLQueryBit = WorkItemMigrationContext.FixAreaPathAndIterationPathForTargetQuery(WIQLQueryBit, "SourceServer", "TargetServer", null);
+            string targetWIQLQueryBit = _underTest.FixAreaPathAndIterationPathForTargetQuery(WIQLQueryBit, "SourceServer", "TargetServer", null);
 
             Assert.AreEqual(expectTargetQueryBit, targetWIQLQueryBit);
         }
@@ -56,7 +106,7 @@ namespace VstsSyncMigrator.Core.Tests
             string WIQLQueryBit = @"AND [System.IterationPath] = 'SourceServer\Iteration\Path1' AND   [Microsoft.VSTS.Common.ClosedDate] = '' AND [System.WorkItemType] NOT IN ('Test Suite', 'Test Plan')";
             string expectTargetQueryBit = @"AND [System.IterationPath] = 'TargetServer\Iteration\Path1' AND   [Microsoft.VSTS.Common.ClosedDate] = '' AND [System.WorkItemType] NOT IN ('Test Suite', 'Test Plan')";
 
-            string targetWIQLQueryBit = WorkItemMigrationContext.FixAreaPathAndIterationPathForTargetQuery(WIQLQueryBit, "SourceServer", "TargetServer", null);
+            string targetWIQLQueryBit = _underTest.FixAreaPathAndIterationPathForTargetQuery(WIQLQueryBit, "SourceServer", "TargetServer", null);
 
             Assert.AreEqual(expectTargetQueryBit, targetWIQLQueryBit);
         }
@@ -67,7 +117,7 @@ namespace VstsSyncMigrator.Core.Tests
             string WIQLQueryBit = @"AND ([System.AreaPath] = 'SourceServer\Area\Path1' OR [System.AreaPath] = 'SourceServer\Area\Path2') AND ([System.IterationPath] = 'SourceServer\Iteration\Path1' OR [System.IterationPath] = 'SourceServer\Iteration\Path2') AND [Microsoft.VSTS.Common.ClosedDate] = '' AND [System.WorkItemType] NOT IN ('Test Suite', 'Test Plan')";
             string expectTargetQueryBit = @"AND ([System.AreaPath] = 'TargetServer\Area\Path1' OR [System.AreaPath] = 'TargetServer\Area\Path2') AND ([System.IterationPath] = 'TargetServer\Iteration\Path1' OR [System.IterationPath] = 'TargetServer\Iteration\Path2') AND [Microsoft.VSTS.Common.ClosedDate] = '' AND [System.WorkItemType] NOT IN ('Test Suite', 'Test Plan')";
 
-            string targetWIQLQueryBit = WorkItemMigrationContext.FixAreaPathAndIterationPathForTargetQuery(WIQLQueryBit, "SourceServer", "TargetServer", null);
+            string targetWIQLQueryBit = _underTest.FixAreaPathAndIterationPathForTargetQuery(WIQLQueryBit, "SourceServer", "TargetServer", null);
 
             Assert.AreEqual(expectTargetQueryBit, targetWIQLQueryBit);
         }
@@ -78,7 +128,7 @@ namespace VstsSyncMigrator.Core.Tests
             string WIQLQueryBit = @"AND ([System.AreaPath] = 'SourceServer\Area\Path1' OR [System.AreaPath] UNDER 'SourceServer\Area\Path2') AND ([System.IterationPath] UNDER 'SourceServer\Iteration\Path1' OR [System.IterationPath] = 'SourceServer\Iteration\Path2') AND [Microsoft.VSTS.Common.ClosedDate] = '' AND [System.WorkItemType] NOT IN ('Test Suite', 'Test Plan')";
             string expectTargetQueryBit = @"AND ([System.AreaPath] = 'TargetServer\Area\Path1' OR [System.AreaPath] UNDER 'TargetServer\Area\Path2') AND ([System.IterationPath] UNDER 'TargetServer\Iteration\Path1' OR [System.IterationPath] = 'TargetServer\Iteration\Path2') AND [Microsoft.VSTS.Common.ClosedDate] = '' AND [System.WorkItemType] NOT IN ('Test Suite', 'Test Plan')";
 
-            string targetWIQLQueryBit = WorkItemMigrationContext.FixAreaPathAndIterationPathForTargetQuery(WIQLQueryBit, "SourceServer", "TargetServer", null);
+            string targetWIQLQueryBit = _underTest.FixAreaPathAndIterationPathForTargetQuery(WIQLQueryBit, "SourceServer", "TargetServer", null);
 
             Assert.AreEqual(expectTargetQueryBit, targetWIQLQueryBit);
         }

--- a/src/VstsSyncMigrator.Core.Tests/WorkItemMigrationTests.cs
+++ b/src/VstsSyncMigrator.Core.Tests/WorkItemMigrationTests.cs
@@ -1,11 +1,13 @@
 ﻿using System.Collections.Generic;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using MigrationTools;
+using MigrationTools._EngineV1.Configuration;
 using MigrationTools._EngineV1.Configuration.Processing;
 using MigrationTools.Enrichers;
-using MigrationTools.Processors;
+using MigrationTools.ProcessorEnrichers;
 using MigrationTools.Tests;
 using VstsSyncMigrator.Engine;
 
@@ -40,9 +42,16 @@ namespace VstsSyncMigrator.Core.Tests
                 },
             });
 
-            _underTest = new WorkItemMigrationContext(_services.GetRequiredService<IMigrationEngine>(), _services,
-                _services.GetRequiredService<ITelemetryLogger>(),
-                _services.GetRequiredService<ILogger<WorkItemMigrationContext>>());
+            _underTest = new WorkItemMigrationContext(_services.GetRequiredService<IMigrationEngine>(),
+                                                      _services,
+                                                      _services.GetRequiredService<ITelemetryLogger>(),
+                                                      _services.GetRequiredService<ILogger<WorkItemMigrationContext>>(),
+                                                      nodeStructure,
+                                                      _services.GetRequiredService<TfsRevisionManager>(),
+                                                      _services.GetRequiredService<TfsWorkItemLinkEnricher>(),
+                                                      _services.GetRequiredService<TfsWorkItemEmbededLinkEnricher>(),
+                                                      _services.GetRequiredService<TfsValidateRequiredField>(),
+                                                      _services.GetRequiredService<IOptions<EngineConfiguration>>());
             _underTest.Configure(new WorkItemMigrationConfig
             {
                 AreaMaps = new Dictionary<string, string>

--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemMigrationContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemMigrationContext.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using Microsoft.ApplicationInsights.DataContracts;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Microsoft.TeamFoundation.WorkItemTracking.Client;
 using Microsoft.TeamFoundation.WorkItemTracking.Proxy;
 using MigrationTools;
@@ -44,23 +45,36 @@ namespace VstsSyncMigrator.Engine
         private ILogger contextLog;
         private IAttachmentMigrationEnricher attachmentEnricher;
         private IWorkItemProcessorEnricher embededImagesEnricher;
-        private IWorkItemProcessorEnricher workItemEmbededLinkEnricher;
-        private TfsAreaAndIterationProcessor areaAndIterationProcessor;
+        private IWorkItemProcessorEnricher _workItemEmbededLinkEnricher;
         private TfsGitRepositoryEnricher gitRepositoryEnricher;
-        private TfsNodeStructure nodeStructureEnricher;
-        private TfsRevisionManager revisionManager;
-        private TfsValidateRequiredField validateConfig;
+        private TfsNodeStructure _nodeStructureEnricher;
+        private readonly EngineConfiguration _engineConfig;
+        private TfsRevisionManager _revisionManager;
+        private TfsValidateRequiredField _validateConfig;
         private IDictionary<string, double> processWorkItemMetrics = null;
         private IDictionary<string, string> processWorkItemParamiters = null;
-        private TfsWorkItemLinkEnricher workItemLinkEnricher;
+        private TfsWorkItemLinkEnricher _workItemLinkEnricher;
         private ILogger workItemLog;
-        private TfsNodeStructure areaAndIterationEnricher;
 
-        public WorkItemMigrationContext(IMigrationEngine engine, IServiceProvider services, ITelemetryLogger telemetry, ILogger<WorkItemMigrationContext> logger)
+        public WorkItemMigrationContext(IMigrationEngine engine,
+                                        IServiceProvider services,
+                                        ITelemetryLogger telemetry,
+                                        ILogger<WorkItemMigrationContext> logger,
+                                        TfsNodeStructure nodeStructureEnricher,
+                                        TfsRevisionManager revisionManager,
+                                        TfsWorkItemLinkEnricher workItemLinkEnricher,
+                                        TfsWorkItemEmbededLinkEnricher workItemEmbeddedLinkEnricher,
+                                        TfsValidateRequiredField requiredFieldValidator,
+                                        IOptions<EngineConfiguration> engineConfig)
             : base(engine, services, telemetry, logger)
         {
+            _engineConfig = engineConfig.Value;
             contextLog = Serilog.Log.ForContext<WorkItemMigrationContext>();
-            areaAndIterationEnricher = Services.GetRequiredService<TfsNodeStructure>();
+            _nodeStructureEnricher = nodeStructureEnricher;
+            _revisionManager = revisionManager;
+            _workItemLinkEnricher = workItemLinkEnricher;
+            _workItemEmbededLinkEnricher = workItemEmbeddedLinkEnricher;
+            _validateConfig = requiredFieldValidator;
         }
 
         public override string Name => "WorkItemMigration";
@@ -68,7 +82,28 @@ namespace VstsSyncMigrator.Engine
         public override void Configure(IProcessorConfig config)
         {
             _config = (WorkItemMigrationConfig)config;
-            validateConfig = Services.GetRequiredService<TfsValidateRequiredField>();
+
+            if (_config.UseCommonNodeStructureEnricherConfig)
+            {
+                var nseConfig = _engineConfig.CommonEnrichersConfig.OfType<TfsNodeStructureOptions>()
+                                    .FirstOrDefault() ??
+                                throw new InvalidOperationException(
+                                    "Cannot use common node structure because it is not found.");
+                _nodeStructureEnricher.Configure(nseConfig);
+            }
+            else
+            {
+                _nodeStructureEnricher.Configure(new TfsNodeStructureOptions
+                {
+                    Enabled = _config.NodeStructureEnricherEnabled ?? true,
+                    NodeBasePaths = _config.NodeBasePaths,
+                    PrefixProjectToNodes = _config.PrefixProjectToNodes,
+                    AreaMaps = _config.AreaMaps ?? new Dictionary<string, string>(),
+                    IterationMaps = _config.IterationMaps ?? new Dictionary<string, string>(),
+                });
+            }
+
+            _revisionManager.Configure(new TfsRevisionManagerOptions() { Enabled = true, MaxRevisions = _config.MaxRevisions, ReplayRevisions = _config.ReplayRevisions });
         }
 
         internal void TraceWriteLine(LogEventLevel level, string message, Dictionary<string, object> properties = null)
@@ -90,25 +125,13 @@ namespace VstsSyncMigrator.Engine
             {
                 throw new Exception("You must call Configure() first");
             }
+
             var workItemServer = Engine.Source.GetService<WorkItemServer>();
             attachmentEnricher = new TfsAttachmentEnricher(workItemServer, _config.AttachmentWorkingPath, _config.AttachmentMaxSize);
-            workItemLinkEnricher = Services.GetRequiredService<TfsWorkItemLinkEnricher>();
             embededImagesEnricher = Services.GetRequiredService<TfsEmbededImagesEnricher>();
-            workItemEmbededLinkEnricher = Services.GetRequiredService<TfsWorkItemEmbededLinkEnricher>();
-            areaAndIterationProcessor = Services.GetRequiredService<TfsAreaAndIterationProcessor>();
             gitRepositoryEnricher = Services.GetRequiredService<TfsGitRepositoryEnricher>();
-            nodeStructureEnricher = Services.GetRequiredService<TfsNodeStructure>();
-            nodeStructureEnricher.Configure(new TfsNodeStructureOptions()
-            {
-                Enabled = _config.NodeStructureEnricherEnabled ?? true,
-                NodeBasePaths = _config.NodeBasePaths,
-                PrefixProjectToNodes = _config.PrefixProjectToNodes,
-                AreaMaps = _config.AreaMaps ?? new Dictionary<string, string>(),
-                IterationMaps = _config.IterationMaps ?? new Dictionary<string, string>(),
-            });
-            nodeStructureEnricher.ProcessorExecutionBegin(null);
-            revisionManager = Services.GetRequiredService<TfsRevisionManager>();
-            revisionManager.Configure(new TfsRevisionManagerOptions() { Enabled = true, MaxRevisions = _config.MaxRevisions, ReplayRevisions = _config.ReplayRevisions });
+
+            _nodeStructureEnricher.ProcessorExecutionBegin(null);
 
             var stopwatch = Stopwatch.StartNew();
 
@@ -139,7 +162,7 @@ namespace VstsSyncMigrator.Engine
                 }
                 //////////////////////////////////////////////////
 
-                var result = validateConfig.ValidatingRequiredField(Engine.Target.Config.AsTeamProjectConfig().ReflectedWorkItemIDFieldName, sourceWorkItems);
+                var result = _validateConfig.ValidatingRequiredField(Engine.Target.Config.AsTeamProjectConfig().ReflectedWorkItemIDFieldName, sourceWorkItems);
                 if (!result)
                 {
                     var ex = new InvalidFieldValueException("Not all work items in scope contain a valid ReflectedWorkItemId Field!");
@@ -227,7 +250,7 @@ namespace VstsSyncMigrator.Engine
                         throw new InvalidOperationException($"Field type {fieldType} is not supported for query remapping.");
                 }
 
-                var remappedPath = areaAndIterationEnricher.GetNewNodeName(value, structureType);
+                var remappedPath = _nodeStructureEnricher.GetNewNodeName(value, structureType);
                 targetWIQLQueryBit = targetWIQLQueryBit.Replace(value, remappedPath);
             }
 
@@ -318,10 +341,10 @@ namespace VstsSyncMigrator.Engine
                 }
             }
 
-            if (nodeStructureEnricher.Options.Enabled)
+            if (_nodeStructureEnricher.Options.Enabled)
             {
-                newWorkItem.AreaPath = nodeStructureEnricher.GetNewNodeName(oldWorkItem.AreaPath, TfsNodeStructureType.Area);
-                newWorkItem.IterationPath = nodeStructureEnricher.GetNewNodeName(oldWorkItem.IterationPath, TfsNodeStructureType.Iteration);
+                newWorkItem.AreaPath = _nodeStructureEnricher.GetNewNodeName(oldWorkItem.AreaPath, TfsNodeStructureType.Area);
+                newWorkItem.IterationPath = _nodeStructureEnricher.GetNewNodeName(oldWorkItem.IterationPath, TfsNodeStructureType.Iteration);
             }
 
             switch (destType)
@@ -357,7 +380,7 @@ namespace VstsSyncMigrator.Engine
         {
             if (sourceWorkItem != null && targetWorkItem != null && _config.FixHtmlAttachmentLinks)
             {
-                workItemEmbededLinkEnricher.Enrich(sourceWorkItem, targetWorkItem);
+                _workItemEmbededLinkEnricher.Enrich(sourceWorkItem, targetWorkItem);
             }
         }
 
@@ -387,7 +410,7 @@ namespace VstsSyncMigrator.Engine
                             { "sourceWorkItemRev", sourceWorkItem.Rev },
                             { "ReplayRevisions", _config.ReplayRevisions }}
                         );
-                    List<RevisionItem> revisionsToMigrate = revisionManager.GetRevisionsToMigrate(sourceWorkItem, targetWorkItem);
+                    List<RevisionItem> revisionsToMigrate = _revisionManager.GetRevisionsToMigrate(sourceWorkItem, targetWorkItem);
                     if (targetWorkItem == null)
                     {
                         targetWorkItem = ReplayRevisions(revisionsToMigrate, sourceWorkItem, null);
@@ -504,7 +527,7 @@ namespace VstsSyncMigrator.Engine
             if (targetWorkItem != null && _config.LinkMigration && sourceWorkItem.ToWorkItem().Links.Count > 0)
             {
                 TraceWriteLine(LogEventLevel.Information, "Links {SourceWorkItemLinkCount} | LinkMigrator:{LinkMigration}", new Dictionary<string, object>() { { "SourceWorkItemLinkCount", sourceWorkItem.ToWorkItem().Links.Count }, { "LinkMigration", _config.LinkMigration } });
-                workItemLinkEnricher.Enrich(sourceWorkItem, targetWorkItem);
+                _workItemLinkEnricher.Enrich(sourceWorkItem, targetWorkItem);
                 AddMetric("RelatedLinkCount", processWorkItemMetrics, targetWorkItem.ToWorkItem().Links.Count);
                 int fixedLinkCount = gitRepositoryEnricher.Enrich(sourceWorkItem, targetWorkItem);
                 AddMetric("FixedGitLinkCount", processWorkItemMetrics, fixedLinkCount);
@@ -534,7 +557,7 @@ namespace VstsSyncMigrator.Engine
 
                 if (_config.AttachRevisionHistory)
                 {
-                    revisionManager.AttachSourceRevisionHistoryJsonToTarget(sourceWorkItem, targetWorkItem);
+                    _revisionManager.AttachSourceRevisionHistoryJsonToTarget(sourceWorkItem, targetWorkItem);
                 }
 
                 foreach (var revision in revisionsToMigrate)

--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemMigrationContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemMigrationContext.cs
@@ -22,6 +22,7 @@ using MigrationTools._EngineV1.Processors;
 using MigrationTools.DataContracts;
 using MigrationTools.Enrichers;
 using MigrationTools.ProcessorEnrichers;
+using MigrationTools.Processors;
 using Serilog.Context;
 using Serilog.Events;
 using ILogger = Serilog.ILogger;
@@ -44,6 +45,7 @@ namespace VstsSyncMigrator.Engine
         private IAttachmentMigrationEnricher attachmentEnricher;
         private IWorkItemProcessorEnricher embededImagesEnricher;
         private IWorkItemProcessorEnricher workItemEmbededLinkEnricher;
+        private TfsAreaAndIterationProcessor areaAndIterationProcessor;
         private TfsGitRepositoryEnricher gitRepositoryEnricher;
         private TfsNodeStructure nodeStructureEnricher;
         private TfsRevisionManager revisionManager;
@@ -52,11 +54,13 @@ namespace VstsSyncMigrator.Engine
         private IDictionary<string, string> processWorkItemParamiters = null;
         private TfsWorkItemLinkEnricher workItemLinkEnricher;
         private ILogger workItemLog;
+        private TfsNodeStructure areaAndIterationEnricher;
 
         public WorkItemMigrationContext(IMigrationEngine engine, IServiceProvider services, ITelemetryLogger telemetry, ILogger<WorkItemMigrationContext> logger)
             : base(engine, services, telemetry, logger)
         {
             contextLog = Serilog.Log.ForContext<WorkItemMigrationContext>();
+            areaAndIterationEnricher = Services.GetRequiredService<TfsNodeStructure>();
         }
 
         public override string Name => "WorkItemMigration";
@@ -91,10 +95,17 @@ namespace VstsSyncMigrator.Engine
             workItemLinkEnricher = Services.GetRequiredService<TfsWorkItemLinkEnricher>();
             embededImagesEnricher = Services.GetRequiredService<TfsEmbededImagesEnricher>();
             workItemEmbededLinkEnricher = Services.GetRequiredService<TfsWorkItemEmbededLinkEnricher>();
+            areaAndIterationProcessor = Services.GetRequiredService<TfsAreaAndIterationProcessor>();
             gitRepositoryEnricher = Services.GetRequiredService<TfsGitRepositoryEnricher>();
             nodeStructureEnricher = Services.GetRequiredService<TfsNodeStructure>();
-            nodeStructureEnricher.Configure(new TfsNodeStructureOptions() { Enabled = _config.NodeStructureEnricherEnabled ?? true, NodeBasePaths = _config.NodeBasePaths, PrefixProjectToNodes = _config.PrefixProjectToNodes });
-            nodeStructureEnricher.Configure(new TfsNodeStructureOptions() { Enabled = _config.NodeStructureEnricherEnabled ?? true, NodeBasePaths = _config.NodeBasePaths, PrefixProjectToNodes = _config.PrefixProjectToNodes });
+            nodeStructureEnricher.Configure(new TfsNodeStructureOptions()
+            {
+                Enabled = _config.NodeStructureEnricherEnabled ?? true,
+                NodeBasePaths = _config.NodeBasePaths,
+                PrefixProjectToNodes = _config.PrefixProjectToNodes,
+                AreaMaps = _config.AreaMaps ?? new Dictionary<string, string>(),
+                IterationMaps = _config.IterationMaps ?? new Dictionary<string, string>(),
+            });
             nodeStructureEnricher.ProcessorExecutionBegin(null);
             revisionManager = Services.GetRequiredService<TfsRevisionManager>();
             revisionManager.Configure(new TfsRevisionManagerOptions() { Enabled = true, MaxRevisions = _config.MaxRevisions, ReplayRevisions = _config.ReplayRevisions });
@@ -176,39 +187,48 @@ namespace VstsSyncMigrator.Engine
             }
         }
 
-        internal static string FixAreaPathAndIterationPathForTargetQuery(string sourceWIQLQueryBit, string sourceProject, string targetProject, ILogger? contextLog)
+        internal string FixAreaPathAndIterationPathForTargetQuery(string sourceWIQLQueryBit, string sourceProject, string targetProject, ILogger? contextLog)
         {
+
             string targetWIQLQueryBit = sourceWIQLQueryBit;
 
-            if (string.IsNullOrWhiteSpace(targetWIQLQueryBit)
-                || string.IsNullOrWhiteSpace(sourceProject)
+            if (string.IsNullOrWhiteSpace(targetWIQLQueryBit))
+            {
+                return targetWIQLQueryBit;
+            }
+
+            var matches = Regex.Matches(targetWIQLQueryBit, RegexPatterForAreaAndIterationPathsFix);
+
+
+            if(string.IsNullOrWhiteSpace(sourceProject)
                 || string.IsNullOrWhiteSpace(targetProject)
                 || sourceProject == targetProject)
             {
                 return targetWIQLQueryBit;
             }
 
-            var matches = Regex.Matches(targetWIQLQueryBit, RegexPatterForAreaAndIterationPathsFix);
             foreach (Match match in matches)
             {
-                if (!match.Success)
-                    continue;
-
                 var value = match.Groups["value"].Value;
                 if (string.IsNullOrWhiteSpace(value) || !value.StartsWith(sourceProject))
                     continue;
 
-                var slashIndex = value.IndexOf('\\');
-                if (slashIndex > 0)
+                var fieldType = match.Groups["key"].Value;
+                TfsNodeStructureType structureType;
+                switch (fieldType)
                 {
-                    var subValue = value.Substring(0, slashIndex);
-                    if (subValue == sourceProject)
-                    {
-                        var targetValue = targetProject + value.Substring(slashIndex);
-                        var targetMatchValue = match.Value.Replace(value, targetValue);
-                        targetWIQLQueryBit = targetWIQLQueryBit.Replace(match.Value, targetMatchValue);
-                    }
+                    case "System.AreaPath":
+                        structureType = TfsNodeStructureType.Area;
+                        break;
+                    case "System.IterationPath":
+                        structureType = TfsNodeStructureType.Iteration;
+                        break;
+                    default:
+                        throw new InvalidOperationException($"Field type {fieldType} is not supported for query remapping.");
                 }
+
+                var remappedPath = areaAndIterationEnricher.GetNewNodeName(value, structureType);
+                targetWIQLQueryBit = targetWIQLQueryBit.Replace(value, remappedPath);
             }
 
             contextLog?.Information("[FilterWorkItemsThatAlreadyExistInTarget] is enabled. Source project {sourceProject} is replaced with target project {targetProject} on the WIQLQueryBit which resulted into this target WIQLQueryBit \"{targetWIQLQueryBit}\" .", sourceProject, targetProject, targetWIQLQueryBit);


### PR DESCRIPTION
This commit implements area and iteration path remapping, which includes

- Remap area and iteration paths during node creation
- Remap area and iteration paths when migrating work items

This is compatible with the `PrefixProjectToNode` option, which is implemented as a "last resort" rule for the remapping.