### PR TITLE
Update flags!

### DIFF
--- a/src/MigrationTools/_EngineV1/Configuration/Processing/WorkItemMigrationConfig.cs
+++ b/src/MigrationTools/_EngineV1/Configuration/Processing/WorkItemMigrationConfig.cs
@@ -212,7 +212,7 @@ namespace MigrationTools._EngineV1.Configuration.Processing
         {
             Enabled = false;
             WorkItemCreateRetryLimit = 5;
-            FilterWorkItemsThatAlreadyExistInTarget = true;
+            FilterWorkItemsThatAlreadyExistInTarget = false;
             ReplayRevisions = true;
             LinkMigration = true;
             AttachmentMigration = true;
@@ -235,7 +235,7 @@ namespace MigrationTools._EngineV1.Configuration.Processing
             SkipRevisionWithInvalidIterationPath = false;
             SkipRevisionWithInvalidAreaPath = false;
             ShouldCreateMissingRevisionPaths = true;
-            ShouldCreateNodesUpFront = true;
+            ShouldCreateNodesUpFront = false;
         }
     }
 }


### PR DESCRIPTION
Update `FilterWorkItemsThatAlreadyExistInTarget` and `ShouldCreateNodesUpFront` to false.

- `FilterWorkItemsThatAlreadyExistInTarget` should be false and at some point should be removed. It causes too many issues for users.
- `ShouldCreateNodesUpFront` is necessary now as we have integrated it into the mapping engine.
