### PR TITLE
This now checks and validated the Nodes in an easier to see format.

### DIFF
--- a/configuration.json
+++ b/configuration.json
@@ -100,7 +100,9 @@
       "ShouldCreateMissingRevisionPaths": true,
       "NodeBasePaths": [],
       "AreaMaps": {},
-      "IterationMaps": {},
+      "IterationMaps": {
+        "^Skypoint Cloud\\\\Sprint 1": "migration Target 1\\NewArea"
+      },
       "MaxGracefulFailures": 0
     }
 

--- a/configuration.json
+++ b/configuration.json
@@ -53,7 +53,7 @@
   "Processors": [
     {
       "$type": "ExportUsersForMappingConfig",
-      "Enabled": true,
+      "Enabled": false,
       "LocalExportJsonFile": "c:\\temp\\ExportUsersForMappingConfig.json",
       "WIQLQuery": "SELECT [System.Id], [System.Tags] FROM WorkItems WHERE [System.TeamProject] = @TeamProject AND [System.WorkItemType] NOT IN ('Test Suite', 'Test Plan') ORDER BY [System.ChangedDate] desc",
       "IdentityFieldsToCheck": [
@@ -73,7 +73,7 @@
     //},
     {
       "$type": "WorkItemMigrationConfig",
-      "Enabled": false,
+      "Enabled": true,
       "ReplayRevisions": true,
       "PrefixProjectToNodes": false,
       "UpdateCreatedDate": true,

--- a/configuration.json
+++ b/configuration.json
@@ -47,7 +47,7 @@
       "NodeBasePaths": [],
       "AreaMaps": {},
       "IterationMaps": {},
-      "ShouldCreateMissingRevisionPaths": false
+      "ShouldCreateMissingRevisionPaths": true
     }
   ],
   "Processors": [
@@ -95,8 +95,9 @@
       "WorkItemIDs": null,
       "MaxRevisions": 0,
       "NodeStructureEnricherEnabled": true,
-      "UseCommonNodeStructureEnricherConfig": true,
+      "UseCommonNodeStructureEnricherConfig": false,
       "StopMigrationOnMissingAreaIterationNodes": false,
+      "ShouldCreateMissingRevisionPaths": true,
       "NodeBasePaths": [],
       "AreaMaps": {},
       "IterationMaps": {},

--- a/docs/Reference/Generated/MigrationTools.xml
+++ b/docs/Reference/Generated/MigrationTools.xml
@@ -507,7 +507,7 @@
         </member>
         <member name="P:MigrationTools._EngineV1.Configuration.Processing.WorkItemMigrationConfig.StopMigrationOnMissingAreaIterationNodes">
             <summary>
-            
+            With this enabled the system will stop after the check for missing nodes if detected.
             </summary>
             <default>?</default>
         </member>
@@ -546,6 +546,11 @@
         <member name="P:MigrationTools._EngineV1.Configuration.Processing.WorkItemMigrationConfig.SkipRevisionWithInvalidAreaPath">
             <summary>
             When set to true, this setting will skip a revision if the source area has not been migrated, has been deleted or is somehow invalid, etc.
+            </summary>
+        </member>
+        <member name="P:MigrationTools._EngineV1.Configuration.Processing.WorkItemMigrationConfig.ShouldCreateMissingRevisionPaths">
+            <summary>
+            When set to True the susyem will try to create any missing missing area or iteration paths from the revisions.
             </summary>
         </member>
         <member name="M:MigrationTools._EngineV1.Configuration.Processing.WorkItemMigrationConfig.IsProcessorCompatible(System.Collections.Generic.IReadOnlyList{MigrationTools._EngineV1.Configuration.IProcessorConfig})">

--- a/src/MigrationTools.Clients.AzureDevops.ObjectModel.Tests/Endpoints/TfsWorkItemEndPointTests.cs
+++ b/src/MigrationTools.Clients.AzureDevops.ObjectModel.Tests/Endpoints/TfsWorkItemEndPointTests.cs
@@ -42,7 +42,7 @@ namespace MigrationTools.Endpoints.Tests
             var endpoint = Services.GetRequiredService<TfsWorkItemEndpoint>();
             endpoint.Configure(GetTfsWorkItemEndPointOptions("migrationSource1"));
             IEnumerable<WorkItemData> result = endpoint.GetWorkItems();
-            Assert.AreEqual(9, result.Count());
+            Assert.AreEqual(10, result.Count());
         }
 
         [TestMethod(), TestCategory("L3"), TestCategory("AzureDevOps.ObjectModel")]
@@ -56,7 +56,7 @@ namespace MigrationTools.Endpoints.Tests
                 Parameters = new Dictionary<string, string>() { { "TeamProject", "migrationSource1" } }
             };
             IEnumerable<WorkItemData> result = endpoint.GetWorkItems(qo);
-            Assert.AreEqual(9, result.Count());
+            Assert.AreEqual(10, result.Count());
         }
 
         private static TfsWorkItemEndpointOptions GetTfsWorkItemEndPointOptions(string project)

--- a/src/MigrationTools.Clients.AzureDevops.ObjectModel/Endpoints/TfsWorkItemConvertor.cs
+++ b/src/MigrationTools.Clients.AzureDevops.ObjectModel/Endpoints/TfsWorkItemConvertor.cs
@@ -43,6 +43,7 @@ namespace MigrationTools.Endpoints
         {
             var items = tfsRevisions.OfType<Revision>().Select(x => new RevisionItem()
             {
+                WorkItemId = x.WorkItem.Id,
                 Index = x.Index,
                 Number = (int)x.Fields["System.Rev"].Value,
                 ChangedDate = (DateTime)x.Fields["System.ChangedDate"].Value,

--- a/src/MigrationTools.Clients.AzureDevops.ObjectModel/ProcessorEnrichers/TfsNodeStructure.cs
+++ b/src/MigrationTools.Clients.AzureDevops.ObjectModel/ProcessorEnrichers/TfsNodeStructure.cs
@@ -531,7 +531,7 @@ namespace MigrationTools.Enrichers
                     contextLog.Debug($"TfsNodeStructure:CheckForMissingPaths:newpath::{newpath}");
                 }
                 catch(NodePathNotAnchoredException ex) {
-                    contextLog.Debug($"TfsNodeStructure:CheckForMissingPaths:NodePathNotAnchoredException::{areaPath}");
+                    contextLog.Debug($"TfsNodeStructure:CheckForMissingPaths:NodePathNotAnchoredException::SourcePath::{areaPath}");
                     keepProcessing = false;
                     missingPaths.Add(newpath);
                 }
@@ -559,6 +559,10 @@ namespace MigrationTools.Enrichers
                         }
                     }
                 }
+            }
+            if(_Options.ShouldCreateMissingRevisionPaths )
+            {
+                _targetCommonStructureService.ClearProjectInfoCache();
             }
             return missingPaths;
         }

--- a/src/MigrationTools/DataContracts/NodeStructureMissingItem.cs
+++ b/src/MigrationTools/DataContracts/NodeStructureMissingItem.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace MigrationTools.DataContracts
+{
+    public class NodeStructureMissingItem
+    {
+        public bool anchored { get; set; } = true;
+
+        public string sourcePath { get; set; }
+        public string targetPath { get; set; }
+        public string systemPath { get; set; }
+        public string nodeType { get; set; }
+        public List<int> workItems { get; set; }
+
+        public override bool Equals(object obj)
+        {
+            var item = obj as NodeStructureMissingItem;
+
+            if (item == null)
+            {
+                return false;
+            }
+
+            return this.sourcePath.Equals(item.sourcePath);
+        }
+
+        public override int GetHashCode()
+        {
+            return this.sourcePath.GetHashCode();
+        }
+    }
+}

--- a/src/MigrationTools/DataContracts/RevisionItem.cs
+++ b/src/MigrationTools/DataContracts/RevisionItem.cs
@@ -5,6 +5,7 @@ namespace MigrationTools.DataContracts
 {
     public class RevisionItem
     {
+        public int WorkItemId { get; set; }
         public int Index { get; set; }
         public int Number { get; set; }
         public DateTime ChangedDate { get; set; }

--- a/src/MigrationTools/Tests/TestingConstants.cs
+++ b/src/MigrationTools/Tests/TestingConstants.cs
@@ -3,6 +3,6 @@
     public static class TestingConstants
     {
         public static string AccessToken { get { return AccessTokenRaw.Replace(@"fake", ""); } }
-        public static readonly string AccessTokenRaw = "mm77swjfgeny6u55efakeat4bebt3ff7hbcjktkakkqfprb4rnri3c6a";
+        public static readonly string AccessTokenRaw = "44exes7dbqq6vrpu4vfyaqmmjy6fake7xnqvulzgvzp2xmscuygc76fa";
     }
 }

--- a/src/MigrationTools/_EngineV1/Configuration/Processing/WorkItemMigrationConfig.cs
+++ b/src/MigrationTools/_EngineV1/Configuration/Processing/WorkItemMigrationConfig.cs
@@ -157,7 +157,7 @@ namespace MigrationTools._EngineV1.Configuration.Processing
         public bool UseCommonNodeStructureEnricherConfig { get; set; }
 
         /// <summary>
-        /// 
+        /// With this enabled the system will stop after the check for missing nodes if detected.
         /// </summary>
         /// <default>?</default>
         public bool StopMigrationOnMissingAreaIterationNodes { get; set; }
@@ -199,6 +199,11 @@ namespace MigrationTools._EngineV1.Configuration.Processing
         /// </summary>
         public bool SkipRevisionWithInvalidAreaPath { get; set; }
 
+        /// <summary>
+        /// When set to True the susyem will try to create any missing missing area or iteration paths from the revisions.
+        /// </summary>
+       public bool ShouldCreateMissingRevisionPaths { get; set; }
+
         /// <inheritdoc />
         public bool IsProcessorCompatible(IReadOnlyList<IProcessorConfig> otherProcessors)
         {
@@ -236,6 +241,7 @@ namespace MigrationTools._EngineV1.Configuration.Processing
             MaxGracefulFailures = 0;
             SkipRevisionWithInvalidIterationPath = false;
             SkipRevisionWithInvalidAreaPath = false;
+            ShouldCreateMissingRevisionPaths = true;
         }
     }
 }

--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemMigrationContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemMigrationContext.cs
@@ -112,6 +112,7 @@ namespace VstsSyncMigrator.Engine
                     PrefixProjectToNodes = _config.PrefixProjectToNodes,
                     AreaMaps = _config.AreaMaps ?? new Dictionary<string, string>(),
                     IterationMaps = _config.IterationMaps ?? new Dictionary<string, string>(),
+                    ShouldCreateMissingRevisionPaths = _config.ShouldCreateMissingRevisionPaths,
                 });
             }
 
@@ -168,14 +169,16 @@ namespace VstsSyncMigrator.Engine
 
                 //////////////////////////////////////////////////
                 contextLog.Information("ValidateTargetNodesExist::Checking all Nodes on Work items");
-                if (!_nodeStructureEnricher.ValidateTargetNodesExist(sourceWorkItems))
+                List<NodeStructureMissingItem> nodeStructureMissingItems = _nodeStructureEnricher.GetMissingRevisionNodes(sourceWorkItems);
+                if (!_nodeStructureEnricher.ValidateTargetNodesExist(nodeStructureMissingItems))
                 {
                     contextLog.Debug("ValidateTargetNodesExist::StopMigrationOnMissingAreaIterationNodes:{StopMigrationOnMissingAreaIterationNodes}", _config.StopMigrationOnMissingAreaIterationNodes);
                     if (_config.StopMigrationOnMissingAreaIterationNodes)
                     {
-                        throw new Exception("Missing Iterations in Target preventing progress, check log for list. If you resolve with a FieldMap set StopMigrationOnMissingAreaIterationNodes = false in the config to continue.");
+                        throw new Exception("Missing Iterations in Target preventing progress, check log for list. If you resolve with a mapping set StopMigrationOnMissingAreaIterationNodes = false in the config to continue.");
                     }
                 }
+
                 //////////////////////////////////////////////////
                 contextLog.Information("Found target project as {@destProject}", Engine.Target.WorkItems.Project.Name);
                 //////////////////////////////////////////////////////////FilterCompletedByQuery


### PR DESCRIPTION
When the nodes are checked, there are better outputs, and validation of the mappings.

If you have a mapping, it will not be listed as an invalid node.

I have also validated that this works with work items that have been moved between projects using the config below. 

```
  {
    "$type": "WorkItemMigrationConfig",
    "Enabled": true,
    "ReplayRevisions": true,
    "PrefixProjectToNodes": false,
    "UpdateCreatedDate": true,
    "UpdateCreatedBy": true,
    "WIQLQueryBit": "AND [System.WorkItemType] NOT IN ('Test Suite', 'Test Plan')",
    "WIQLOrderBit": "[System.ChangedDate] desc",
    "LinkMigration": true,
    "AttachmentMigration": true,
    "AttachmentWorkingPath": "c:\\temp\\WorkItemAttachmentWorkingFolder\\",
    "FixHtmlAttachmentLinks": false,
    "SkipToFinalRevisedWorkItemType": false,
    "WorkItemCreateRetryLimit": 5,
    "FilterWorkItemsThatAlreadyExistInTarget": false,
    "PauseAfterEachWorkItem": false,
    "AttachmentMaxSize": 480000000,
    "AttachRevisionHistory": false,
    "LinkMigrationSaveEachAsAdded": false,
    "GenerateMigrationComment": true,
    "WorkItemIDs": null,
    "MaxRevisions": 0,
    "NodeStructureEnricherEnabled": true,
    "UseCommonNodeStructureEnricherConfig": false,
    "StopMigrationOnMissingAreaIterationNodes": false,
    "ShouldCreateMissingRevisionPaths": true,
    "NodeBasePaths": [],
    "AreaMaps": {},
    "IterationMaps": {
      "^Skypoint Cloud\\\\Sprint 1": "migration Target 1\\NewArea"
    },
    "MaxGracefulFailures": 0
  }
```

Supports #1643, #1629, #1589, #1548, #1667