### PR TITLE
[preview] Update to now use values from `TfsAttachmentEnricherOptions`

### DIFF
--- a/src/MigrationTools.Clients.AzureDevops.ObjectModel/ProcessorEnrichers/TfsAttachmentEnricher.cs
+++ b/src/MigrationTools.Clients.AzureDevops.ObjectModel/ProcessorEnrichers/TfsAttachmentEnricher.cs
@@ -21,7 +21,7 @@ namespace MigrationTools.ProcessorEnrichers
     {
         private WorkItemServer _server;
         private string _exportWiPath;
-        private TfsAttachmentEnricherOptions _options;
+        private TfsAttachmentEnricherOptions _options; 
         private WorkItemServer _workItemServer;
 
         public TfsAttachmentEnricherOptions Options {  get { return _options; } } 

--- a/src/MigrationTools.Clients.AzureDevops.ObjectModel/ProcessorEnrichers/TfsAttachmentEnricher.cs
+++ b/src/MigrationTools.Clients.AzureDevops.ObjectModel/ProcessorEnrichers/TfsAttachmentEnricher.cs
@@ -20,9 +20,7 @@ namespace MigrationTools.ProcessorEnrichers
     public class TfsAttachmentEnricher : WorkItemProcessorEnricher, IAttachmentMigrationEnricher
     {
         private WorkItemServer _server;
-        private string _exportBasePath;
         private string _exportWiPath;
-        private int _maxAttachmentSize;
         private TfsAttachmentEnricherOptions _options;
         private WorkItemServer _workItemServer;
 
@@ -30,7 +28,7 @@ namespace MigrationTools.ProcessorEnrichers
 
         public TfsAttachmentEnricher(IServiceProvider services, ILogger<WorkItemProcessorEnricher> logger) : base(services, logger)
         {
-             
+          
         }
 
         public void ProcessAttachemnts(WorkItemData source, WorkItemData target, bool save = true)
@@ -46,7 +44,7 @@ namespace MigrationTools.ProcessorEnrichers
                 throw new ArgumentNullException(nameof(target));
             }
             Log.LogInformation("AttachmentMigrationEnricher: Migrating  {AttachmentCount} attachemnts from {SourceWorkItemID} to {TargetWorkItemID}", source.ToWorkItem().Attachments.Count, source.Id, target.Id);
-            _exportWiPath = Path.Combine(_exportBasePath, source.ToWorkItem().Id.ToString());
+            _exportWiPath = Path.Combine(Options.ExportBasePath, source.ToWorkItem().Id.ToString());
             if (Directory.Exists(_exportWiPath))
             {
                 Directory.Delete(_exportWiPath, true);
@@ -139,7 +137,7 @@ namespace MigrationTools.ProcessorEnrichers
             SetupWorkItemServer();
             var filename = Path.GetFileName(filepath);
             FileInfo fi = new FileInfo(filepath);
-            if (_maxAttachmentSize > fi.Length)
+            if (Options.MaxAttachmentSize > fi.Length)
             {
                 string originalId = "[originalId:" + wia.Id + "]";
                 var attachments = targetWorkItem.Attachments.Cast<Attachment>();
@@ -169,7 +167,7 @@ namespace MigrationTools.ProcessorEnrichers
             }
             else
             {
-                Log.LogWarning(" [SKIP] Attachment {filename} on Work Item {targetWorkItemId} is bigger than the limit of {maxAttachmentSize} bites for Azure DevOps.", filename, targetWorkItem.Id, _maxAttachmentSize);
+                Log.LogWarning(" [SKIP] Attachment {filename} on Work Item {targetWorkItemId} is bigger than the limit of {maxAttachmentSize} bites for Azure DevOps.", filename, targetWorkItem.Id, Options.MaxAttachmentSize);
             }
         }
 


### PR DESCRIPTION
The system ignored `TfsAttachmentEnricherOptions` and used empty variables instead. This fix removes the empty local variables and always uses the values in `TfsAttachmentEnricherOptions`

For Bug reported by @muradjames and will fix #2003 