### PR TITLE
KEPT OPEN FOR TESTING: Flip check for attachment size so too large files don't crash the migration

### DIFF
--- a/src/MigrationTools.Clients.AzureDevops.ObjectModel/Enrichers/TfsAttachmentEnricher.cs
+++ b/src/MigrationTools.Clients.AzureDevops.ObjectModel/Enrichers/TfsAttachmentEnricher.cs
@@ -127,7 +127,7 @@ namespace MigrationTools.Enrichers
         {
             var filename = System.IO.Path.GetFileName(filepath);
             FileInfo fi = new FileInfo(filepath);
-            if (_maxAttachmentSize > fi.Length)
+            if (_maxAttachmentSize < fi.Length)
             {
                 string originalId = "[originalId:" + wia.Id + "]";
                 var attachments = targetWorkItem.Attachments.Cast<Attachment>();


### PR DESCRIPTION
Found while preparing our migration.
The ``MaxAttachementSize`` is checked in the wrong direction which causes the migration to fail in case of too large files.