### PR TITLE
Update `FindTestPlan` to actually check the right things

### DIFF
--- a/docs/Reference/Generated/MigrationTools.Host.xml
+++ b/docs/Reference/Generated/MigrationTools.Host.xml
@@ -11,7 +11,7 @@
         </member>
         <member name="F:ThisAssembly.Git.IsDirtyString">
             <summary>
-            => @"false"
+            => @"true"
             </summary>
         </member>
         <member name="F:ThisAssembly.Git.RepositoryUrl">
@@ -21,37 +21,37 @@
         </member>
         <member name="F:ThisAssembly.Git.Branch">
             <summary>
-            => @"master"
+            => @"issue/1772"
             </summary>
         </member>
         <member name="F:ThisAssembly.Git.Commit">
             <summary>
-            => @"6a99c83"
+            => @"06bccf8"
             </summary>
         </member>
         <member name="F:ThisAssembly.Git.Sha">
             <summary>
-            => @"6a99c8370a13b1807e23ff34c7b12888435a15d6"
+            => @"06bccf8671348e366db1a41cc36e81da315fabab"
             </summary>
         </member>
         <member name="F:ThisAssembly.Git.CommitDate">
             <summary>
-            => @"2023-11-23T13:43:28+00:00"
+            => @"2023-12-05T18:16:30+00:00"
             </summary>
         </member>
         <member name="F:ThisAssembly.Git.Commits">
             <summary>
-            => @"0"
+            => @"3"
             </summary>
         </member>
         <member name="F:ThisAssembly.Git.Tag">
             <summary>
-            => @"v14.3.2"
+            => @"v14.3.5-3-g06bccf8"
             </summary>
         </member>
         <member name="F:ThisAssembly.Git.BaseTag">
             <summary>
-            => @"v14.3.2"
+            => @"v14.3.5"
             </summary>
         </member>
         <member name="F:ThisAssembly.Git.BaseVersion.Major">
@@ -66,7 +66,7 @@
         </member>
         <member name="F:ThisAssembly.Git.BaseVersion.Patch">
             <summary>
-            => @"2"
+            => @"5"
             </summary>
         </member>
         <member name="F:ThisAssembly.Git.SemVer.Major">
@@ -81,7 +81,7 @@
         </member>
         <member name="F:ThisAssembly.Git.SemVer.Patch">
             <summary>
-            => @"2"
+            => @"8"
             </summary>
         </member>
         <member name="F:ThisAssembly.Git.SemVer.Label">

--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/TestPlansAndSuitesMigrationContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/TestPlansAndSuitesMigrationContext.cs
@@ -633,7 +633,7 @@ namespace VstsSyncMigrator.Engine
                 //Check test plan is in fact the right one
                 var sourceWI = Engine.Source.WorkItems.GetWorkItem(sourcePlanId);
                 string expectedReflectedId = Engine.Source.WorkItems.CreateReflectedWorkItemId(sourceWI).ToString();
-                var targetWI = Engine.Source.WorkItems.GetWorkItem(testPlan.Id.ToString());
+                var targetWI = Engine.Target.WorkItems.GetWorkItem(testPlan.Id.ToString());
                 string workItemReflectedId = (string)targetWI.Fields[Engine.Target.Config.AsTeamProjectConfig().ReflectedWorkItemIDFieldName].Value;
 
                 if (workItemReflectedId != expectedReflectedId)

--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/TestPlansAndSuitesMigrationContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/TestPlansAndSuitesMigrationContext.cs
@@ -544,7 +544,7 @@ namespace VstsSyncMigrator.Engine
                         Id = int.Parse(targetSuite.Id)
                     }
                 };
-                TestSuite suite = testPlanHttpClient.CreateTestSuiteAsync(testSuiteCreateParams, project, int.Parse(targetPlan.Id)).Result;
+                Microsoft.VisualStudio.Services.TestManagement.TestPlanning.WebApi.TestSuite suite = testPlanHttpClient.CreateTestSuiteAsync(testSuiteCreateParams, project, int.Parse(targetPlan.Id)).Result;
                 targetSuiteChild = (IRequirementTestSuite)_targetTestStore.Project.TestSuites.Find(suite.Id);
                 //Replaced soap api with rest api because work item type Bug is no longer part of the Microsoft.Requirement.Category
                 //targetSuiteChild = _targetTestStore.Project.TestSuites.CreateRequirement(requirement.ToWorkItem());

--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/TestPlansAndSuitesMigrationContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/TestPlansAndSuitesMigrationContext.cs
@@ -635,6 +635,7 @@ namespace VstsSyncMigrator.Engine
                 string expectedReflectedId = Engine.Source.WorkItems.CreateReflectedWorkItemId(sourceWI).ToString();
                 var targetWI = Engine.Source.WorkItems.GetWorkItem(testPlan.Id.ToString());
                 string workItemReflectedId = (string)targetWI.Fields[Engine.Target.Config.AsTeamProjectConfig().ReflectedWorkItemIDFieldName].Value;
+
                 if (workItemReflectedId != expectedReflectedId)
                 {
                     Log.LogDebug("TestPlansAndSuitesMigrationContext::FindTestPlan:: Found test plan with name {name} does not match {workItemReflectedId} ", planName, workItemReflectedId);


### PR DESCRIPTION
Thank you for responding so quickly.

I still believe the behavior is incorrect. 

This line finds the target test Plan and sets it to the variable of `testPlan`

```csharp
ITestPlan testPlan = (from p in tmc.Project.TestPlans.Query("Select * From TestPlan") where p.Name == name select p).SingleOrDefault();
```

This line uses the ID of the target work item to find an item in source, thereby returning the wrong work item.

```csharp
 var sourceWI = Engine.Source.WorkItems.GetWorkItem(testPlan.Id.ToString());
```

Observe how in my case the id of 12422 finds a Test Plan in the target, but a Bug work item in the source

![image](https://github.com/nkdAgility/azure-devops-migration-tools/assets/16128271/2a7c0e02-c37c-405f-aa80-a1b5ef6fb8f8)

_Originally posted by @sonofhammer in https://github.com/nkdAgility/azure-devops-migration-tools/discussions/1770#discussioncomment-7766304_

The fix is to pass in the sourceWorkItemId and use both the Source and Target work items to get the expected and actual RefectedWorkItemID:

```
   private ITestPlan FindTestPlan(string planName, int sourcePlanId)
   {
       Log.LogDebug("TestPlansAndSuitesMigrationContext::FindTestPlan");
       ITestPlan testPlan = (from p in _targetTestStore.Project.TestPlans.Query("Select * From TestPlan") where p.Name == planName select p).SingleOrDefault();
 
       if (testPlan != null)
       {
           Log.LogDebug("TestPlansAndSuitesMigrationContext::FindTestPlan:: FOUND Test Plan with {name}", planName);
           //Check test plan is in fact the right one
           var sourceWI = Engine.Source.WorkItems.GetWorkItem(sourcePlanId);
           string expectedReflectedId = Engine.Source.WorkItems.CreateReflectedWorkItemId(sourceWI).ToString();
           var targetWI = Engine.Source.WorkItems.GetWorkItem(testPlan.Id.ToString());
           string workItemReflectedId = (string)targetWI.Fields[Engine.Target.Config.AsTeamProjectConfig().ReflectedWorkItemIDFieldName].Value;
           if (workItemReflectedId != expectedReflectedId)
           {
               Log.LogDebug("TestPlansAndSuitesMigrationContext::FindTestPlan:: Found test plan with name {name} does not match {workItemReflectedId} ", planName, workItemReflectedId);
               testPlan = null;
           }
       }
       else
       {
           Log.LogDebug("TestPlansAndSuitesMigrationContext::FindTestPlan:: NOT FOUND Test Plan with {name}", planName);
       }
       return testPlan;
   }
```

