### PR TITLE
Bug when getting testplans and order of testcases

### DIFF
--- a/src/VstsSyncMigrator.Core/Execution/ComponentContext/TestManagementContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/ComponentContext/TestManagementContext.cs
@@ -26,13 +26,15 @@ namespace VstsSyncMigrator.Engine.ComponentContext
             Project = tms.GetTeamProject(source.Config.AsTeamProjectConfig().Project);
         }
 
-        internal ITestPlanCollection GetTestPlans()
+        internal List<ITestPlan> GetTestPlans()
         {
             var query = (string.IsNullOrWhiteSpace(testPlanQueryBit))
                 ? "Select * From TestPlan"
                 : $"Select * From TestPlan Where {testPlanQueryBit}";
 
-            return Project.TestPlans.Query(query);
+            var testPlans = Project.TestPlans.Query(query);
+
+            return testPlans.Select(tp => Project.TestPlans.Find(tp.Id)).ToList();
         }
 
         internal List<ITestRun> GetTestRuns()


### PR DESCRIPTION
Somehow we no longer gets the full testplan object when doing the query, so now added a step to get each testplan id as well get getting all plans.

Also noticed that the order of test cases are not based on the inputlist but based on sorting the test case workitem id, so adding each testcase one by one gives the correct order