### PR TITLE
Update AzureDevOpsPipelineProcessor.cs

### DIFF
--- a/src/MigrationTools.Clients.AzureDevops.Rest/Processors/AzureDevOpsPipelineProcessor.cs
+++ b/src/MigrationTools.Clients.AzureDevops.Rest/Processors/AzureDevOpsPipelineProcessor.cs
@@ -362,7 +362,7 @@ namespace MigrationTools.Processors
         private void MapRepositoriesInBuidDefinition(IEnumerable<GitRepository> sourceRepositories, IEnumerable<GitRepository> targetRepositories, BuildDefinition definitionToBeMigrated)
         {
             var sourceRepoId = definitionToBeMigrated.Repository.Id;
-            string sourceRepositoryName = sourceRepositories.FirstOrDefault(s => s.Id == sourceRepoId)?.Name;
+            string sourceRepositoryName = sourceRepositories.FirstOrDefault(s => s.Id == sourceRepoId)?.Name ?? string.Empty;
             string targetRepoId;
 
             if (_Options.RepositoryNameMaps.ContainsKey(sourceRepositoryName))  //Map repository name if configured


### PR DESCRIPTION
While executing a pipeline configuration on my ADO project, the application threw an error with the message System.ArgumentNullException: Value cannot be null. Parameter name: key . At first, I wasn't sure what was the problem, but I did some troubleshooting and found that two of my pipelines were referring to repositories that no longer existed. Then I checked the line of the code, and the source repository name is defaulting to null instead of a string. My proposed solution is to add a null coalesce to an empty string, I tested out and it ran showing me the two repositories that had the issue and could not be migrated.