### PR TITLE
[preview] SoapException: VS402625: Dates must be increasing with each revision

### DIFF
--- a/src/MigrationTools/MigrationEngine.cs
+++ b/src/MigrationTools/MigrationEngine.cs
@@ -36,7 +36,7 @@ namespace MigrationTools
             ILogger<MigrationEngine> logger)
         {
             _logger = logger;
-            _logger.LogInformation("Creating Migration Engine {SessionId}", telemetry.SessionId);
+            _logger.LogInformation("Creating Migration Engine Session[{SessionId}] on {datetime}", telemetry.SessionId, DateTime.Now);
             _services = services;
             FieldMaps = fieldMaps;
             _networkCredentials = networkCredentials.Value;

--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemMigrationContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemMigrationContext.cs
@@ -812,10 +812,6 @@ namespace VstsSyncMigrator.Engine
                     }
                     // Impersonate revision author. Mapping will apply later and may change this.
                     targetWorkItem.ToWorkItem().Fields["System.ChangedDate"].Value = revision.Fields["System.ChangedDate"].Value;
-                    if (targetWorkItem.ToWorkItem().Fields.Contains("System.RevisedDate"))
-                    {
-                        targetWorkItem.ToWorkItem().Fields["System.RevisedDate"].Value = revision.Fields["System.ChangedDate"].Value;
-                    }
                     targetWorkItem.ToWorkItem().Fields["System.ChangedBy"].Value = revision.Fields["System.ChangedBy"].Value.ToString();
                     targetWorkItem.ToWorkItem().Fields["System.History"].Value = revision.Fields["System.History"].Value;
 

--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemMigrationContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemMigrationContext.cs
@@ -812,6 +812,10 @@ namespace VstsSyncMigrator.Engine
                     }
                     // Impersonate revision author. Mapping will apply later and may change this.
                     targetWorkItem.ToWorkItem().Fields["System.ChangedDate"].Value = revision.Fields["System.ChangedDate"].Value;
+                    if (targetWorkItem.ToWorkItem().Fields.Contains("System.RevisedDate"))
+                    {
+                        targetWorkItem.ToWorkItem().Fields["System.RevisedDate"].Value = revision.Fields["System.ChangedDate"].Value;
+                    }
                     targetWorkItem.ToWorkItem().Fields["System.ChangedBy"].Value = revision.Fields["System.ChangedBy"].Value.ToString();
                     targetWorkItem.ToWorkItem().Fields["System.History"].Value = revision.Fields["System.History"].Value;
 


### PR DESCRIPTION
Added potential fix for Aditional `SoapException: VS402625: Dates must be increasing with each revision` error. Updated `System.RevisedDate` with the same revised date if the field exists on the target.