### PR TITLE
Clean Up on Aisle 4

### DIFF
--- a/docs/Reference/Generated/MigrationTools.Host.xml
+++ b/docs/Reference/Generated/MigrationTools.Host.xml
@@ -21,37 +21,37 @@
         </member>
         <member name="F:ThisAssembly.Git.Branch">
             <summary>
-            => @"experimentNoUpFrontNodeCreation"
+            => @"cleanUpOnAisle4"
             </summary>
         </member>
         <member name="F:ThisAssembly.Git.Commit">
             <summary>
-            => @"b8dd5b9"
+            => @"02feb41"
             </summary>
         </member>
         <member name="F:ThisAssembly.Git.Sha">
             <summary>
-            => @"b8dd5b9288e5f82afb4d9ae704a1fefa1d4e2788"
+            => @"02feb418673fa13ce414c12596ebd46248dbd4a1"
             </summary>
         </member>
         <member name="F:ThisAssembly.Git.CommitDate">
             <summary>
-            => @"2023-11-15T12:01:24+00:00"
+            => @"2023-11-16T14:45:58+00:00"
             </summary>
         </member>
         <member name="F:ThisAssembly.Git.Commits">
             <summary>
-            => @"2"
+            => @"3"
             </summary>
         </member>
         <member name="F:ThisAssembly.Git.Tag">
             <summary>
-            => @"v14.2.3-2-gb8dd5b9"
+            => @"v14.3.0-3-g02feb41"
             </summary>
         </member>
         <member name="F:ThisAssembly.Git.BaseTag">
             <summary>
-            => @"v14.2.3"
+            => @"v14.3.0"
             </summary>
         </member>
         <member name="F:ThisAssembly.Git.BaseVersion.Major">
@@ -61,12 +61,12 @@
         </member>
         <member name="F:ThisAssembly.Git.BaseVersion.Minor">
             <summary>
-            => @"2"
+            => @"3"
             </summary>
         </member>
         <member name="F:ThisAssembly.Git.BaseVersion.Patch">
             <summary>
-            => @"3"
+            => @"0"
             </summary>
         </member>
         <member name="F:ThisAssembly.Git.SemVer.Major">
@@ -76,12 +76,12 @@
         </member>
         <member name="F:ThisAssembly.Git.SemVer.Minor">
             <summary>
-            => @"2"
+            => @"3"
             </summary>
         </member>
         <member name="F:ThisAssembly.Git.SemVer.Patch">
             <summary>
-            => @"5"
+            => @"3"
             </summary>
         </member>
         <member name="F:ThisAssembly.Git.SemVer.Label">

--- a/src/MigrationTools.Clients.AzureDevops.ObjectModel/Enrichers/TfsGitRepositoryEnricher.cs
+++ b/src/MigrationTools.Clients.AzureDevops.ObjectModel/Enrichers/TfsGitRepositoryEnricher.cs
@@ -88,12 +88,18 @@ namespace MigrationTools.Enrichers
             List<ExternalLink> newEL = new List<ExternalLink>();
             List<ExternalLink> removeEL = new List<ExternalLink>();
             int count = 0;
+            SetupRepoBits();
+            if (sourceRepoService == null)
+            {
+                Log.LogWarning("Unable to configure connection to git!");
+                return -1;
+            }
             foreach (Link l in targetWorkItem.ToWorkItem().Links)
             {
                 if (l is ExternalLink && gitWits.Contains(l.ArtifactLinkType.Name))
                 {
                     ExternalLink el = (ExternalLink)l;
-                    SetupRepoBits();
+                    
                     TfsGitRepositoryInfo sourceRepoInfo = TfsGitRepositoryInfo.Create(el, sourceRepos, Engine, sourceWorkItem?.ProjectName);
 
                     // if sourceRepo is null ignore this link and keep processing further links

--- a/src/MigrationTools.Clients.AzureDevops.ObjectModel/Enrichers/TfsGitRepositoryEnricher.cs
+++ b/src/MigrationTools.Clients.AzureDevops.ObjectModel/Enrichers/TfsGitRepositoryEnricher.cs
@@ -34,14 +34,6 @@ namespace MigrationTools.Enrichers
         {
             Engine = Services.GetRequiredService<IMigrationEngine>();
             _Logger = logger ?? throw new ArgumentNullException(nameof(logger));
-
-            sourceRepoService = Engine.Source.GetService<GitRepositoryService>();
-            sourceRepos = sourceRepoService.QueryRepositories(Engine.Source.Config.AsTeamProjectConfig().Project);
-            allSourceRepos = sourceRepoService.QueryRepositories("");
-            //////////////////////////////////////////////////
-            targetRepoService = Engine.Target.GetService<GitRepositoryService>();
-            targetRepos = targetRepoService.QueryRepositories(Engine.Target.Config.AsTeamProjectConfig().Project);
-            allTargetRepos = targetRepoService.QueryRepositories("");
             gitWits = new List<string>
                 {
                     "Branch",
@@ -56,6 +48,27 @@ namespace MigrationTools.Enrichers
         {
             _filter = filter;
             _save = save;
+        }
+
+        public void SetupRepoBits()
+        {
+            if (sourceRepoService == null)
+            {
+                try
+                {
+                    sourceRepoService = Engine.Source.GetService<GitRepositoryService>();
+                    sourceRepos = sourceRepoService.QueryRepositories(Engine.Source.Config.AsTeamProjectConfig().Project);
+                    allSourceRepos = sourceRepoService.QueryRepositories("");
+                    //////////////////////////////////////////////////
+                    targetRepoService = Engine.Target.GetService<GitRepositoryService>();
+                    targetRepos = targetRepoService.QueryRepositories(Engine.Target.Config.AsTeamProjectConfig().Project);
+                    allTargetRepos = targetRepoService.QueryRepositories("");
+                } catch (Exception ex)
+                {
+                    sourceRepoService = null;
+                }
+                
+            }            
         }
 
         [Obsolete]
@@ -80,7 +93,7 @@ namespace MigrationTools.Enrichers
                 if (l is ExternalLink && gitWits.Contains(l.ArtifactLinkType.Name))
                 {
                     ExternalLink el = (ExternalLink)l;
-
+                    SetupRepoBits();
                     TfsGitRepositoryInfo sourceRepoInfo = TfsGitRepositoryInfo.Create(el, sourceRepos, Engine, sourceWorkItem?.ProjectName);
 
                     // if sourceRepo is null ignore this link and keep processing further links

--- a/src/MigrationTools.Clients.AzureDevops.ObjectModel/_Enginev1/Clients/TfsMigrationClient.cs
+++ b/src/MigrationTools.Clients.AzureDevops.ObjectModel/_Enginev1/Clients/TfsMigrationClient.cs
@@ -148,7 +148,7 @@ namespace MigrationTools._EngineV1.Clients
                         break;
                 }
                 Log.Information("MigrationClient: Connecting to {CollectionUrl} ", TfsConfig.Collection);
-                Log.Information("MigrationClient: validating security for {@AuthorizedIdentity} ", y.AuthorizedIdentity);
+                Log.Debug("MigrationClient: validating security for {@AuthorizedIdentity} ", y.AuthorizedIdentity);
                 y.EnsureAuthenticated();
                 timer.Stop();
                 Log.Information("MigrationClient: Access granted to {CollectionUrl} for {Name} ({Account})", TfsConfig.Collection, y.AuthorizedIdentity.DisplayName, y.AuthorizedIdentity.UniqueName);

--- a/src/MigrationTools.Clients.AzureDevops.ObjectModel/_Enginev1/Clients/TfsMigrationClient.cs
+++ b/src/MigrationTools.Clients.AzureDevops.ObjectModel/_Enginev1/Clients/TfsMigrationClient.cs
@@ -110,7 +110,7 @@ namespace MigrationTools._EngineV1.Clients
         {
             var startTime = DateTime.UtcNow;
             var timer = System.Diagnostics.Stopwatch.StartNew();
-            TfsTeamProjectCollection y;
+            TfsTeamProjectCollection y = null;
             try
             {
                 Log.Information("TfsMigrationClient::GetDependantTfsCollection:AuthenticationMode({0})", _config.AuthenticationMode.ToString());

--- a/src/MigrationTools.Clients.AzureDevops.ObjectModel/_Enginev1/Clients/TfsMigrationClient.cs
+++ b/src/MigrationTools.Clients.AzureDevops.ObjectModel/_Enginev1/Clients/TfsMigrationClient.cs
@@ -166,8 +166,8 @@ namespace MigrationTools._EngineV1.Clients
                        new Dictionary<string, double> {
                             { "Time",timer.ElapsedMilliseconds }
                        });
-                Log.Error(ex, "Unable to configure store");
-                throw;
+                Log.Error(ex, "Unable to configure store: Check persmissions and credentials for {AuthenticationMode}", _config.AuthenticationMode);
+                Environment.Exit(-1);
             }
             return y;
         }

--- a/src/MigrationTools.Host/StartupService.cs
+++ b/src/MigrationTools.Host/StartupService.cs
@@ -81,31 +81,32 @@ namespace MigrationTools.Host
                         Console.WriteLine("Do you want install the managed version? (y/n)");
                         if (Console.ReadKey().Key == ConsoleKey.Y)
                         {
-                            
                             _detectVersionService.UpdateFromSource();
                         }
                     }
                     if (_detectVersionService.IsUpdateAvailable && _detectVersionService.IsPackageInstalled)
                     {
-                        Log.Information("It looks like an updated version is available from Winget, would you like to update?");
+                        Log.Information("It looks like an updated version is available from Winget, would you like to exit and update?");
                         Console.WriteLine("Do you want install the managed version? (y/n)");
                         if (Console.ReadKey().Key == ConsoleKey.Y)
                         {
-                            _detectVersionService.UpdateFromSource();
+                                Thread.Sleep(2000);
+                                Environment.Exit(0);
+                                //_detectVersionService.UpdateFromSource();
                         }
                     }
-                    if (_detectVersionService.IsNewLocalVersionAvailable && _detectVersionService.IsPackageInstalled)
-                    {
-                        Log.Information("It looks like this package ({PackageId}) has been updated locally to version {InstalledVersion} and you are not running the latest version?", _detectVersionService.PackageId, _detectVersionService.InstalledVersion);
-                        Console.WriteLine("Do you want to quit and restart? (y/n)");
-                        if (Console.ReadKey().Key == ConsoleKey.Y)
-                        {
-                            Log.Information("Restarting as {CommandLine}", Environment.CommandLine);
-                            Process.Start("devopsmigration", string.Join(" ", Environment.GetCommandLineArgs().Skip(1)));
-                            Thread.Sleep(2000);
-                            Environment.Exit(0);
-                        }
-                    }
+                    //if (_detectVersionService.IsNewLocalVersionAvailable && _detectVersionService.IsPackageInstalled)
+                    //{
+                    //    Log.Information("It looks like this package ({PackageId}) has been updated locally to version {InstalledVersion} and you are not running the latest version?", _detectVersionService.PackageId, _detectVersionService.InstalledVersion);
+                    //    Console.WriteLine("Do you want to quit and restart? (y/n)");
+                    //    if (Console.ReadKey().Key == ConsoleKey.Y)
+                    //    {
+                    //        Log.Information("Restarting as {CommandLine}", Environment.CommandLine);
+                    //        Process.Start("devopsmigration", string.Join(" ", Environment.GetCommandLineArgs().Skip(1)));
+                    //        Thread.Sleep(2000);
+                    //        Environment.Exit(0);
+                    //    }
+                    //}
                     } else
                     {
                         Log.Information("Running in Debug! No further version checkes.....");

--- a/src/MigrationTools/DataContracts/NodeStructureMissingItem.cs
+++ b/src/MigrationTools/DataContracts/NodeStructureMissingItem.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace MigrationTools.DataContracts
 {
-    public class NodeStructureMissingItem
+    public class NodeStructureItem
     {
         public bool anchored { get; set; } = true;
 
@@ -15,7 +15,7 @@ namespace MigrationTools.DataContracts
 
         public override bool Equals(object obj)
         {
-            var item = obj as NodeStructureMissingItem;
+            var item = obj as NodeStructureItem;
 
             if (item == null)
             {

--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemMigrationContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemMigrationContext.cs
@@ -658,9 +658,9 @@ namespace VstsSyncMigrator.Engine
                         TraceWriteLine(LogEventLevel.Information, $"WorkItem has changed type at one of the revisions, from {targetType} to {finalDestType}");
                     }
 
-                    if (skipToFinalRevisedWorkItemType && Engine.TypeDefinitionMaps.Items.ContainsKey(finalDestType))
+                    if (skipToFinalRevisedWorkItemType)
                     {
-                        finalDestType = Engine.TypeDefinitionMaps.Items[finalDestType].Map();
+                        targetType = finalDestType;
                     }
 
                     if (Engine.TypeDefinitionMaps.Items.ContainsKey(targetType))

--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemMigrationContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemMigrationContext.cs
@@ -177,7 +177,7 @@ namespace VstsSyncMigrator.Engine
 
                 //////////////////////////////////////////////////
                 contextLog.Information("ValidateTargetNodesExist::Checking all Nodes on Work items");
-                List<NodeStructureMissingItem> nodeStructureMissingItems = _nodeStructureEnricher.GetMissingRevisionNodes(sourceWorkItems);
+                List<NodeStructureItem> nodeStructureMissingItems = _nodeStructureEnricher.GetMissingRevisionNodes(sourceWorkItems);
                 if (_nodeStructureEnricher.ValidateTargetNodesExist(nodeStructureMissingItems))
                 {
                     throw new Exception("Missing Iterations in Target preventing progress, check log for list. To continue you MUST configure IterationMaps or AreaMaps that matches the missing paths..");


### PR DESCRIPTION
Bring out your Dead! 

1. Fix the update on the new version loop. It no longer does auto-update as Winget does not support it.
2. `skipToFinalRevisedWorkItemType` now works more how people expect by jumping to the final type, and then applying the mapping set in the config. This way a work item of the old type is never created. #1734 #1581
3. Add a full failure and exit if we fail to create a Source or Target Store. #1712 
4. This change should enable the tools on pre Git version of TFS. #1577
5. Updated the regex to allow for root nodes to ve valid so that they are checked as well. #1738 

**_What else?_**