### PR TITLE
Fixed the issue with target query when PrefixProjectToNodes is enabled

### DIFF
--- a/src/VstsSyncMigrator.Core.Tests/WorkItemMigrationTests.cs
+++ b/src/VstsSyncMigrator.Core.Tests/WorkItemMigrationTests.cs
@@ -5,25 +5,36 @@ namespace VstsSyncMigrator.Core.Tests
 {
     [TestClass]
     public class WorkItemMigrationTests
-    {        
+    {
         [TestMethod]
         public void TestFixAreaPath_WhenNoAreaPathOrIterationPath_DoesntChangeQuery()
         {
             string WIQLQueryBit = @"AND  [Microsoft.VSTS.Common.ClosedDate] = '' AND [System.WorkItemType] NOT IN ('Test Suite', 'Test Plan')";
 
-            string targetWIQLQueryBit = WorkItemMigrationContext.FixAreaPathAndIterationPathForTargetQuery(WIQLQueryBit, "SourceServer", "TargetServer", null);
+            string targetWIQLQueryBit = WorkItemMigrationContext.FixAreaPathAndIterationPathForTargetQuery(WIQLQueryBit, "SourceServer", "TargetServer", false, null);
 
             Assert.AreEqual(WIQLQueryBit, targetWIQLQueryBit);
         }
 
-        
+
         [TestMethod]
         public void TestFixAreaPath_WhenAreaPathInQuery_ChangesQuery()
         {
-            string WIQLQueryBit =         @"AND [System.AreaPath] = 'SourceServer\Area\Path1' AND   [Microsoft.VSTS.Common.ClosedDate] = '' AND [System.WorkItemType] NOT IN ('Test Suite', 'Test Plan')";
+            string WIQLQueryBit = @"AND [System.AreaPath] = 'SourceServer\Area\Path1' AND   [Microsoft.VSTS.Common.ClosedDate] = '' AND [System.WorkItemType] NOT IN ('Test Suite', 'Test Plan')";
             string expectTargetQueryBit = @"AND [System.AreaPath] = 'TargetServer\Area\Path1' AND   [Microsoft.VSTS.Common.ClosedDate] = '' AND [System.WorkItemType] NOT IN ('Test Suite', 'Test Plan')";
 
-            string targetWIQLQueryBit = WorkItemMigrationContext.FixAreaPathAndIterationPathForTargetQuery(WIQLQueryBit, "SourceServer", "TargetServer", null);
+            string targetWIQLQueryBit = WorkItemMigrationContext.FixAreaPathAndIterationPathForTargetQuery(WIQLQueryBit, "SourceServer", "TargetServer", false, null);
+
+            Assert.AreEqual(expectTargetQueryBit, targetWIQLQueryBit);
+        }
+
+        [TestMethod]
+        public void TestFixAreaPath_WhenAreaPathInQuery_WithPrefixProjectToNodesEnabled_ChangesQuery()
+        {
+            string WIQLQueryBit = @"AND [System.AreaPath] = 'SourceServer\Area\Path1' AND   [Microsoft.VSTS.Common.ClosedDate] = '' AND [System.WorkItemType] NOT IN ('Test Suite', 'Test Plan')";
+            string expectTargetQueryBit = @"AND [System.AreaPath] = 'TargetServer\SourceServer\Area\Path1' AND   [Microsoft.VSTS.Common.ClosedDate] = '' AND [System.WorkItemType] NOT IN ('Test Suite', 'Test Plan')";
+
+            string targetWIQLQueryBit = WorkItemMigrationContext.FixAreaPathAndIterationPathForTargetQuery(WIQLQueryBit, "SourceServer", "TargetServer", true, null);
 
             Assert.AreEqual(expectTargetQueryBit, targetWIQLQueryBit);
         }
@@ -31,10 +42,10 @@ namespace VstsSyncMigrator.Core.Tests
         [TestMethod]
         public void TestFixAreaPath_WhenMultipleAreaPathInQuery_ChangesQuery()
         {
-            string WIQLQueryBit =         @"AND [System.AreaPath] = 'SourceServer\Area\Path1' OR [System.AreaPath] = 'SourceServer\Area\Path2' AND [Microsoft.VSTS.Common.ClosedDate] = '' AND [System.WorkItemType] NOT IN ('Test Suite', 'Test Plan')";
+            string WIQLQueryBit = @"AND [System.AreaPath] = 'SourceServer\Area\Path1' OR [System.AreaPath] = 'SourceServer\Area\Path2' AND [Microsoft.VSTS.Common.ClosedDate] = '' AND [System.WorkItemType] NOT IN ('Test Suite', 'Test Plan')";
             string expectTargetQueryBit = @"AND [System.AreaPath] = 'TargetServer\Area\Path1' OR [System.AreaPath] = 'TargetServer\Area\Path2' AND [Microsoft.VSTS.Common.ClosedDate] = '' AND [System.WorkItemType] NOT IN ('Test Suite', 'Test Plan')";
 
-            string targetWIQLQueryBit = WorkItemMigrationContext.FixAreaPathAndIterationPathForTargetQuery(WIQLQueryBit, "SourceServer", "TargetServer", null);
+            string targetWIQLQueryBit = WorkItemMigrationContext.FixAreaPathAndIterationPathForTargetQuery(WIQLQueryBit, "SourceServer", "TargetServer", false, null);
 
             Assert.AreEqual(expectTargetQueryBit, targetWIQLQueryBit);
         }
@@ -42,10 +53,10 @@ namespace VstsSyncMigrator.Core.Tests
         [TestMethod]
         public void TestFixAreaPath_WhenAreaPathAtEndOfQuery_ChangesQuery()
         {
-            string WIQLQueryBit =         @"AND [Microsoft.VSTS.Common.ClosedDate] = '' AND [System.WorkItemType] NOT IN ('Test Suite', 'Test Plan') AND [System.AreaPath] = 'SourceServer\Area\Path1'";
+            string WIQLQueryBit = @"AND [Microsoft.VSTS.Common.ClosedDate] = '' AND [System.WorkItemType] NOT IN ('Test Suite', 'Test Plan') AND [System.AreaPath] = 'SourceServer\Area\Path1'";
             string expectTargetQueryBit = @"AND [Microsoft.VSTS.Common.ClosedDate] = '' AND [System.WorkItemType] NOT IN ('Test Suite', 'Test Plan') AND [System.AreaPath] = 'TargetServer\Area\Path1'";
 
-            string targetWIQLQueryBit = WorkItemMigrationContext.FixAreaPathAndIterationPathForTargetQuery(WIQLQueryBit, "SourceServer", "TargetServer", null);
+            string targetWIQLQueryBit = WorkItemMigrationContext.FixAreaPathAndIterationPathForTargetQuery(WIQLQueryBit, "SourceServer", "TargetServer", false, null);
 
             Assert.AreEqual(expectTargetQueryBit, targetWIQLQueryBit);
         }
@@ -56,7 +67,7 @@ namespace VstsSyncMigrator.Core.Tests
             string WIQLQueryBit = @"AND [System.IterationPath] = 'SourceServer\Iteration\Path1' AND   [Microsoft.VSTS.Common.ClosedDate] = '' AND [System.WorkItemType] NOT IN ('Test Suite', 'Test Plan')";
             string expectTargetQueryBit = @"AND [System.IterationPath] = 'TargetServer\Iteration\Path1' AND   [Microsoft.VSTS.Common.ClosedDate] = '' AND [System.WorkItemType] NOT IN ('Test Suite', 'Test Plan')";
 
-            string targetWIQLQueryBit = WorkItemMigrationContext.FixAreaPathAndIterationPathForTargetQuery(WIQLQueryBit, "SourceServer", "TargetServer", null);
+            string targetWIQLQueryBit = WorkItemMigrationContext.FixAreaPathAndIterationPathForTargetQuery(WIQLQueryBit, "SourceServer", "TargetServer", false, null);
 
             Assert.AreEqual(expectTargetQueryBit, targetWIQLQueryBit);
         }
@@ -67,7 +78,7 @@ namespace VstsSyncMigrator.Core.Tests
             string WIQLQueryBit = @"AND ([System.AreaPath] = 'SourceServer\Area\Path1' OR [System.AreaPath] = 'SourceServer\Area\Path2') AND ([System.IterationPath] = 'SourceServer\Iteration\Path1' OR [System.IterationPath] = 'SourceServer\Iteration\Path2') AND [Microsoft.VSTS.Common.ClosedDate] = '' AND [System.WorkItemType] NOT IN ('Test Suite', 'Test Plan')";
             string expectTargetQueryBit = @"AND ([System.AreaPath] = 'TargetServer\Area\Path1' OR [System.AreaPath] = 'TargetServer\Area\Path2') AND ([System.IterationPath] = 'TargetServer\Iteration\Path1' OR [System.IterationPath] = 'TargetServer\Iteration\Path2') AND [Microsoft.VSTS.Common.ClosedDate] = '' AND [System.WorkItemType] NOT IN ('Test Suite', 'Test Plan')";
 
-            string targetWIQLQueryBit = WorkItemMigrationContext.FixAreaPathAndIterationPathForTargetQuery(WIQLQueryBit, "SourceServer", "TargetServer", null);
+            string targetWIQLQueryBit = WorkItemMigrationContext.FixAreaPathAndIterationPathForTargetQuery(WIQLQueryBit, "SourceServer", "TargetServer", false, null);
 
             Assert.AreEqual(expectTargetQueryBit, targetWIQLQueryBit);
         }
@@ -78,7 +89,7 @@ namespace VstsSyncMigrator.Core.Tests
             string WIQLQueryBit = @"AND ([System.AreaPath] = 'SourceServer\Area\Path1' OR [System.AreaPath] UNDER 'SourceServer\Area\Path2') AND ([System.IterationPath] UNDER 'SourceServer\Iteration\Path1' OR [System.IterationPath] = 'SourceServer\Iteration\Path2') AND [Microsoft.VSTS.Common.ClosedDate] = '' AND [System.WorkItemType] NOT IN ('Test Suite', 'Test Plan')";
             string expectTargetQueryBit = @"AND ([System.AreaPath] = 'TargetServer\Area\Path1' OR [System.AreaPath] UNDER 'TargetServer\Area\Path2') AND ([System.IterationPath] UNDER 'TargetServer\Iteration\Path1' OR [System.IterationPath] = 'TargetServer\Iteration\Path2') AND [Microsoft.VSTS.Common.ClosedDate] = '' AND [System.WorkItemType] NOT IN ('Test Suite', 'Test Plan')";
 
-            string targetWIQLQueryBit = WorkItemMigrationContext.FixAreaPathAndIterationPathForTargetQuery(WIQLQueryBit, "SourceServer", "TargetServer", null);
+            string targetWIQLQueryBit = WorkItemMigrationContext.FixAreaPathAndIterationPathForTargetQuery(WIQLQueryBit, "SourceServer", "TargetServer", false, null);
 
             Assert.AreEqual(expectTargetQueryBit, targetWIQLQueryBit);
         }

--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemMigrationContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemMigrationContext.cs
@@ -122,7 +122,7 @@ namespace VstsSyncMigrator.Engine
                 {
                     contextLog.Information("[FilterWorkItemsThatAlreadyExistInTarget] is enabled. Searching for work items that have already been migrated to the target...", sourceWorkItems.Count());
 
-                    string targetWIQLQueryBit = FixAreaPathAndIterationPathForTargetQuery(_config.WIQLQueryBit, Engine.Source.WorkItems.Project.Name, Engine.Target.WorkItems.Project.Name, contextLog);
+                    string targetWIQLQueryBit = FixAreaPathAndIterationPathForTargetQuery(_config.WIQLQueryBit, Engine.Source.WorkItems.Project.Name, Engine.Target.WorkItems.Project.Name, _config.PrefixProjectToNodes, contextLog);
                     sourceWorkItems = ((TfsWorkItemMigrationClient)Engine.Target.WorkItems).FilterExistingWorkItems(sourceWorkItems, new TfsWiqlDefinition() { OrderBit = _config.WIQLOrderBit, QueryBit = targetWIQLQueryBit }, (TfsWorkItemMigrationClient)Engine.Source.WorkItems);
                     contextLog.Information("!! After removing all found work items there are {SourceWorkItemCount} remaining to be migrated.", sourceWorkItems.Count());
                 }
@@ -176,7 +176,7 @@ namespace VstsSyncMigrator.Engine
             }
         }
 
-        internal static string FixAreaPathAndIterationPathForTargetQuery(string sourceWIQLQueryBit, string sourceProject, string targetProject, ILogger? contextLog)
+        internal static string FixAreaPathAndIterationPathForTargetQuery(string sourceWIQLQueryBit, string sourceProject, string targetProject, bool isPrefixProjectToNode, ILogger? contextLog)
         {
             string targetWIQLQueryBit = sourceWIQLQueryBit;
 
@@ -187,6 +187,8 @@ namespace VstsSyncMigrator.Engine
             {
                 return targetWIQLQueryBit;
             }
+
+            var prefixProject = isPrefixProjectToNode ? "\\" + sourceProject : string.Empty;
 
             var matches = Regex.Matches(targetWIQLQueryBit, RegexPatterForAreaAndIterationPathsFix);
             foreach (Match match in matches)
@@ -204,7 +206,7 @@ namespace VstsSyncMigrator.Engine
                     var subValue = value.Substring(0, slashIndex);
                     if (subValue == sourceProject)
                     {
-                        var targetValue = targetProject + value.Substring(slashIndex);
+                        var targetValue = targetProject + prefixProject + value.Substring(slashIndex);
                         var targetMatchValue = match.Value.Replace(value, targetValue);
                         targetWIQLQueryBit = targetWIQLQueryBit.Replace(match.Value, targetMatchValue);
                     }


### PR DESCRIPTION
# Description
Fixed the issue with target query when PrefixProjectToNodes is enabled. It was throwing area/iteration path not found on the target server.

## Type of change
- [x] Bug fix

# How Has This Been Tested?
I have tested it on my production migration from Azure DevOps Server to Azure DevOps Services.

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
