### PR TITLE
Find and add missing Area & Iteration paths in revisions and add them if necessary

### DIFF
--- a/src/MigrationTools.Clients.AzureDevops.ObjectModel/ProcessorEnrichers/TfsNodeStructure.cs
+++ b/src/MigrationTools.Clients.AzureDevops.ObjectModel/ProcessorEnrichers/TfsNodeStructure.cs
@@ -492,7 +492,13 @@ namespace MigrationTools.Enrichers
                     break;
 
             }
-            List<string> areaPaths = (from workItem in workItems where workItem.Fields[fieldName].Value.ToString().Contains("\\") select workItem.Fields[fieldName].Value.ToString()).Distinct().ToList();
+
+            List<string> areaPaths = workItems.SelectMany(x => x.Revisions.Values)
+                .Where(x => x.Fields[fieldName].Value.ToString().Contains("\\"))
+                .Select(x => x.Fields[fieldName].Value.ToString())
+                .Distinct()
+                .ToList();
+
             List<string> missingPaths = new List<string>();
 
             foreach (var areaPath in areaPaths)
@@ -505,7 +511,11 @@ namespace MigrationTools.Enrichers
                 }
                 catch
                 {
-                    missingPaths.Add(newpath);
+                    if (_Options.ShouldCreateMissingRevisionPaths && ShouldCreateNode(systempath))
+                        GetOrCreateNode(systempath, null, null);
+                    else
+                        missingPaths.Add(newpath);
+
                 }
             }
             return missingPaths;

--- a/src/MigrationTools.Clients.AzureDevops.ObjectModel/ProcessorEnrichers/TfsNodeStructureOptions.cs
+++ b/src/MigrationTools.Clients.AzureDevops.ObjectModel/ProcessorEnrichers/TfsNodeStructureOptions.cs
@@ -11,12 +11,14 @@ namespace MigrationTools.Enrichers
         public string[] NodeBasePaths { get; set; }
         public Dictionary<string, string> AreaMaps { get; set; }
         public Dictionary<string, string> IterationMaps { get; set; }
+        public bool ShouldCreateMissingRevisionPaths { get; set; }
 
         public override void SetDefaults()
         {
             Enabled = true;
             AreaMaps = new Dictionary<string, string>();
             IterationMaps = new Dictionary<string, string>();
+            ShouldCreateMissingRevisionPaths = true;
         }
     }
 


### PR DESCRIPTION
Hi,

We ran into an issue where if an area path or iteration path was removed & used in a revision, we had to map them all manually. I've updated the TfsNodeStructure.CheckForMissingPaths method to scan all revisions instead of only the WorkItemData Area & Iteration paths. I've also added an options to the TfsNodeStructureOptions to enable/disable automatic adding of missing Area/Iteration paths.

I'm happy to discuss the implementation further & adapt where necessary.
