### PR TITLE
Fix/tfs attachment enricher unable to export

### DIFF
--- a/src/MigrationTools.Clients.AzureDevops.ObjectModel/ProcessorEnrichers/TfsAttachmentEnricher.cs
+++ b/src/MigrationTools.Clients.AzureDevops.ObjectModel/ProcessorEnrichers/TfsAttachmentEnricher.cs
@@ -19,7 +19,6 @@ namespace MigrationTools.ProcessorEnrichers
 {
     public class TfsAttachmentEnricher : WorkItemProcessorEnricher, IAttachmentMigrationEnricher
     {
-        private WorkItemServer _server;
         private string _exportWiPath;
         private TfsAttachmentEnricherOptions _options; 
         private WorkItemServer _workItemServer;
@@ -116,7 +115,7 @@ namespace MigrationTools.ProcessorEnrichers
                 Log.LogDebug(string.Format("...downloading {0} to {1}", fname, exportpath));
                 try
                 {
-                    var fileLocation = _server.DownloadFile(wia.Id);
+                    var fileLocation = _workItemServer.DownloadFile(wia.Id);
                     File.Copy(fileLocation, fpath, true);
                 }
                 catch (Exception ex)
@@ -178,7 +177,7 @@ namespace MigrationTools.ProcessorEnrichers
 
         private void SetupWorkItemServer()
         {
-            if (_workItemServer != null)
+            if (_workItemServer == null)
             {
                 IMigrationEngine engine = Services.GetRequiredService<IMigrationEngine>();
                 _workItemServer = engine.Source.GetService<WorkItemServer>();

--- a/src/MigrationTools.Clients.AzureDevops.ObjectModel/ProcessorEnrichers/TfsAttachmentEnricher.cs
+++ b/src/MigrationTools.Clients.AzureDevops.ObjectModel/ProcessorEnrichers/TfsAttachmentEnricher.cs
@@ -21,7 +21,7 @@ namespace MigrationTools.ProcessorEnrichers
     {
         private WorkItemServer _server;
         private string _exportWiPath;
-        private TfsAttachmentEnricherOptions _options;
+        private TfsAttachmentEnricherOptions _options; 
         private WorkItemServer _workItemServer;
 
         public TfsAttachmentEnricherOptions Options {  get { return _options; } } 

--- a/src/MigrationTools.Clients.AzureDevops.ObjectModel/ProcessorEnrichers/TfsAttachmentEnricher.cs
+++ b/src/MigrationTools.Clients.AzureDevops.ObjectModel/ProcessorEnrichers/TfsAttachmentEnricher.cs
@@ -20,9 +20,7 @@ namespace MigrationTools.ProcessorEnrichers
     public class TfsAttachmentEnricher : WorkItemProcessorEnricher, IAttachmentMigrationEnricher
     {
         private WorkItemServer _server;
-        private string _exportBasePath;
         private string _exportWiPath;
-        private int _maxAttachmentSize;
         private TfsAttachmentEnricherOptions _options;
         private WorkItemServer _workItemServer;
 
@@ -30,7 +28,7 @@ namespace MigrationTools.ProcessorEnrichers
 
         public TfsAttachmentEnricher(IServiceProvider services, ILogger<WorkItemProcessorEnricher> logger) : base(services, logger)
         {
-             
+          
         }
 
         public void ProcessAttachemnts(WorkItemData source, WorkItemData target, bool save = true)
@@ -46,7 +44,7 @@ namespace MigrationTools.ProcessorEnrichers
                 throw new ArgumentNullException(nameof(target));
             }
             Log.LogInformation("AttachmentMigrationEnricher: Migrating  {AttachmentCount} attachemnts from {SourceWorkItemID} to {TargetWorkItemID}", source.ToWorkItem().Attachments.Count, source.Id, target.Id);
-            _exportWiPath = Path.Combine(_exportBasePath, source.ToWorkItem().Id.ToString());
+            _exportWiPath = Path.Combine(Options.ExportBasePath, source.ToWorkItem().Id.ToString());
             if (Directory.Exists(_exportWiPath))
             {
                 Directory.Delete(_exportWiPath, true);
@@ -139,7 +137,7 @@ namespace MigrationTools.ProcessorEnrichers
             SetupWorkItemServer();
             var filename = Path.GetFileName(filepath);
             FileInfo fi = new FileInfo(filepath);
-            if (_maxAttachmentSize > fi.Length)
+            if (Options.MaxAttachmentSize > fi.Length)
             {
                 string originalId = "[originalId:" + wia.Id + "]";
                 var attachments = targetWorkItem.Attachments.Cast<Attachment>();
@@ -169,7 +167,7 @@ namespace MigrationTools.ProcessorEnrichers
             }
             else
             {
-                Log.LogWarning(" [SKIP] Attachment {filename} on Work Item {targetWorkItemId} is bigger than the limit of {maxAttachmentSize} bites for Azure DevOps.", filename, targetWorkItem.Id, _maxAttachmentSize);
+                Log.LogWarning(" [SKIP] Attachment {filename} on Work Item {targetWorkItemId} is bigger than the limit of {maxAttachmentSize} bites for Azure DevOps.", filename, targetWorkItem.Id, Options.MaxAttachmentSize);
             }
         }
 


### PR DESCRIPTION
From: @jacobmalliet

Resolves an issue with the `TfsAttachmentEnricher` where `_server` instance was always `null`. This seemingly occurred because of a duplicate `WorkItemServer` instance variable `_workItemServer`.

After attempting to use `workItemServer` instead, I found that it was also not being set properly because of a null comparison being done incorrectly.

This change removes the duplicate `WorkItemServer` variable and properly initializes the `_workItemServer` before exporting attachments.

First time contributing so let me know if you need anything else changed here.