### PR TITLE
Update DetectVersionService.cs

### DIFF
--- a/src/MigrationTools.Host/Services/DetectVersionService.cs
+++ b/src/MigrationTools.Host/Services/DetectVersionService.cs
@@ -37,7 +37,7 @@ namespace MigrationTools.Host.Services
             try
             {
                 WinGetPackageManager packageManager = new WinGetPackageManager();
-                var package = packageManager.GetInstalledPackages(PackageId).SingleOrDefault();
+                var package = packageManager.GetInstalledPackages(PackageId).GroupBy(e => e.Id, (id, g) => g.First()).SingleOrDefault();
 
                 latestPackageVersion = new Version(package.AvailableVersion);
                 if (latestPackageVersion != null)

--- a/src/MigrationTools.Host/Services/DetectVersionService.cs
+++ b/src/MigrationTools.Host/Services/DetectVersionService.cs
@@ -37,7 +37,7 @@ namespace MigrationTools.Host.Services
             try
             {
                 WinGetPackageManager packageManager = new WinGetPackageManager();
-                var package = packageManager.SearchPackage(PackageId).SingleOrDefault();
+                var package = packageManager.GetInstalledPackages(PackageId).SingleOrDefault();
 
                 latestPackageVersion = new Version(package.AvailableVersion);
                 if (latestPackageVersion != null)


### PR DESCRIPTION
The package search will search the winget repository and will always return the newest version.  
Package.Version and Package.AvailableVersion will always be the same here.  

I changed it to `GetInstalledPackages(packageId)` instead of `SearchPackage(PackageId)`.  
This will give you the correct installed and available version and should also be faster, because you are just going through the installed packages.