### PR TITLE
Make embedded images regex lazy

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ We use these tools with our customers, and for fun, to do real world migrations 
 
 ## Change Log
 
+- 12.1 - Make embedded images regex lazy
 - 12.1 - Added a stop when there are area or iteration nodes in the source history that are not in the target. This causes missing of data. System will now list the areas and iteration that are missing, and then stop. You can decide to add them manually, or add a field mapping.
 - v11.11 - Refactored revision manager to have more tests and support limiting the number of revisions. CollapseRevisions has been replaced by setting MaxRevisions to 1 and setting AttachRevisionHistory to true; MaxRevisions sets the maximum number of revisions that will be migrated. "First + Last*N = Max". If this was set to 5 and there were 10 revisions you would get the first 1 (creation) and the latest 4 migrated. This is done after all of the existing revisions are created but before anything newer that target is removed.
 - v11.10 - Added ability to limit the number of revisions migrated with `MaxRevisions` on `WorkItemMigration` processor. 0 = All, and any other number should migrate the first revision + the latest up to MAX.

--- a/src/MigrationTools.Clients.AzureDevops.ObjectModel/Enrichers/TfsEmbededImagesEnricher.cs
+++ b/src/MigrationTools.Clients.AzureDevops.ObjectModel/Enrichers/TfsEmbededImagesEnricher.cs
@@ -19,7 +19,7 @@ namespace MigrationTools.Enrichers
 {
     public class TfsEmbededImagesEnricher : EmbededImagesRepairEnricherBase
     {
-        private const string RegexPatternForImageUrl = "(?<=<img.*src=\")[^\"]*";
+        private const string RegexPatternForImageUrl = "(?<=<img.*?src=\")[^\"]*";
         private const string RegexPatternForImageFileName = "(?<=FileName=)[^=]*";
         private const string TargetDummyWorkItemTitle = "***** DELETE THIS - Migration Tool Generated Dummy Work Item For TfsEmbededImagesEnricher *****";
 


### PR DESCRIPTION
In my case, when an HTML field contained more than one embedded image, only the last image was replaced correctly. By making the regex lazy instead of greedy, the problem was fixed.

Please test this carefully as I fixed this in another base version where we also used a capturing group for url replacement.