### PR TITLE
Fix issue when target ADO instance has no valid iteration path for a revision

### DIFF
--- a/docs/Reference/Generated/MigrationTools.xml
+++ b/docs/Reference/Generated/MigrationTools.xml
@@ -177,6 +177,11 @@
         <member name="P:MigrationTools._EngineV1.Configuration.Processing.WorkItemMigrationConfig.Processor">
             <inheritdoc />
         </member>
+        <member name="P:MigrationTools._EngineV1.Configuration.Processing.WorkItemMigrationConfig.SkipRevisionWithInvalidIterationPath">
+            <summary>
+            This will skip a revision if the source iteration has not been migrated i.e. it was deleted
+            </summary>
+        </member>
         <member name="M:MigrationTools._EngineV1.Configuration.Processing.WorkItemMigrationConfig.IsProcessorCompatible(System.Collections.Generic.IReadOnlyList{MigrationTools._EngineV1.Configuration.IProcessorConfig})">
             <inheritdoc />
         </member>

--- a/src/MigrationTools/_EngineV1/Configuration/Processing/WorkItemMigrationConfig.cs
+++ b/src/MigrationTools/_EngineV1/Configuration/Processing/WorkItemMigrationConfig.cs
@@ -47,6 +47,11 @@ namespace MigrationTools._EngineV1.Configuration.Processing
 
         public int MaxGracefulFailures { get; set; }
 
+        /// <summary>
+        /// This will skip a revision if the source iteration has not been migrated i.e. it was deleted
+        /// </summary>
+        public bool SkipRevisionWithInvalidIterationPath { get; set; }
+
         /// <inheritdoc />
         public bool IsProcessorCompatible(IReadOnlyList<IProcessorConfig> otherProcessors)
         {
@@ -80,6 +85,7 @@ namespace MigrationTools._EngineV1.Configuration.Processing
             AreaMaps = new Dictionary<string, string>();
             IterationMaps = new Dictionary<string, string>();
             MaxGracefulFailures = 0;
+            SkipRevisionWithInvalidIterationPath = false;
         }
     }
 }

--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemMigrationContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemMigrationContext.cs
@@ -260,7 +260,7 @@ namespace VstsSyncMigrator.Engine
             var matches = Regex.Matches(targetWIQLQueryBit, RegexPatternForAreaAndIterationPathsFix);
 
 
-            if(string.IsNullOrWhiteSpace(sourceProject)
+            if (string.IsNullOrWhiteSpace(sourceProject)
                 || string.IsNullOrWhiteSpace(targetProject)
                 || sourceProject == targetProject)
             {
@@ -318,11 +318,13 @@ namespace VstsSyncMigrator.Engine
             }
             newWorkItemTimer.Stop();
             Telemetry.TrackDependency(new DependencyTelemetry("TfsObjectModel", Engine.Target.Config.AsTeamProjectConfig().Collection.ToString(), "NewWorkItem", null, newWorkItemstartTime, newWorkItemTimer.Elapsed, "200", true));
-            if (_config.UpdateCreatedBy) {
+            if (_config.UpdateCreatedBy)
+            {
                 newwit.Fields["System.CreatedBy"].Value = currentRevisionWorkItem.ToWorkItem().Revisions[0].Fields["System.CreatedBy"].Value;
                 workItemLog.Debug("Setting 'System.CreatedBy'={SystemCreatedBy}", currentRevisionWorkItem.ToWorkItem().Revisions[0].Fields["System.CreatedBy"].Value);
             }
-            if (_config.UpdateCreatedDate) {
+            if (_config.UpdateCreatedDate)
+            {
                 newwit.Fields["System.CreatedDate"].Value = currentRevisionWorkItem.ToWorkItem().Revisions[0].Fields["System.CreatedDate"].Value;
                 workItemLog.Debug("Setting 'System.CreatedDate'={SystemCreatedDate}", currentRevisionWorkItem.ToWorkItem().Revisions[0].Fields["System.CreatedDate"].Value);
             }
@@ -588,7 +590,7 @@ namespace VstsSyncMigrator.Engine
                     var finalDestType = revisionsToMigrate.Last().Type;
                     var targetType = revisionsToMigrate.First().Type;
 
-                    if(targetType != finalDestType)
+                    if (targetType != finalDestType)
                     {
                         TraceWriteLine(LogEventLevel.Information, $"WorkItem has changed type at one of the revisions, from {targetType} to {finalDestType}");
                     }
@@ -597,7 +599,7 @@ namespace VstsSyncMigrator.Engine
                     {
                         finalDestType = Engine.TypeDefinitionMaps.Items[finalDestType].Map();
                     }
-                    
+
                     if (Engine.TypeDefinitionMaps.Items.ContainsKey(targetType))
                     {
                         targetType = Engine.TypeDefinitionMaps.Items[targetType].Map();
@@ -651,7 +653,12 @@ namespace VstsSyncMigrator.Engine
                     ProcessHTMLFieldAttachements(targetWorkItem);
                     ProcessWorkItemEmbeddedLinks(sourceWorkItem, targetWorkItem);
 
-                    targetWorkItem.SaveToAzureDevOps();
+                    var validRevision = RevisionHasValidIterationPath(targetWorkItem);
+
+                    if (validRevision)
+                    {
+                        targetWorkItem.SaveToAzureDevOps();
+                    }
                     TraceWriteLine(LogEventLevel.Information,
                         " Saved TargetWorkItem {TargetWorkItemId}. Replayed revision {RevisionNumber} of {RevisionsToMigrateCount}",
                        new Dictionary<string, object>() {
@@ -704,6 +711,27 @@ namespace VstsSyncMigrator.Engine
             }
 
             return targetWorkItem;
+        }
+
+        private static bool RevisionHasValidIterationPath(WorkItemData targetWorkItem)
+        {
+            var isValid = true;
+            var workItem = (WorkItem)targetWorkItem.internalObject;
+            var fails = workItem.Validate();
+
+            if (fails.Count > 0)
+            {
+                foreach (Field f in fails)
+                {
+                    // We cannot save a revision when it has no IterationPath
+                    if (f.ReferenceName == "System.IterationPath")
+                    {
+                        isValid = false;
+                    }
+                }
+
+            }
+            return isValid;
         }
     }
 }

--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemMigrationContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemMigrationContext.cs
@@ -715,7 +715,6 @@ namespace VstsSyncMigrator.Engine
 
         private static bool RevisionHasValidIterationPath(WorkItemData targetWorkItem)
         {
-            var isValid = true;
             var workItem = (WorkItem)targetWorkItem.internalObject;
             var fails = workItem.Validate();
 
@@ -726,12 +725,13 @@ namespace VstsSyncMigrator.Engine
                     // We cannot save a revision when it has no IterationPath
                     if (f.ReferenceName == "System.IterationPath")
                     {
-                        isValid = false;
+                        return false;
                     }
                 }
 
             }
-            return isValid;
+
+            return true;
         }
     }
 }

--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemMigrationContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemMigrationContext.cs
@@ -715,24 +715,27 @@ namespace VstsSyncMigrator.Engine
             return targetWorkItem;
         }
 
-        internal bool SkipRevisionWithInvalidIterationPath(WorkItemData targetWorkItem)
+        private bool SkipRevisionWithInvalidIterationPath(WorkItemData targetWorkItemData)
         {
-            if (_config.SkipRevisionWithInvalidIterationPath)
+            if (!_config.SkipRevisionWithInvalidIterationPath)
             {
-                var workItem = (WorkItem)targetWorkItem.internalObject;
-                var fails = workItem.Validate();
+                return false;
+            }
 
-                if (fails.Count > 0)
+            var workItem = targetWorkItemData.ToWorkItem();
+            var invalidFields = workItem.Validate();
+
+            if (invalidFields.Count == 0)
+            {
+                return false;
+            }
+
+            foreach (Field invalidField in invalidFields)
+            {
+                // We cannot save a revision when it has no IterationPath
+                if (invalidField.ReferenceName == "System.IterationPath")
                 {
-                    foreach (Field f in fails)
-                    {
-                        // We cannot save a revision when it has no IterationPath
-                        if (f.ReferenceName == "System.IterationPath")
-                        {
-                            return true;
-                        }
-                    }
-
+                    return true;
                 }
             }
 


### PR DESCRIPTION
This Pull Request addresses an issue found whereby a revision in the source Azure DevOps instance has a deleted iteration path, and when the migration occurs, we had an error as the deleted iteration path is understandably not migrated to the target system. Azure DevOps will not allow null Iteration Paths, so this fix skips the revision.