### PR TITLE
[preview] Full fix for #1660 will ensure that all revisions have consecutive datetime with a full second intervel.

### DIFF
--- a/src/MigrationTools.Clients.AzureDevops.ObjectModel/Endpoints/TfsWorkItemConvertor.cs
+++ b/src/MigrationTools.Clients.AzureDevops.ObjectModel/Endpoints/TfsWorkItemConvertor.cs
@@ -48,6 +48,7 @@ namespace MigrationTools.Endpoints
                 Index = x.Index,
                 Number = (int)x.Fields["System.Rev"].Value,
                 ChangedDate = (DateTime)x.Fields["System.ChangedDate"].Value,
+                OriginalChangedDate = (DateTime)x.Fields["System.ChangedDate"].Value,
                 Type = x.Fields["System.WorkItemType"].Value as string,
                 Fields = GetFieldItems(x.Fields)
             }).ToList();

--- a/src/MigrationTools/DataContracts/RevisionItem.cs
+++ b/src/MigrationTools/DataContracts/RevisionItem.cs
@@ -9,6 +9,8 @@ namespace MigrationTools.DataContracts
         public int Index { get; set; }
         public int Number { get; set; }
         public DateTime ChangedDate { get; set; }
+
+        public DateTime OriginalChangedDate { get; set; }
         public string Type { get; set; }
         public Dictionary<string, FieldItem> Fields { get; set; }
         public Dictionary<string, EnricherData> EnricherData { get; set; }


### PR DESCRIPTION
Fix for #1660

The new addition will check that all dates are consecutive with at least a full-second difference. 
