### PR TITLE
Extra logging new node name

### DIFF
--- a/src/MigrationTools.Clients.AzureDevops.ObjectModel/ProcessorEnrichers/TfsNodeStructure.cs
+++ b/src/MigrationTools.Clients.AzureDevops.ObjectModel/ProcessorEnrichers/TfsNodeStructure.cs
@@ -95,11 +95,16 @@ namespace MigrationTools.Enrichers
             var mappers = GetMaps(nodeStructureType);
             var lastResortRule = GetLastResortRemappingRule();
 
+            Log.LogDebug("NodeStructureEnricher.GetNewNodeName::Mappers", mappers);
             foreach (var mapper in mappers)
             {
+                Log.LogDebug("NodeStructureEnricher.GetNewNodeName::Mappers::{key}", mapper.Key);
                 if (Regex.IsMatch(sourceNodePath, mapper.Key, RegexOptions.IgnoreCase))
                 {
-                    return Regex.Replace(sourceNodePath, mapper.Key, mapper.Value);
+                    Log.LogDebug("NodeStructureEnricher.GetNewNodeName::Mappers::{key}::match detected", mapper.Key);
+                    string replacement = Regex.Replace(sourceNodePath, mapper.Key, mapper.Value);
+                    Log.LogDebug("NodeStructureEnricher.GetNewNodeName::Mappers::{key}::replaceWith({replace})", mapper.Key, replacement);
+                    return replacement;
                 }
             }
 

--- a/src/MigrationTools.Clients.AzureDevops.ObjectModel/ProcessorEnrichers/TfsNodeStructure.cs
+++ b/src/MigrationTools.Clients.AzureDevops.ObjectModel/ProcessorEnrichers/TfsNodeStructure.cs
@@ -98,12 +98,12 @@ namespace MigrationTools.Enrichers
             Log.LogDebug("NodeStructureEnricher.GetNewNodeName::Mappers", mappers);
             foreach (var mapper in mappers)
             {
-                Log.LogDebug("NodeStructureEnricher.GetNewNodeName::Mappers::{key}", mapper.Key);
+                Log.LogDebug("NodeStructureEnricher.GetNewNodeName::MapperToRun::{key}", mapper.Key);
                 if (Regex.IsMatch(sourceNodePath, mapper.Key, RegexOptions.IgnoreCase))
                 {
-                    Log.LogDebug("NodeStructureEnricher.GetNewNodeName::Mappers::{key}::match detected", mapper.Key);
+                    Log.LogDebug("NodeStructureEnricher.GetNewNodeName::MapperMatched::{key}", mapper.Key);
                     string replacement = Regex.Replace(sourceNodePath, mapper.Key, mapper.Value);
-                    Log.LogDebug("NodeStructureEnricher.GetNewNodeName::Mappers::{key}::replaceWith({replace})", mapper.Key, replacement);
+                    Log.LogDebug("NodeStructureEnricher.GetNewNodeName::MapperMatched::{key}::replaceWith({replace})", mapper.Key, replacement);
                     return replacement;
                 }
             }


### PR DESCRIPTION
New Debug loggin for @ejmarmonti

```
Log.LogDebug("NodeStructureEnricher.GetNewNodeName::Mappers", mappers);
foreach (var mapper in mappers)
{
    Log.LogDebug("NodeStructureEnricher.GetNewNodeName::MapperToRun::{key}", mapper.Key);
    if (Regex.IsMatch(sourceNodePath, mapper.Key, RegexOptions.IgnoreCase))
    {
        Log.LogDebug("NodeStructureEnricher.GetNewNodeName::MapperMatched::{key}", mapper.Key);
        string replacement = Regex.Replace(sourceNodePath, mapper.Key, mapper.Value);
        Log.LogDebug("NodeStructureEnricher.GetNewNodeName::MapperMatched::{key}::replaceWith({replace})", mapper.Key, replacement);
        return replacement;
    }
}
```

Added `MapperToRun`, `MapperMatched`, and `replaceWith` to help with debugging #1589