### PR TITLE
Fix Reference Guide path in getting started file

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -74,5 +74,5 @@ The default [WorkItemMigrationConfig](/docs/Reference/v1/Processors/WorkItemMigr
 
 **Remember:** if you want a processor to run, it's `Enabled` attribute must be set to `true`. 
 
-Refer to the [Reference Guide](/docs/reference/index.md) for more details.
+Refer to the [Reference Guide](/docs/Reference/index.md) for more details.
 


### PR DESCRIPTION
Fix an issue with the reference guide path in the getting started file. 
The reference guide path was incorrect and was leading to a 404 error page. 

![image](https://github.com/nkdAgility/azure-devops-migration-tools/assets/67760628/5ebc1b24-2fd6-4eac-9494-a30d8af1f56a)

This pull request updates the reference guide path to the correct URL.