### PR TITLE
[preview] Images Not Correctly Migrated from TFS Server URLs Containing Spaces

### DIFF
--- a/src/MigrationTools.Clients.AzureDevops.ObjectModel/Enrichers/TfsEmbededImagesEnricher.cs
+++ b/src/MigrationTools.Clients.AzureDevops.ObjectModel/Enrichers/TfsEmbededImagesEnricher.cs
@@ -56,7 +56,7 @@ namespace MigrationTools.Enrichers
         [Obsolete]
         public override int Enrich(WorkItemData sourceWorkItem, WorkItemData targetWorkItem)
         {
-            FixEmbededImages(targetWorkItem, Engine.Source.Config.AsTeamProjectConfig().Collection.ToString(), Engine.Target.Config.AsTeamProjectConfig().Collection.ToString(), Engine.Source.Config.AsTeamProjectConfig().PersonalAccessToken);
+            FixEmbededImages(targetWorkItem, Engine.Source.Config.AsTeamProjectConfig().Collection.AbsoluteUri, Engine.Target.Config.AsTeamProjectConfig().Collection.AbsoluteUri, Engine.Source.Config.AsTeamProjectConfig().PersonalAccessToken);
             return 0;
         }
 


### PR DESCRIPTION
Fixes #2050 

The method Uri.ToString() fails to encode spaces as %20, leading to incorrect outcomes in URL comparisons. To address this, I have modified the code to use Uri.AbsoluteUri, which correctly encodes the URL. This change ensures that the comparison operates as expected in the following code snipped.

` if (!match.Value.ToLower().Contains(oldTfsurl.ToLower()) && !match.Value.ToLower().Contains(oldTfsurlOppositeSchema.ToLower()))
`