### PR TITLE
[feature] Get PAT from environment variables

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -212,7 +212,9 @@ The default [WorkItemMigrationConfig](./Processors/WorkItemMigrationConfig.md) p
 1. Adjust the value of the `Project` attribute for Source and Target
 1. Set the `AuthenticationMode` (`Prompt` or `AccessToken`) for Source and Target
 
-    If you set Authentication mode to `AccessToken`, enter a valid PAT as value for the `PersonalAccessToken` attribute
+    If you set Authentication mode to `AccessToken`, enter a valid PAT as value
+    for the `PersonalAccessToken` attribute, or set the
+    `PersonalAccessTokenVariableName` to the name of an environment variable containing your PAT.
 
 1. Adjust the value of the `ReflectedWorkItemIDFieldName` attribute (field name of the migration tracking field) for Source and Target
 

--- a/src/MigrationTools.Clients.AzureDevops.ObjectModel/_EngineV1/Configuration/TfsTeamProjectConfig.cs
+++ b/src/MigrationTools.Clients.AzureDevops.ObjectModel/_EngineV1/Configuration/TfsTeamProjectConfig.cs
@@ -16,6 +16,7 @@ namespace MigrationTools._EngineV1.Configuration
         public AuthenticationMode AuthenticationMode { get; set; }
 
         public string PersonalAccessToken { get; set; }
+        public string PersonalAccessTokenVariableName { get; set; }
         public TfsLanguageMapOptions LanguageMaps { get; set; }
 
         public IMigrationClientConfig PopulateWithDefault()
@@ -25,6 +26,7 @@ namespace MigrationTools._EngineV1.Configuration
             Collection = new Uri("https://dev.azure.com/nkdagility-preview/");
             ReflectedWorkItemIDFieldName = "Custom.ReflectedWorkItemId";
             PersonalAccessToken = "";
+            PersonalAccessTokenVariableName = "";
             AuthenticationMode = AuthenticationMode.Prompt;
             LanguageMaps = new TfsLanguageMapOptions() { AreaPath = "Area", IterationPath = "Iteration" };
             return this;

--- a/src/MigrationTools.Clients.AzureDevops.ObjectModel/_Enginev1/Clients/TfsMigrationClient.cs
+++ b/src/MigrationTools.Clients.AzureDevops.ObjectModel/_Enginev1/Clients/TfsMigrationClient.cs
@@ -118,7 +118,12 @@ namespace MigrationTools._EngineV1.Clients
                 {
                     case AuthenticationMode.AccessToken:
                         Log.Information("TfsMigrationClient::GetDependantTfsCollection: Connecting with AccessToken ");
-                        _vssCredentials = new VssBasicCredential(string.Empty, TfsConfig.PersonalAccessToken);
+                        var pat = TfsConfig.PersonalAccessToken;
+                        if (!string.IsNullOrEmpty(TfsConfig.PersonalAccessTokenVariableName))
+                        {
+                            pat = Environment.GetEnvironmentVariable(TfsConfig.PersonalAccessTokenVariableName);
+                        }
+                        _vssCredentials = new VssBasicCredential(string.Empty, pat);
                         y = new TfsTeamProjectCollection(TfsConfig.Collection, _vssCredentials);
                         break;
 


### PR DESCRIPTION
This commit allows loading PATs from environment variables, which in turns makes it easier to store configuration files in source control.