### PR TITLE
Experiment: Create Nodes (Area\Iteration) at validation and not up front.

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ We use these tools with our customers, and for fun, to do real world migrations 
 
 ## Change Log
 
+- 14.3 - Created a flag for `ShouldCreateNodesUpFront`, while the default is `true` this is a private preview of a new feature. Instead of creating the area and iteration paths up front, this new feature instead creates the Area & Iteration paths at validation time. For each missing path it will create it, and for those that exist it will simply pass over after a `GetNodeFromPath` call. For tose wishing to participate in the preview please set `ShouldCreateNodesUpFront` to `false`, and to create the nodes rather than just list them set `ShouldCreateMissingRevisionPaths` to `true` as well. It will still list nodes that are not able to be created and require a mapping. NOTE: You can also run with `"ShouldCreateMissingRevisionPaths": false` to list all the nodes that will be created so that you can create more elaborate mappings. 
 - 14.2 - Removed the `StopMigrationOnMissingAreaIterationNodes` flag. All missing nodes MUST be present or mapped using `AreaMaps` and `IterationMaps`. System will always stop on missing nodes.
 - 14.1 - Enabled auto update on client devices, server still used choco
 - 14.0 - Move from Chocolaty to Winget as the base installer. We will continue to publish to Chocolaty, but we recommend using `winget install nkdAgility.AzureDevOpsMigrationTools` for future installs. Main executable renamed to "devopsmigration.exe" to prevent conflict with other applications with symbolic links.

--- a/docs/Reference/Generated/MigrationTools.Host.xml
+++ b/docs/Reference/Generated/MigrationTools.Host.xml
@@ -11,7 +11,7 @@
         </member>
         <member name="F:ThisAssembly.Git.IsDirtyString">
             <summary>
-            => @"true"
+            => @"false"
             </summary>
         </member>
         <member name="F:ThisAssembly.Git.RepositoryUrl">
@@ -21,32 +21,32 @@
         </member>
         <member name="F:ThisAssembly.Git.Branch">
             <summary>
-            => @"master"
+            => @"experimentNoUpFrontNodeCreation"
             </summary>
         </member>
         <member name="F:ThisAssembly.Git.Commit">
             <summary>
-            => @"97de284"
+            => @"b8dd5b9"
             </summary>
         </member>
         <member name="F:ThisAssembly.Git.Sha">
             <summary>
-            => @"97de284c96ffe7082c703484027c9ac2923282a6"
+            => @"b8dd5b9288e5f82afb4d9ae704a1fefa1d4e2788"
             </summary>
         </member>
         <member name="F:ThisAssembly.Git.CommitDate">
             <summary>
-            => @"2023-11-14T14:04:44+00:00"
+            => @"2023-11-15T12:01:24+00:00"
             </summary>
         </member>
         <member name="F:ThisAssembly.Git.Commits">
             <summary>
-            => @"0"
+            => @"2"
             </summary>
         </member>
         <member name="F:ThisAssembly.Git.Tag">
             <summary>
-            => @"v14.2.3"
+            => @"v14.2.3-2-gb8dd5b9"
             </summary>
         </member>
         <member name="F:ThisAssembly.Git.BaseTag">
@@ -81,7 +81,7 @@
         </member>
         <member name="F:ThisAssembly.Git.SemVer.Patch">
             <summary>
-            => @"3"
+            => @"5"
             </summary>
         </member>
         <member name="F:ThisAssembly.Git.SemVer.Label">

--- a/docs/Reference/Generated/MigrationTools.Host.xml
+++ b/docs/Reference/Generated/MigrationTools.Host.xml
@@ -21,37 +21,37 @@
         </member>
         <member name="F:ThisAssembly.Git.Branch">
             <summary>
-            => @"fixPATTokenRequirement"
+            => @"master"
             </summary>
         </member>
         <member name="F:ThisAssembly.Git.Commit">
             <summary>
-            => @"c9106fc"
+            => @"97de284"
             </summary>
         </member>
         <member name="F:ThisAssembly.Git.Sha">
             <summary>
-            => @"c9106fc819aa016243c4aa7ff62624afa232c892"
+            => @"97de284c96ffe7082c703484027c9ac2923282a6"
             </summary>
         </member>
         <member name="F:ThisAssembly.Git.CommitDate">
             <summary>
-            => @"2023-11-14T12:12:43+00:00"
+            => @"2023-11-14T14:04:44+00:00"
             </summary>
         </member>
         <member name="F:ThisAssembly.Git.Commits">
             <summary>
-            => @"3"
+            => @"0"
             </summary>
         </member>
         <member name="F:ThisAssembly.Git.Tag">
             <summary>
-            => @"v14.2.2-3-gc9106fc"
+            => @"v14.2.3"
             </summary>
         </member>
         <member name="F:ThisAssembly.Git.BaseTag">
             <summary>
-            => @"v14.2.2"
+            => @"v14.2.3"
             </summary>
         </member>
         <member name="F:ThisAssembly.Git.BaseVersion.Major">
@@ -66,7 +66,7 @@
         </member>
         <member name="F:ThisAssembly.Git.BaseVersion.Patch">
             <summary>
-            => @"2"
+            => @"3"
             </summary>
         </member>
         <member name="F:ThisAssembly.Git.SemVer.Major">
@@ -81,7 +81,7 @@
         </member>
         <member name="F:ThisAssembly.Git.SemVer.Patch">
             <summary>
-            => @"5"
+            => @"3"
             </summary>
         </member>
         <member name="F:ThisAssembly.Git.SemVer.Label">

--- a/docs/_data/reference.v1.processors.workitemmigrationcontext.yaml
+++ b/docs/_data/reference.v1.processors.workitemmigrationcontext.yaml
@@ -17,7 +17,7 @@ configurationSamples:
       "AttachmentMigration": true,
       "AttachmentWorkingPath": "c:\\temp\\WorkItemAttachmentWorkingFolder\\",
       "FixHtmlAttachmentLinks": false,
-      "SkipToFinalRevisedWorkItemType": true,
+      "SkipToFinalRevisedWorkItemType": false,
       "WorkItemCreateRetryLimit": 5,
       "FilterWorkItemsThatAlreadyExistInTarget": true,
       "PauseAfterEachWorkItem": false,
@@ -38,7 +38,8 @@ configurationSamples:
       "MaxGracefulFailures": 0,
       "SkipRevisionWithInvalidIterationPath": false,
       "SkipRevisionWithInvalidAreaPath": false,
-      "ShouldCreateMissingRevisionPaths": true
+      "ShouldCreateMissingRevisionPaths": true,
+      "ShouldCreateNodesUpFront": true
     }
   sampleFor: MigrationTools._EngineV1.Configuration.Processing.WorkItemMigrationConfig
 description: WorkItemMigrationConfig is the main processor used to Migrate Work Items, Links, and Attachments. Use `WorkItemMigrationConfig` to configure.
@@ -121,6 +122,10 @@ options:
 - parameterName: ShouldCreateMissingRevisionPaths
   type: Boolean
   description: When set to True the susyem will try to create any missing missing area or iteration paths from the revisions.
+  defaultValue: missng XML code comments
+- parameterName: ShouldCreateNodesUpFront
+  type: Boolean
+  description: missng XML code comments
   defaultValue: missng XML code comments
 - parameterName: SkipRevisionWithInvalidAreaPath
   type: Boolean

--- a/docs/_data/reference.v2.processorenrichers.tfsnodestructure.yaml
+++ b/docs/_data/reference.v2.processorenrichers.tfsnodestructure.yaml
@@ -15,7 +15,8 @@ configurationSamples:
       "IterationMaps": {
         "$type": "Dictionary`2"
       },
-      "ShouldCreateMissingRevisionPaths": true
+      "ShouldCreateMissingRevisionPaths": true,
+      "ShouldCreateNodesUpFront": true
     }
   sampleFor: MigrationTools.Enrichers.TfsNodeStructureOptions
 description: missng XML code comments
@@ -48,6 +49,10 @@ options:
   description: missng XML code comments
   defaultValue: missng XML code comments
 - parameterName: ShouldCreateMissingRevisionPaths
+  type: Boolean
+  description: missng XML code comments
+  defaultValue: missng XML code comments
+- parameterName: ShouldCreateNodesUpFront
   type: Boolean
   description: missng XML code comments
   defaultValue: missng XML code comments

--- a/docs/collections/_reference/reference.v2.processorenrichers.tfsnodestructure.md
+++ b/docs/collections/_reference/reference.v2.processorenrichers.tfsnodestructure.md
@@ -16,7 +16,8 @@ configurationSamples:
       "IterationMaps": {
         "$type": "Dictionary`2"
       },
-      "ShouldCreateMissingRevisionPaths": true
+      "ShouldCreateMissingRevisionPaths": true,
+      "ShouldCreateNodesUpFront": true
     }
   sampleFor: MigrationTools.Enrichers.TfsNodeStructureOptions
 description: missng XML code comments
@@ -49,6 +50,10 @@ options:
   description: missng XML code comments
   defaultValue: missng XML code comments
 - parameterName: ShouldCreateMissingRevisionPaths
+  type: Boolean
+  description: missng XML code comments
+  defaultValue: missng XML code comments
+- parameterName: ShouldCreateNodesUpFront
   type: Boolean
   description: missng XML code comments
   defaultValue: missng XML code comments

--- a/src/MigrationTools.Clients.AzureDevops.ObjectModel/ProcessorEnrichers/TfsNodeStructure.cs
+++ b/src/MigrationTools.Clients.AzureDevops.ObjectModel/ProcessorEnrichers/TfsNodeStructure.cs
@@ -170,7 +170,15 @@ namespace MigrationTools.Enrichers
                     _pathToKnownNodeMap.TryGetValue(currentAncestorPath, out parentNode);
                     if (parentNode == null)
                     {
-                        parentNode= _targetCommonStructureService.GetNodeFromPath(currentAncestorPath);
+                        try
+                        {
+                            parentNode = _targetCommonStructureService.GetNodeFromPath(currentAncestorPath);
+                        } catch (Exception ex)
+                        {
+                            Log.LogDebug("  Not Found:", currentAncestorPath);
+                            parentNode = null;
+                        }
+                        
                     }
                 }
                 else
@@ -251,7 +259,7 @@ namespace MigrationTools.Enrichers
             {
                 Log.LogInformation("Migrating all Nodes before the Processor run.");
                 EntryForProcessorType(processor);
-                MigrateAllNodeStructures();
+                //MigrateAllNodeStructures();
                 RefreshForProcessorType(processor);
             }
         }

--- a/src/MigrationTools.Clients.AzureDevops.ObjectModel/ProcessorEnrichers/TfsNodeStructure.cs
+++ b/src/MigrationTools.Clients.AzureDevops.ObjectModel/ProcessorEnrichers/TfsNodeStructure.cs
@@ -259,7 +259,10 @@ namespace MigrationTools.Enrichers
             {
                 Log.LogInformation("Migrating all Nodes before the Processor run.");
                 EntryForProcessorType(processor);
-                //MigrateAllNodeStructures();
+                if (Options.ShouldCreateNodesUpFront) // FLAG for Expermiment to Do on Demand.
+                {
+                    MigrateAllNodeStructures();
+                }
                 RefreshForProcessorType(processor);
             }
         }

--- a/src/MigrationTools.Clients.AzureDevops.ObjectModel/ProcessorEnrichers/TfsNodeStructureOptions.cs
+++ b/src/MigrationTools.Clients.AzureDevops.ObjectModel/ProcessorEnrichers/TfsNodeStructureOptions.cs
@@ -12,6 +12,7 @@ namespace MigrationTools.Enrichers
         public Dictionary<string, string> AreaMaps { get; set; }
         public Dictionary<string, string> IterationMaps { get; set; }
         public bool ShouldCreateMissingRevisionPaths { get; set; }
+        public bool ShouldCreateNodesUpFront { get; set; }   // FLAG for Expermiment to Do on Demand.
 
         public override void SetDefaults()
         {
@@ -19,6 +20,7 @@ namespace MigrationTools.Enrichers
             AreaMaps = new Dictionary<string, string>();
             IterationMaps = new Dictionary<string, string>();
             ShouldCreateMissingRevisionPaths = true;
+            ShouldCreateNodesUpFront = true;  // FLAG for Expermiment to Do on Demand.
         }
     }
 

--- a/src/MigrationTools.Host/MigrationToolHost.cs
+++ b/src/MigrationTools.Host/MigrationToolHost.cs
@@ -151,7 +151,7 @@ namespace MigrationTools.Host
         private static string GetVersionTextForLog()
         {
             Version runningVersion = DetectVersionService2.GetRunningVersion();
-            string textVersion = ((runningVersion.Major > 1) ? "$v" + runningVersion : ThisAssembly.Git.BaseTag + "-" + ThisAssembly.Git.Commits + "-local");
+            string textVersion = ((runningVersion.Major > 1) ? "v" + runningVersion : ThisAssembly.Git.BaseTag + "-" + ThisAssembly.Git.Commits + "-local");
             return textVersion;
         }
 

--- a/src/MigrationTools.Host/StartupService.cs
+++ b/src/MigrationTools.Host/StartupService.cs
@@ -73,7 +73,9 @@ namespace MigrationTools.Host
                     Log.Warning("Windows Server: If you are running on Windows Server you can use the experimental version of Winget, or you can still use Chocolatey to manage the install. Install chocolatey from https://chocolatey.org/install and then use `choco install vsts-sync-migrator` to install, and `choco upgrade vsts-sync-migrator` to upgrade to newer versions.", _detectVersionService.PackageId);
                 } else
                 {
-                    if (!_detectVersionService.IsPackageInstalled && !_detectVersionService.IsRunningInDebug)
+                    if (!_detectVersionService.IsRunningInDebug)
+                    { 
+                    if (!_detectVersionService.IsPackageInstalled)
                     {
                         Log.Information("It looks like this application has been installed from a zip, would you like to use the managed version?");
                         Console.WriteLine("Do you want install the managed version? (y/n)");
@@ -85,14 +87,14 @@ namespace MigrationTools.Host
                     }
                     if (_detectVersionService.IsUpdateAvailable && _detectVersionService.IsPackageInstalled)
                     {
-                        Log.Information("It looks like this application has been installed from a zip, would you like to use the managed version from Winget?");
+                        Log.Information("It looks like an updated version is available from Winget, would you like to update?");
                         Console.WriteLine("Do you want install the managed version? (y/n)");
                         if (Console.ReadKey().Key == ConsoleKey.Y)
                         {
                             _detectVersionService.UpdateFromSource();
                         }
                     }
-                    if ((_detectVersionService.IsNewLocalVersionAvailable && _detectVersionService.IsPackageInstalled) && !_detectVersionService.IsRunningInDebug)
+                    if (_detectVersionService.IsNewLocalVersionAvailable && _detectVersionService.IsPackageInstalled)
                     {
                         Log.Information("It looks like this package ({PackageId}) has been updated locally to version {InstalledVersion} and you are not running the latest version?", _detectVersionService.PackageId, _detectVersionService.InstalledVersion);
                         Console.WriteLine("Do you want to quit and restart? (y/n)");
@@ -103,6 +105,10 @@ namespace MigrationTools.Host
                             Thread.Sleep(2000);
                             Environment.Exit(0);
                         }
+                    }
+                    } else
+                    {
+                        Log.Information("Running in Debug! No further version checkes.....");
                     }
                 }
             } else

--- a/src/MigrationTools/_EngineV1/Configuration/Processing/WorkItemMigrationConfig.cs
+++ b/src/MigrationTools/_EngineV1/Configuration/Processing/WorkItemMigrationConfig.cs
@@ -197,6 +197,7 @@ namespace MigrationTools._EngineV1.Configuration.Processing
         /// When set to True the susyem will try to create any missing missing area or iteration paths from the revisions.
         /// </summary>
        public bool ShouldCreateMissingRevisionPaths { get; set; }
+        public bool ShouldCreateNodesUpFront { get; set; }  // FLAG for Expermiment to Do on Demand.
 
         /// <inheritdoc />
         public bool IsProcessorCompatible(IReadOnlyList<IProcessorConfig> otherProcessors)
@@ -234,6 +235,7 @@ namespace MigrationTools._EngineV1.Configuration.Processing
             SkipRevisionWithInvalidIterationPath = false;
             SkipRevisionWithInvalidAreaPath = false;
             ShouldCreateMissingRevisionPaths = true;
+            ShouldCreateNodesUpFront = true;
         }
     }
 }

--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemMigrationContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemMigrationContext.cs
@@ -150,6 +150,7 @@ namespace VstsSyncMigrator.Engine
             embededImagesEnricher = Services.GetRequiredService<TfsEmbededImagesEnricher>();
             gitRepositoryEnricher = Services.GetRequiredService<TfsGitRepositoryEnricher>();
 
+
             _nodeStructureEnricher.ProcessorExecutionBegin(null);
 
             var stopwatch = Stopwatch.StartNew();

--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemMigrationContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemMigrationContext.cs
@@ -115,7 +115,8 @@ namespace VstsSyncMigrator.Engine
                     AreaMaps = _config.AreaMaps ?? new Dictionary<string, string>(),
                     IterationMaps = _config.IterationMaps ?? new Dictionary<string, string>(),
                     ShouldCreateMissingRevisionPaths = _config.ShouldCreateMissingRevisionPaths,
-                });
+                    ShouldCreateNodesUpFront = _config.ShouldCreateNodesUpFront
+                }); ;
             }
 
             _revisionManager.Configure(new TfsRevisionManagerOptions() { Enabled = true, MaxRevisions = _config.MaxRevisions, ReplayRevisions = _config.ReplayRevisions });


### PR DESCRIPTION
Instead of creating all of the nodes at the start, we create them when we check the history instead.

This way all nodes can be mapped as needed, if needed.


https://github.com/nkdAgility/azure-devops-migration-tools/discussions/1727

[ ] TODO Add flag!
