### PR TITLE
exitcode=0 when no failures occur

### DIFF
--- a/src/MigrationTools.Host/MigrationToolHost.cs
+++ b/src/MigrationTools.Host/MigrationToolHost.cs
@@ -153,7 +153,6 @@ namespace MigrationTools.Host
                 return;
             }
             await host.RunAsync();
-            startupService.RunExitLogic();
         }
 
         private static string CreateLogsPath()

--- a/src/MigrationTools.Host/StartupService.cs
+++ b/src/MigrationTools.Host/StartupService.cs
@@ -68,10 +68,7 @@ namespace MigrationTools.Host
 
             appLifetime.ApplicationStopped.Register(() =>
             {
-                _logger.LogInformation("Terminating: Application forcebly closed.");
                 RunExitLogic();
-                Environment.Exit(-1);
-                //System.Diagnostics.Process.GetCurrentProcess().Kill();
             });
         }
 
@@ -85,8 +82,6 @@ namespace MigrationTools.Host
                 });
             _telemetryLogger.CloseAndFlush();
             _logger.LogInformation("The application ran in {Application_Elapsed} and finished at {Application_EndTime}", _mainTimer.Elapsed.ToString("c"), DateTime.Now.ToUniversalTime().ToLocalTime());
-            //Log.CloseAndFlush();
-            System.Threading.Thread.Sleep(5000);
         }
 
         private void ApplicationStartup(string[] args)


### PR DESCRIPTION
**Problem:**
The return code of  Migration.exe is always set to -1 even if a migration run is successful. If you want to incorporate the Migration.exe in a script, you should be able to base yourself on the exit code.

**Solution:**
Small fix ithat if the migration process is successful the return code is not modified aka 0. In the case of an error, the exit code should be set to a non zero value.