### PR TITLE
Correct Markdown tables display issues

### DIFF
--- a/docs/Reference/v2/Endpoints/TfsWorkItemEndpoint-notes.md
+++ b/docs/Reference/v2/Endpoints/TfsWorkItemEndpoint-notes.md
@@ -1,7 +1,7 @@
 The Work Item endpoint is super awesome.
 
-Client  | WriteTo/ReadFrom | Endpoint | Data Target | Description
-----------|-----------|------------
+|Client  | WriteTo/ReadFrom | Endpoint | Data Target | Description |
+|:-:|:-:|:-:|:-:|:-:|
 AzureDevops.ObjectModel | Tfs Object Model | `TfsWorkItemEndPoint` | WorkItems | TBA
 AzureDevops.Rest | Azure DevOps REST | ?
 FileSystem | Local Files | `FileSystemWorkItemEndpoint` | WorkItems | TBA

--- a/docs/Reference/v2/Endpoints/index.md
+++ b/docs/Reference/v2/Endpoints/index.md
@@ -13,8 +13,8 @@ discussionId:
 
 Azure DevOps Migration Tools provides _endpoints_ for reading and writing `WorkItems`, `PlansAndSuits`, `Teams`, or `Queries`. 
 
-Client  | WriteTo/ReadFrom | Endpoint | Data Target | Description
-----------|-----------|------------
+| Client   | WriteTo/ReadFrom | Endpoint | Data Target | Description |
+|:-:|:-:|:-:|:-:|:-:|
 AzureDevops.ObjectModel | Tfs Object Model | `TfsWorkItemEndPoint` | WorkItems | TBA
 AzureDevops.Rest | Azure DevOps REST | ?
 FileSystem | Local Files | `FileSystemWorkItemEndpoint` | WorkItems | TBA


### PR DESCRIPTION
 Correct Markdown tables display issues as they were not properly formatted, which made it difficult to read and understand.
 
 These 2 files:
-  [TfsWorkItemEndpoint-notes](https://github.com/RehabAbotalep/azure-devops-migration-tools/blob/fix-broken-links/docs/Reference/v2/Endpoints/TfsWorkItemEndpoint-notes.md)
- [index](https://github.com/RehabAbotalep/azure-devops-migration-tools/blob/fix-broken-links/docs/Reference/v2/Endpoints/index.md)