### PR TITLE
Added check for Winget version numbers

### DIFF
--- a/src/MigrationTools.Host/MigrationTools.Host.csproj
+++ b/src/MigrationTools.Host/MigrationTools.Host.csproj
@@ -24,6 +24,7 @@
     <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="4.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
+    <PackageReference Include="WGet.NET" Version="3.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MigrationTools.Host/Services/DetectVersionService.cs
+++ b/src/MigrationTools.Host/Services/DetectVersionService.cs
@@ -18,9 +18,13 @@ namespace MigrationTools.Host.Services
     {
         private readonly ITelemetryLogger _Telemetry;
 
+        public string PackageId { get; set; }
+
+
         public DetectVersionService(ITelemetryLogger telemetry)
         {
             _Telemetry = telemetry;
+            PackageId = "nkdAgility.AzureDevOpsMigrationTools";
         }
 
         public Version GetLatestVersion()
@@ -29,30 +33,28 @@ namespace MigrationTools.Host.Services
             Stopwatch mainTimer = Stopwatch.StartNew();
             //////////////////////////////////
             Version latestPackageVersion = null;
-            string packageID = "nkdAgility.AzureDevOpsMigrationTools";
             bool sucess = false;
             try
             {
                 WinGetPackageManager packageManager = new WinGetPackageManager();
-                var package = packageManager.SearchPackage(packageID).SingleOrDefault();
+                var package = packageManager.SearchPackage(PackageId).SingleOrDefault();
 
                 latestPackageVersion = new Version(package.AvailableVersion);
                 if (latestPackageVersion != null)
                 {
                     sucess = true;
                 }
-                _Telemetry.TrackDependency(new DependencyTelemetry("PackageRepository", "winget", packageID, latestPackageVersion == null ? "nullVersion" : latestPackageVersion.ToString(), startTime, mainTimer.Elapsed, "200", sucess));
+                _Telemetry.TrackDependency(new DependencyTelemetry("PackageRepository", "winget", PackageId, latestPackageVersion == null ? "nullVersion" : latestPackageVersion.ToString(), startTime, mainTimer.Elapsed, "200", sucess));
             }
             catch (Exception ex)
             {
                 Log.Error(ex, "DetectVersionService");
                 sucess = false;
-                _Telemetry.TrackDependency(new DependencyTelemetry("PackageRepository", "winget", packageID, latestPackageVersion == null ? "nullVersion" : latestPackageVersion.ToString(), startTime, mainTimer.Elapsed, "500", sucess));
+                _Telemetry.TrackDependency(new DependencyTelemetry("PackageRepository", "winget", PackageId, latestPackageVersion == null ? "nullVersion" : latestPackageVersion.ToString(), startTime, mainTimer.Elapsed, "500", sucess));
             }
             /////////////////
             mainTimer.Stop();
             return latestPackageVersion;
         }
-
     }
 }

--- a/src/MigrationTools.Host/StartupService.cs
+++ b/src/MigrationTools.Host/StartupService.cs
@@ -44,17 +44,21 @@ namespace MigrationTools.Host
 
                 _logger.LogInformation($"Latest version detected as {{{nameof(latestVersion)}}}", latestVersion);
                 var version = Assembly.GetEntryAssembly().GetName().Version;
-                if (latestVersion > version && args.Contains("skipVersionCheck"))
+                if (latestVersion > version)
                 {
                     _logger.LogWarning("You are currently running version {Version} and a newer version ({LatestVersion}) is available. You should update now using Winget command 'winget nkdAgility.AzureDevOpsMigrationTools' from the Windows Terminal.", version, latestVersion);
+                    if (!args.Contains("skipVersionCheck"))
+                    {                    
 #if !DEBUG
                     Console.WriteLine("Do you want to continue? (y/n)");
                     if (Console.ReadKey().Key != ConsoleKey.Y)
                     {
-                        _logger.LogWarning("User aborted to update version");
+                        _logger.LogWarning("User aborted to update version");                       
                         throw new Exception("User Abort");
+                      
                     }
 #endif
+                    }
                 }
             }
         }


### PR DESCRIPTION
Incorporate the new https://github.com/basicx-StrgV/WGet.NET/releases/tag/3.0.0 update into the check for version at the beginning of the application.

This incorporates https://github.com/basicx-StrgV/WGet.NET created by @basicx-StrgV to check that we are running the latest version at the beginning of the run. 