### PR TITLE
Protect CheckIsParentOfSelectedBasePath against null nodeBasePaths

### DIFF
--- a/src/MigrationTools.Clients.AzureDevops.ObjectModel/ProcessorEnrichers/TfsNodeStructure.cs
+++ b/src/MigrationTools.Clients.AzureDevops.ObjectModel/ProcessorEnrichers/TfsNodeStructure.cs
@@ -472,8 +472,8 @@ namespace MigrationTools.Enrichers
         /// <exception cref="NotImplementedException"></exception>
         private bool CheckIsParentOfSelectedBasePath(string userFriendlyPath)
         {
-            return _nodeBasePaths.Where(onePath => !onePath.StartsWith("!"))
-                                 .Any(onePath => onePath.StartsWith(userFriendlyPath));
+            return _nodeBasePaths != null ? _nodeBasePaths.Where(onePath => !onePath.StartsWith("!"))
+                                 .Any(onePath => onePath.StartsWith(userFriendlyPath)) : false;
         }
 
         public List<string> CheckForMissingPaths(List<WorkItemData> workItems, TfsNodeStructureType nodeType)


### PR DESCRIPTION
If users forget to configure nodeBasePaths its not defaulting the value and resulting in unfriendly error messages.

I believe this was the case here in #1268 , #1239 

Just adding a little null check.