### PR TITLE
Improve handling for work item attachments with duplicate names

### DIFF
--- a/src/MigrationTools.Clients.AzureDevops.ObjectModel/Enrichers/TfsAttachmentEnricher.cs
+++ b/src/MigrationTools.Clients.AzureDevops.ObjectModel/Enrichers/TfsAttachmentEnricher.cs
@@ -61,7 +61,7 @@ namespace MigrationTools.Enrichers
                     Log.Debug("AttachmentMigrationEnricher: Exported {Filename} to disk", System.IO.Path.GetFileName(filepath));
                     if (filepath != null)
                     {
-                        ImportAttachemnt(target.ToWorkItem(), filepath, save);
+                        ImportAttachemnt(target.ToWorkItem(), wia, filepath, save);
                         Log.Debug("AttachmentMigrationEnricher: Imported {Filename} from disk", System.IO.Path.GetFileName(filepath));
                     }
                 }
@@ -122,14 +122,14 @@ namespace MigrationTools.Enrichers
             return fpath;
         }
 
-        private void ImportAttachemnt(WorkItem targetWorkItem, string filepath, bool save = true)
+        private void ImportAttachemnt(WorkItem targetWorkItem, Attachment wia, string filepath, bool save = true)
         {
             var filename = System.IO.Path.GetFileName(filepath);
             FileInfo fi = new FileInfo(filepath);
             if (_maxAttachmentSize > fi.Length)
             {
                 var attachments = targetWorkItem.Attachments.Cast<Attachment>();
-                var attachment = attachments.Where(a => a.Name == filename).FirstOrDefault();
+                var attachment = attachments.Where(a => a.Name == wia.Name && a.Length == wia.Length).FirstOrDefault();
                 if (attachment == null)
                 {
                     Attachment a = new Attachment(filepath);


### PR DESCRIPTION
This PR fixes the issue with duplicate attachment names reported in #923 by looking up existing attachments by name **and** size (not a perfect solution as an attachment with the same name and exact size will still fail to migrate, but that is a far more unlikely scenario)