### PR TITLE
Validation to check Work Item Type Defenitions

### DIFF
--- a/docs/Reference/Generated/MigrationTools.Host.xml
+++ b/docs/Reference/Generated/MigrationTools.Host.xml
@@ -11,7 +11,7 @@
         </member>
         <member name="F:ThisAssembly.Git.IsDirtyString">
             <summary>
-            => @"false"
+            => @"true"
             </summary>
         </member>
         <member name="F:ThisAssembly.Git.RepositoryUrl">
@@ -21,37 +21,37 @@
         </member>
         <member name="F:ThisAssembly.Git.Branch">
             <summary>
-            => @"bug/1826"
+            => @"bug/1832-processTemplateChangeCausesError"
             </summary>
         </member>
         <member name="F:ThisAssembly.Git.Commit">
             <summary>
-            => @"d624da0"
+            => @"77adbfe"
             </summary>
         </member>
         <member name="F:ThisAssembly.Git.Sha">
             <summary>
-            => @"d624da012527785e20ad31f225de1072977f4a6c"
+            => @"77adbfe0309d57bae73ef82585f90a67c37b5c35"
             </summary>
         </member>
         <member name="F:ThisAssembly.Git.CommitDate">
             <summary>
-            => @"2024-01-09T10:57:08+00:00"
+            => @"2024-01-09T11:47:49+00:00"
             </summary>
         </member>
         <member name="F:ThisAssembly.Git.Commits">
             <summary>
-            => @"1"
+            => @"0"
             </summary>
         </member>
         <member name="F:ThisAssembly.Git.Tag">
             <summary>
-            => @"v14.3.10-1-gd624da0"
+            => @"v14.3.11"
             </summary>
         </member>
         <member name="F:ThisAssembly.Git.BaseTag">
             <summary>
-            => @"v14.3.10"
+            => @"v14.3.11"
             </summary>
         </member>
         <member name="F:ThisAssembly.Git.BaseVersion.Major">
@@ -66,7 +66,7 @@
         </member>
         <member name="F:ThisAssembly.Git.BaseVersion.Patch">
             <summary>
-            => @"10"
+            => @"11"
             </summary>
         </member>
         <member name="F:ThisAssembly.Git.SemVer.Major">

--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemMigrationContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemMigrationContext.cs
@@ -25,6 +25,7 @@ using MigrationTools;
 using MigrationTools._EngineV1.Clients;
 using MigrationTools._EngineV1.Configuration;
 using MigrationTools._EngineV1.Configuration.Processing;
+using MigrationTools._EngineV1.Containers;
 using MigrationTools._EngineV1.DataContracts;
 using MigrationTools._EngineV1.Enrichers;
 using MigrationTools._EngineV1.Processors;
@@ -161,7 +162,8 @@ namespace VstsSyncMigrator.Engine
 
             try
             {
-                //Validation: make sure that the ReflectedWorkItemId field name specified in the config exists in the target process, preferably on each work item type.
+                
+
                 PopulateIgnoreList();
 
                 string sourceQuery =
@@ -175,10 +177,63 @@ namespace VstsSyncMigrator.Engine
                 contextLog.Information("Replay all revisions of {sourceWorkItemsCount} work items?",
                     sourceWorkItems.Count);
 
+                //Validation: make sure that the ReflectedWorkItemId field name specified in the config exists in the target process, preferably on each work item type.
+                //////////////////////////////////////////////////
+                contextLog.Information("Validating::Check all Target Work Items have the RefectedWorkItemId field");
 
+                var result = _validateConfig.ValidatingRequiredField(
+                    Engine.Target.Config.AsTeamProjectConfig().ReflectedWorkItemIDFieldName, sourceWorkItems);
+                if (!result)
+                {
+                    var ex = new InvalidFieldValueException(
+                        "Not all work items in scope contain a valid ReflectedWorkItemId Field!");
+                    Log.LogError(ex, "Not all work items in scope contain a valid ReflectedWorkItemId Field!");
+                    throw ex;
+                }
 
                 //////////////////////////////////////////////////
-                contextLog.Information("ValidateTargetNodesExist::Checking all Nodes on Work items");
+
+                //
+                contextLog.Information("Validating::Check that all work item types needed in the Target exist or are mapped");
+                // get list of all work item types
+                List<String> sourceWorkItemTypes = sourceWorkItems.SelectMany(x => x.Revisions.Values)
+                //.Where(x => x.Fields[fieldName].Value.ToString().Contains("\\"))
+                .Select(x => x.Type )
+                .Distinct()
+                .ToList();
+
+                Log.LogDebug("Validating::WorkItemTypes::sourceWorkItemTypes: {count} WorkItemTypes in the full source history {sourceWorkItemTypesString}", sourceWorkItemTypes.Count(), string.Join(",", sourceWorkItemTypes));
+
+                var targetWorkItemTypes = Engine.Target.WorkItems.Project.ToProject().WorkItemTypes.Cast<WorkItemType>().Select(x => x.Name);
+                Log.LogDebug("Validating::WorkItemTypes::targetWorkItemTypes::{count} WorkItemTypes in Target process: {targetWorkItemTypesString}", targetWorkItemTypes.Count(), string.Join(",", targetWorkItemTypes));
+
+               var missingWorkItemTypes = sourceWorkItemTypes.Where(sourceWit => !targetWorkItemTypes.Contains(sourceWit)); // the real one
+                if (missingWorkItemTypes.Count() > 0)
+                {
+                    Log.LogWarning("Validating::WorkItemTypes::targetWorkItemTypes::There are {count} WorkItemTypes that are used in the history of the Source and that do not exist in the Target. These will all need mapped using `WorkItemTypeDefinition` in the config. ", missingWorkItemTypes.Count());
+
+                    bool allTypesMapped = true;
+                    foreach (var missingWorkItemType in missingWorkItemTypes)
+                    {
+                        bool thisTypeMapped = true;
+                        if (!Engine.TypeDefinitionMaps.Items.ContainsKey(missingWorkItemType))
+                        {
+                            thisTypeMapped = false;
+                        }
+                        Log.LogWarning("Validating::WorkItemTypes::targetWorkItemTypes::{missingWorkItemType}::Mapped? {thisTypeMapped}", missingWorkItemType, thisTypeMapped.ToString());
+                        allTypesMapped &= thisTypeMapped;
+                    }
+                    if (!allTypesMapped)
+                    {
+                        var ex = new Exception(
+                           "Not all WorkItemTypes present in the Source are present in the Target or mapped!");
+                        Log.LogError(ex, "Not all WorkItemTypes present in the Source are present in the Target or mapped using `WorkItemTypeDefinition` in the config.");
+                        throw ex;
+                    }
+                }               
+                //////////////////////////////////////////////////
+
+                contextLog.Information("Validating::Check that all Area & Iteration paths from Source have a valid mapping on Target");
                 List<NodeStructureItem> nodeStructureMissingItems = _nodeStructureEnricher.GetMissingRevisionNodes(sourceWorkItems);
                 if (_nodeStructureEnricher.ValidateTargetNodesExist(nodeStructureMissingItems))
                 {
@@ -186,8 +241,11 @@ namespace VstsSyncMigrator.Engine
                 }
 
                 //////////////////////////////////////////////////
+
                 contextLog.Information("Found target project as {@destProject}", Engine.Target.WorkItems.Project.Name);
+
                 //////////////////////////////////////////////////////////FilterCompletedByQuery
+                
                 if (_config.FilterWorkItemsThatAlreadyExistInTarget)
                 {
                     contextLog.Information(
@@ -204,19 +262,10 @@ namespace VstsSyncMigrator.Engine
                         "!! After removing all found work items there are {SourceWorkItemCount} remaining to be migrated.",
                         sourceWorkItems.Count());
                 }
-                //////////////////////////////////////////////////
-
-                var result = _validateConfig.ValidatingRequiredField(
-                    Engine.Target.Config.AsTeamProjectConfig().ReflectedWorkItemIDFieldName, sourceWorkItems);
-                if (!result)
-                {
-                    var ex = new InvalidFieldValueException(
-                        "Not all work items in scope contain a valid ReflectedWorkItemId Field!");
-                    Log.LogError(ex, "Not all work items in scope contain a valid ReflectedWorkItemId Field!");
-                    throw ex;
-                }
 
                 //////////////////////////////////////////////////
+
+
                 _current = 1;
                 _count = sourceWorkItems.Count;
                 _elapsedms = 0;


### PR DESCRIPTION
Added a validator at the start of the migration process that:

1. Created a distinct list of all of the work item types used in each revision of the Source work items in scope
2. Create a list of the target work item types
3. Compare these lists to see if there are any types needed for the migration that is missing.
4. List all of the missing Work Item Types and if they are mapped
5. Throw and exit if any of the needed Types are missing and not mapped.

This should prevent folks from getting errors mid-execution if they were not aware of a work item type migration or of an old conversation and then subsequent deletion of the work item type. 

Resovles #1832 and contributes to resolving #1556