### PR TITLE
Remove hard coded `user-agent` From `AzureDevOpsEndpoint`

### DIFF
--- a/src/MigrationTools.Clients.AzureDevops.Rest/Endpoints/AzureDevOpsEndpoint.cs
+++ b/src/MigrationTools.Clients.AzureDevops.Rest/Endpoints/AzureDevOpsEndpoint.cs
@@ -98,8 +98,7 @@ namespace MigrationTools.Endpoints
             };
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", Convert.ToBase64String(Encoding.ASCII.GetBytes(string.Format("{0}:{1}", "", Options.AccessToken))));
             client.DefaultRequestHeaders.Add("Accept", $"application/json; {versionParameter}");
-            client.DefaultRequestHeaders.Add("user-agent", "Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.2; .NET CLR 1.0.3705;)");
-
+            //client.DefaultRequestHeaders.Add("user-agent", "Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.2; .NET CLR 1.0.3705;)"); #1784
             return client;
         }
 


### PR DESCRIPTION
For some reason, we have the User Agent hard coded on `AzureDevOpsEndpoint`. No idea why, but it looks like the version that's coded is no longer supported.

This comments out that line to hopefully resolve the issue some users are facing of `BrowserNotSupportedException`.

https://github.com/nkdAgility/azure-devops-migration-tools/discussions/1783

This closes #1784 1784