### PR TITLE
Extend Build Definition and Task Group filtering

### DIFF
--- a/docs/Reference/Generated/MigrationTools.Clients.AzureDevops.Rest.xml
+++ b/docs/Reference/Generated/MigrationTools.Clients.AzureDevops.Rest.xml
@@ -175,12 +175,28 @@
             <param name="targetDefinitions"></param>
             <returns>List of filtered Definitions</returns>
         </member>
+        <member name="M:MigrationTools.Processors.AzureDevOpsPipelineProcessor.FilterOutIncompatibleBuildDefinitions(System.Collections.Generic.IEnumerable{MigrationTools.DataContracts.Pipelines.BuildDefinition},System.Collections.Generic.IEnumerable{MigrationTools.DataContracts.Pipelines.TaskDefinition})">
+            <summary>
+            Filter incompatible TaskGroups
+            </summary>
+            <param name="filteredTaskGroups"></param>
+            <param name="availableTasks"></param>
+            <returns>List of filtered Definitions</returns>
+        </member>
         <member name="M:MigrationTools.Processors.AzureDevOpsPipelineProcessor.FilterOutExistingTaskGroups(System.Collections.Generic.IEnumerable{MigrationTools.DataContracts.Pipelines.TaskGroup},System.Collections.Generic.IEnumerable{MigrationTools.DataContracts.Pipelines.TaskGroup})">
             <summary>
             Filter existing TaskGroups
             </summary>
             <param name="sourceDefinitions"></param>
             <param name="targetDefinitions"></param>
+            <returns>List of filtered Definitions</returns>
+        </member>
+        <member name="M:MigrationTools.Processors.AzureDevOpsPipelineProcessor.FilterOutIncompatibleTaskGroups(System.Collections.Generic.IEnumerable{MigrationTools.DataContracts.Pipelines.TaskGroup},System.Collections.Generic.IEnumerable{MigrationTools.DataContracts.Pipelines.TaskDefinition})">
+            <summary>
+            Filter incompatible TaskGroups
+            </summary>
+            <param name="filteredTaskGroups"></param>
+            <param name="availableTasks"></param>
             <returns>List of filtered Definitions</returns>
         </member>
         <member name="M:MigrationTools.Processors.AzureDevOpsPipelineProcessor.SortDefinitionsByVersion(System.Collections.Generic.IEnumerable{MigrationTools.DataContracts.Pipelines.TaskGroup})">

--- a/src/MigrationTools.Clients.AzureDevops.Rest/Endpoints/AzureDevOpsEndpoint.cs
+++ b/src/MigrationTools.Clients.AzureDevops.Rest/Endpoints/AzureDevOpsEndpoint.cs
@@ -185,8 +185,7 @@ namespace MigrationTools.Endpoints
             {
                 var definitions = await httpResponse.Content.ReadAsAsync<RestResultDefinition<DefinitionType>>();
 
-                // Taskgroups only have a LIST option, so the following step is not needed
-                if (!typeof(DefinitionType).ToString().Contains("TaskGroup") && queryForDetails)
+                if (queryForDetails)
                 {
                     var client2 = GetHttpClient<DefinitionType>(routeParameters);
                     foreach (RestApiDefinition definition in definitions.Value)

--- a/src/MigrationTools.Clients.AzureDevops.Rest/Processors/AzureDevOpsPipelineProcessor.cs
+++ b/src/MigrationTools.Clients.AzureDevops.Rest/Processors/AzureDevOpsPipelineProcessor.cs
@@ -157,6 +157,39 @@ namespace MigrationTools.Processors
         }
 
         /// <summary>
+        /// Filter incompatible TaskGroups
+        /// </summary>
+        /// <param name="filteredTaskGroups"></param>
+        /// <param name="availableTasks"></param>
+        /// <returns>List of filtered Definitions</returns>
+        private IEnumerable<BuildDefinition> FilterOutIncompatibleBuildDefinitions(IEnumerable<BuildDefinition> sourceDefinitions, IEnumerable<TaskDefinition> availableTasks)
+        {
+            var objectsToMigrate = sourceDefinitions.Where(g =>
+            {
+                var missingTasksNames = new List<string>();
+                var allTasksAreAvailable = g.Process.Phases.Select(p => p.Steps).SelectMany(s => s).All(t =>
+                {
+                    if (availableTasks.Any(a => a.Id == t.Task.Id))
+                    {
+                        return true;
+                    }
+                    missingTasksNames.Add(t.DisplayName);
+                    return false;
+                });
+
+                if (!allTasksAreAvailable)
+                {
+                    Log.LogWarning(
+                        @"{DefinitionType} ""{DefinitionName}"" cannot be migrated because the Task(s) ""{MissingTaskNames}"" are not available. This usually happens if the extension for the task is not installed.",
+                        typeof(BuildDefinition).Name, g.Name, string.Join(",", missingTasksNames));
+                    return false;
+                }
+                return true;
+            });
+            return objectsToMigrate;
+        }
+
+        /// <summary>
         /// Filter existing TaskGroups
         /// </summary>
         /// <param name="sourceDefinitions"></param>
@@ -167,6 +200,39 @@ namespace MigrationTools.Processors
             var objectsToMigrate = sourceDefinitions.Where(s => !targetDefinitions.Any(t => t.Name == s.Name));
             var rootSourceDefinitions = SortDefinitionsByVersion(objectsToMigrate).First();
             Log.LogInformation("{ObjectsToBeMigrated} of {TotalObjects} source {DefinitionType}(s) are going to be migrated..", objectsToMigrate.GroupBy(o => o.Name).Where(o => o.Count() >= 1).Count(), rootSourceDefinitions.Count(), typeof(TaskGroup).Name);
+            return objectsToMigrate;
+        }
+
+        /// <summary>
+        /// Filter incompatible TaskGroups
+        /// </summary>
+        /// <param name="filteredTaskGroups"></param>
+        /// <param name="availableTasks"></param>
+        /// <returns>List of filtered Definitions</returns>
+        private IEnumerable<TaskGroup> FilterOutIncompatibleTaskGroups(IEnumerable<TaskGroup> filteredTaskGroups, IEnumerable<TaskDefinition> availableTasks)
+        {
+            var objectsToMigrate = filteredTaskGroups.Where(g =>
+            {
+                var missingTasksNames = new List<string>();
+                var allTasksAreAvailable = g.Tasks.All(t =>
+                {
+                    if (availableTasks.Any(a => a.Id == t.Task.Id))
+                    {
+                        return true;
+                    }
+                    missingTasksNames.Add(t.DisplayName);
+                    return false;
+                });
+
+                if (!allTasksAreAvailable)
+                {
+                    Log.LogWarning(
+                        @"{DefinitionType} ""{DefinitionName}"" cannot be migrated because the Task(s) ""{MissingTaskNames}"" are not available. This usually happens if the extension for the task is not installed.",
+                        typeof(TaskGroup).Name, g.Name ,string.Join(",", missingTasksNames));
+                    return false;
+                }
+                return true;
+            });
             return objectsToMigrate;
         }
 
@@ -195,7 +261,7 @@ namespace MigrationTools.Processors
         /// <param name="definitionNames">The list of definitions to query for. If the value is <c>null</c> or an empty list, all definitions will be queried.</param>
         /// <returns></returns>
         private async Task<IEnumerable<DefinitionType>> GetSelectedDefinitionsFromEndpointAsync<DefinitionType>(AzureDevOpsEndpoint endpoint, List<string> definitionNames)
-            where DefinitionType: RestApiDefinition, new()
+            where DefinitionType : RestApiDefinition, new()
         {
             IEnumerable<Task<IEnumerable<DefinitionType>>> GetDefinitionListTasks(AzureDevOpsEndpoint endpoint, List<string> definitionNames) =>
                 definitionNames switch
@@ -225,13 +291,15 @@ namespace MigrationTools.Processors
 
             var sourceDefinitions = await GetSelectedDefinitionsFromEndpointAsync<BuildDefinition>(Source, _Options.BuildPipelines);
             var targetDefinitions = await GetSelectedDefinitionsFromEndpointAsync<BuildDefinition>(Target, _Options.BuildPipelines);
+            var availableTasks = await Target.GetApiDefinitionsAsync<TaskDefinition>(queryForDetails: false);
             var sourceServiceConnections = await Source.GetApiDefinitionsAsync<ServiceConnection>();
             var targetServiceConnections = await Target.GetApiDefinitionsAsync<ServiceConnection>();
             var sourceRepositories = await Source.GetApiDefinitionsAsync<GitRepository>(queryForDetails: false);
             var targetRepositories = await Target.GetApiDefinitionsAsync<GitRepository>(queryForDetails: false);
             var definitionsToBeMigrated = FilterOutExistingDefinitions(sourceDefinitions, targetDefinitions);
-
+            definitionsToBeMigrated = FilterOutIncompatibleBuildDefinitions(definitionsToBeMigrated, availableTasks).ToList();
             definitionsToBeMigrated = FilterAwayIfAnyMapsAreMissing(definitionsToBeMigrated, TaskGroupMapping, VariableGroupMapping);
+
             // Replace taskgroup and variablegroup sIds with tIds
             foreach (var definitionToBeMigrated in definitionsToBeMigrated)
             {
@@ -240,7 +308,7 @@ namespace MigrationTools.Processors
                     .FirstOrDefault(c => c.Id == sourceConnectedServiceId)?.Name == s.Name)?.Id;
                 definitionToBeMigrated.Repository.Properties.ConnectedServiceId = targetConnectedServiceId;
 
-                
+
                 MapRepositoriesInBuidDefinition(sourceRepositories, targetRepositories, definitionToBeMigrated);
 
                 if (TaskGroupMapping is not null)
@@ -532,9 +600,12 @@ namespace MigrationTools.Processors
         {
             Log.LogInformation($"Processing Taskgroups..");
 
-            var sourceDefinitions = await Source.GetApiDefinitionsAsync<TaskGroup>();
-            var targetDefinitions = await Target.GetApiDefinitionsAsync<TaskGroup>();
+            var sourceDefinitions = await Source.GetApiDefinitionsAsync<TaskGroup>(queryForDetails: false);
+            var targetDefinitions = await Target.GetApiDefinitionsAsync<TaskGroup>(queryForDetails: false);
+            var availableTasks = await Target.GetApiDefinitionsAsync<TaskDefinition>(queryForDetails: false);
             var filteredTaskGroups = FilterOutExistingTaskGroups(sourceDefinitions, targetDefinitions);
+            filteredTaskGroups = FilterOutIncompatibleTaskGroups(filteredTaskGroups, availableTasks).ToList();
+
             var rootSourceDefinitions = SortDefinitionsByVersion(filteredTaskGroups).First();
             var updatedSourceDefinitions = SortDefinitionsByVersion(filteredTaskGroups).Last();
 
@@ -572,8 +643,6 @@ namespace MigrationTools.Processors
             var mappings = await Target.CreateApiDefinitionsAsync(filteredDefinition);
             mappings.AddRange(FindExistingMappings(sourceDefinitions, targetDefinitions, mappings));
             return mappings;
-
-            
         }
     }
 }

--- a/src/MigrationTools/DataContracts/Pipelines/Tasks.cs
+++ b/src/MigrationTools/DataContracts/Pipelines/Tasks.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace MigrationTools.DataContracts.Pipelines
+{
+    [ApiPath("distributedtask/tasks", false)]
+    [ApiName("Tasks")]
+    public class TaskDefinition : RestApiDefinition
+    {
+        public override bool HasTaskGroups() => false;
+
+        public override bool HasVariableGroups() => false;
+
+        public override void ResetObject() {}
+    }
+}


### PR DESCRIPTION
This PR adds an additional filtering for Build Definitions and Task Groups. before trying to migrate them, a validation runs to ensure that all referenced tasks are actually available inside the target project.
If that is not the case, a warning will be generated and the pipeline processor will not further try to migrate the invalid definition(s).

This fixes part of #1460 

Example of how the output would look like:
<img width="1627" alt="image" src="https://user-images.githubusercontent.com/40773830/226188309-dfc31cb9-8842-45df-a854-560afbe32044.png">
