### PR TITLE
Feature: support negative basepaths

### DIFF
--- a/docs/Processors/WorkItemMigrationConfig.md
+++ b/docs/Processors/WorkItemMigrationConfig.md
@@ -89,21 +89,38 @@ The `NodeBasePaths` entry allows the filtering of the nodes to be replicated on 
    - SourceProj
    - SourceProj\Team 1
    - SourceProj\Team 2
+   - SourceProj\Team 2\Sub-Area
    - SourceProj\Team 3
 - IterationPath
    - SourceProj
    - SourceProj\Sprint 1
    - SourceProj\Sprint 2
+   - SourceProj\Sprint 2\Sub-Iteration
    - SourceProj\Sprint 3
 
-Depending upon what node structures you wish to migrate you would need the following settings. Example are
+Depending upon what node structures you wish to migrate you would need the following settings. Exclusions are also possible by prefixing a path with an exclamation mark `!`. Example are
 
-| Migration Option                                                                   | NodeBasePath         | Comment                                                                                                                                                                                                                                                                                                                                             |
-| :--------------------------------------------------------------------------------- | :------------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Migrate all areas and iterations and all WI                                        | []                   | The same AreaPath and Iteration Paths are created on the target as on the source. Hence, all migrated WI remain in their existing area and iteration paths                                                                                                                                                                                          |
-| To only migrate area path `Team 2` and it's associated WI, but all iteration paths | [ "Team 2, "Sprint"] | Only the area path ending `Team 2` will be migrated. <br>The `WIQLQueryBit` should be edited to limit the WI migrated to this area path e.g. add `AND [System.AreaPath] UNDER 'SampleProject\\Team 2'` . <br> The migrated WI will have an area path of `TargetProj\Team 2` but retain their iteration paths matching the sprint name on the source |
-| Only migrate iterations structure                                                  | [ "Sprint"]          | Only the area path ending `Team 2` will be migrated<br>All the iteration paths will be migrated. <br> The migrated WI will have the default area path of `TargetProj` as their source area path was not migrated i.e. `TargetProj`<br> The migrated WI will have an iteration path match the sprint name on the source                              |
-| Move all WI to the existing area and iteration paths on the targetProj             | ["DUMMY VALUE"]      | As the `NodeBasePath` does not match any source area or iteration path no nodes are migrated. <br>Migrated WI will be assigned to any matching area or iteration paths. If no matching ones can be found they will default to the respective root values                                                                                            |
+| | |
+|-|-|
+| Intention    | Migrate all areas and iterations and all Work Items
+| NodeBasePath | `[]`
+| Comment      | The same AreaPath and Iteration Paths are created on the target as on the source. Hence, all migrated WI remain in their existing area and iteration paths
+||
+| Intention    | Only migrate area path `Team 2` and it associated Work Items, but all iteration paths
+| NodeBasePath | `["Team 2", "Sprint"]`
+| Comment      | Only the area path ending `Team 2` will be migrated. <br>The `WIQLQueryBit` should be edited to limit the WI migrated to this area path e.g. add `AND [System.AreaPath] UNDER 'SampleProject\\Team 2'` . <br> The migrated WI will have an area path of `TargetProj\Team 2` but retain their iteration paths matching the sprint name on the source
+||
+| Intention    | Only migrate iterations structure
+| NodeBasePath | `["Sprint"]`
+| Comment      | Only the area path ending `Team 2` will be migrated<br>All the iteration paths will be migrated. <br> The migrated WI will have the default area path of `TargetProj` as their source area path was not migrated i.e. `TargetProj`<br> The migrated WI will have an iteration path match the sprint name on the source
+||
+| Intention    | Move all WI to the existing area and iteration paths on the targetProj
+| NodeBasePath | `["DUMMY VALUE"]`
+| Comment      | As the `NodeBasePath` does not match any source area or iteration path no nodes are migrated. <br>Migrated WI will be assigned to any matching area or iteration paths. If no matching ones can be found they will default to the respective root values
+||
+| Intention    | Move the `Team 2` area, but not its `Sub-Area`
+| NodeBasePath | `["Team 2", "!Team 2\\SubArea"]`
+| Comment      | The Work Items will have to be restricted to the right areas, e.g. with `AND [System.AreaPath] UNDER 'SampleProject\\Team 2' AND [System.AreaPath] NOT UNDER 'SampleProject\\Team 2\\Sub-Area'`, otherwise their migratin will fail
 
 # Iteration Maps and Area Maps
 

--- a/docs/Reference/Generated/MigrationTools.Clients.AzureDevops.ObjectModel.xml
+++ b/docs/Reference/Generated/MigrationTools.Clients.AzureDevops.ObjectModel.xml
@@ -11,7 +11,7 @@
             <summary>
             Checks node-to-be-created with allowed BasePath's
             </summary>
-            <param name="sourceNodePath">The path of the source node</param>
+            <param name="userFriendlyPath">The user-friendly path of the source node</param>
             <returns>true/false</returns>
         </member>
         <member name="T:MigrationTools.Processors.TfsAreaAndIterationProcessor">


### PR DESCRIPTION
This commit introduces negative basepaths, i.e. base paths that are ignored even if they are under a selected basepath.

This means that if /path1 and !/path1/path2 are both in the basepaths, path2 and anything under it are ignored.