### PR TITLE
Update Marketplace Package to better version number

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -205,7 +205,7 @@ jobs:
         shell: pwsh
         if: ${{ steps.Build.outcome == 'success' }}
         run: |
-            .\build\packageExtension.ps1 -version ${{ env.GitVersion_MajorMinorPatch }}.${{ env.GitVersion_PreReleaseNumber }} -outfolder "./staging" 
+            .\build\packageExtension.ps1 -version ${{ env.GitVersion_AssemblySemVer }} -outfolder "./staging" 
       - name: "List Package Files"
         shell: pwsh
         if: ${{ steps.Build.outcome == 'success' }}


### PR DESCRIPTION
🔧 (main.yml): update versioning scheme in packageExtension script

Switch the versioning scheme from `GitVersion_MajorMinorPatch` and `GitVersion_PreReleaseNumber` to `GitVersion_AssemblySemVer` for better alignment with semantic versioning practices. This change ensures that the versioning is more consistent and easier to manage.