### PR TITLE
configure WorkItemLinkEnricher

### DIFF
--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemMigrationContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemMigrationContext.cs
@@ -104,6 +104,8 @@ namespace VstsSyncMigrator.Engine
             }
 
             _revisionManager.Configure(new TfsRevisionManagerOptions() { Enabled = true, MaxRevisions = _config.MaxRevisions, ReplayRevisions = _config.ReplayRevisions });
+
+            _workItemLinkEnricher.Configure(_config.LinkMigrationSaveEachAsAdded, _config.FilterWorkItemsThatAlreadyExistInTarget);
         }
 
         internal void TraceWriteLine(LogEventLevel level, string message, Dictionary<string, object> properties = null)


### PR DESCRIPTION
The changes in this PR forward the configuration setting from the v1 processor (in the configuration.json file) to the ```WorkItemLinkEnricher```. Currently, I think ```LinkMigrationSaveEachAsAdded``` is not taken into account at all and the default value for ```FilterWorkItemsThatAlreadyExistInTarget``` hinders updates of WI links.

Please get back in case of questions and consider the merge!

(I haven't updated gitversion*.yml for the moment. Please give me the relevant hints.)