### PR TITLE
TeamSettings project name replacement issue

### DIFF
--- a/src/MigrationTools.Clients.AzureDevops.ObjectModel/Processors/TfsTeamSettingsProcessor.cs
+++ b/src/MigrationTools.Clients.AzureDevops.ObjectModel/Processors/TfsTeamSettingsProcessor.cs
@@ -166,11 +166,11 @@ namespace MigrationTools.Processors
                                 }
                                 else
                                 {
-                                    targetConfig.TeamSettings.BacklogIterationPath = sourceConfig.TeamSettings.BacklogIterationPath.Replace(Source.Project, Target.Project);
+                                    targetConfig.TeamSettings.BacklogIterationPath = SwitchProjectName(sourceConfig.TeamSettings.BacklogIterationPath, Source.Project, Target.Project);
                                     Log.LogDebug("targetConfig.TeamSettings.BacklogIterationPath={BacklogIterationPath}", targetConfig.TeamSettings.BacklogIterationPath);
                                     targetConfig.TeamSettings.IterationPaths = sourceConfig.TeamSettings.IterationPaths.Select(ip =>
                                     {
-                                        var result = ip.Replace(Source.Project, Target.Project);
+                                        var result = SwitchProjectName(ip, Source.Project, Target.Project);
                                         iterationMap[ip] = result;
                                         return result;
                                     }).ToArray();
@@ -178,7 +178,7 @@ namespace MigrationTools.Processors
                                     targetConfig.TeamSettings.TeamFieldValues = sourceConfig.TeamSettings.TeamFieldValues;
                                     foreach (var item in targetConfig.TeamSettings.TeamFieldValues)
                                     {
-                                        item.Value = item.Value.Replace(Source.Project, Target.Project);
+                                        item.Value = SwitchProjectName(item.Value, Source.Project, Target.Project);
                                     }
                                     Log.LogDebug("targetConfig.TeamSettings.TeamFieldValues={@TeamFieldValues}", targetConfig.TeamSettings.TeamFieldValues);
                                 }
@@ -240,6 +240,26 @@ namespace MigrationTools.Processors
             //////////////////////////////////////////////////
             stopwatch.Stop();
             Log.LogDebug("DONE in {Elapsed} ", stopwatch.Elapsed.ToString("c"));
+        }
+
+        internal static string SwitchProjectName(string expressionString, string sourceProjectName, string targetProjectName)
+        {
+            if (expressionString == sourceProjectName)
+            {
+                return targetProjectName;
+            }
+
+            var slashIndex = expressionString.IndexOf('\\');
+            if (slashIndex > 0)
+            {
+                var subValue = expressionString.Substring(0, slashIndex);
+                if (subValue == sourceProjectName)
+                {
+                    return targetProjectName + expressionString.Substring(slashIndex);
+                }
+            }
+
+            return string.Empty;
         }
 
         private void MigrateCapacities(WorkHttpClient sourceHttpClient, WorkHttpClient targetHttpClient, TeamFoundationTeam sourceTeam, TeamFoundationTeam targetTeam, Dictionary<string, string> iterationMap)


### PR DESCRIPTION
# Description
Fixed the issue with replacing source project name with target project name when migrating Team Settings. It was replacing every occurrence source project name string and causing issues. So changed it to only replace the first occurrence on the path hierarchy.  

## Type of change
- [x] Bug fix

# How Has This Been Tested?
I have tested it on my production migration from Azure DevOps Server to Azure DevOps Services.

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
