### PR TITLE
added a safety fix for when save ends up as a no-operation

### DIFF
--- a/src/MigrationTools.Clients.AzureDevops.ObjectModel/TfsExtensions.cs
+++ b/src/MigrationTools.Clients.AzureDevops.ObjectModel/TfsExtensions.cs
@@ -72,9 +72,12 @@ namespace MigrationTools
                 Log.Debug("--------------------------------------------------------------------------------------------------------------------");
             }
             Log.Verbose("TfsExtensions::SaveToAzureDevOps::Save()");
-            try {
+            try
+            {
                 workItem.Save();
-            } catch (FormatException exc) when (exc.Message.Equals("The string 'Microsoft.TeamFoundation.WorkItemTracking.Common.ServerDefaultFieldValue' is not a valid AllXsd value.", StringComparison.InvariantCultureIgnoreCase)) {
+            }
+            catch (FormatException exc) when (exc.Message.Equals("The string 'Microsoft.TeamFoundation.WorkItemTracking.Common.ServerDefaultFieldValue' is not a valid AllXsd value.", StringComparison.InvariantCultureIgnoreCase))
+            {
                 Log.Warning("Ignoring: " + exc.Message);
             }
             context.RefreshWorkItem();

--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemMigrationContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemMigrationContext.cs
@@ -668,7 +668,9 @@ namespace VstsSyncMigrator.Engine
                 {
                     ProcessWorkItemAttachments(sourceWorkItem, targetWorkItem, false);
                     if (!string.IsNullOrEmpty(targetWorkItem.Id))
-                    { ProcessWorkItemLinks(Engine.Source.WorkItems, Engine.Target.WorkItems, sourceWorkItem, targetWorkItem); }
+                    {
+                        ProcessWorkItemLinks(Engine.Source.WorkItems, Engine.Target.WorkItems, sourceWorkItem, targetWorkItem);
+                    }
 
                     if (_config.GenerateMigrationComment)
                     {


### PR DESCRIPTION
This means that the revision number does not go up, and this ToDictionary call fails.

@MrHinsh Do you think we need a "backwards do not enable" flag in config so that we don't enable this fix by default? Since we are not getting alot of reports of this happening either people does not know or I have running into a freak case. In my case there was alot of revisions popping up in the list that was representing a link change, aka parent removed or similar

The fault does not break the run, you only spots that some revisions are missing, and that there are no reflectedworkitem written to the custom field and no migration comment in the history
