### PR TITLE
Version check improvements

### DIFF
--- a/src/MigrationTools.Host/MigrationTools.Host.csproj
+++ b/src/MigrationTools.Host/MigrationTools.Host.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="4.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
-    <PackageReference Include="WGet.NET" Version="3.1.0" />
+    <PackageReference Include="WGet.NET" Version="3.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MigrationTools.Host/Services/DetectVersionService.cs
+++ b/src/MigrationTools.Host/Services/DetectVersionService.cs
@@ -37,11 +37,11 @@ namespace MigrationTools.Host.Services
             try
             {
                 WinGetPackageManager packageManager = new WinGetPackageManager();
-                var package = packageManager.GetInstalledPackages(PackageId).GroupBy(e => e.Id, (id, g) => g.First()).SingleOrDefault();
+                var package = packageManager.GetInstalledPackages(PackageId, true).FirstOrDefault();
 
-                latestPackageVersion = new Version(package.AvailableVersion);
-                if (latestPackageVersion != null)
+                if (package != null)
                 {
+                    latestPackageVersion = package.AvailableVersionObject;
                     sucess = true;
                 }
                 _Telemetry.TrackDependency(new DependencyTelemetry("PackageRepository", "winget", PackageId, latestPackageVersion == null ? "nullVersion" : latestPackageVersion.ToString(), startTime, mainTimer.Elapsed, "200", sucess));

--- a/src/MigrationTools.Host/Services/DetectVersionService2.cs
+++ b/src/MigrationTools.Host/Services/DetectVersionService2.cs
@@ -87,11 +87,11 @@ namespace MigrationTools.Host.Services
                     if (IsPackageManagerInstalled)
                     {
                         Log.Verbose("Searching for package!");
-                        package = packageManager.GetInstalledPackages(PackageId).GroupBy(e => e.Id, (id, g) => g.First()).SingleOrDefault();
+                        package = packageManager.GetInstalledPackages(PackageId, true).FirstOrDefault();
                         if (package != null)
                         {
-                            AvailableVersion = new Version(package.AvailableVersion);
-                            InstalledVersion = new Version(package.Version);
+                            AvailableVersion = package.AvailableVersionObject;
+                            InstalledVersion = package.VersionObject;
                             Log.Debug("Found package with id {PackageId}", PackageId);
                             IsPackageInstalled = true;
                         }


### PR DESCRIPTION
With the newest version of `WGet.NET` (`3.2.0`) the check for the newest and current version of a package can be simplified.
Instat of checking for the correct package ID yourself, the `exact` flag can now be used.
Parsing of the version strings to a version object is also not needed anymore, because the `WinGetPackage` class now provides properties to get the parsed version object.

The new `WGet.NET` internal algorithm for passing version strings to a `Version` objects is able to parse version strings that can not be passed directly, as best as possible (e.g. Version strings like: `1.2.3-preview1` or  `1.2.3.1A2B3C`).

I have created this pull request which contains the possible improvements if you are interested in using them.
