### PR TITLE
fixed empty Stack issue

### DIFF
--- a/src/MigrationTools.Clients.AzureDevops.ObjectModel/ProcessorEnrichers/TfsNodeStructure.cs
+++ b/src/MigrationTools.Clients.AzureDevops.ObjectModel/ProcessorEnrichers/TfsNodeStructure.cs
@@ -220,7 +220,7 @@ namespace MigrationTools.Enrichers
                             startDate, finishDate);
                     }
                 }
-            } while (parentNode.Path != nodePath);
+            } while (string.Equals(parentNode.Path, nodePath, StringComparison.InvariantCultureIgnoreCase));
 
             return parentNode;
         }


### PR DESCRIPTION
wrongly typed the iteration path in config:
"Something\\Sprint_history" - should be like that
"Something\\sprint_history" - was like that

that caused that while loop to reenter even tho pathSegments at line 184 were already empty.