### PR TITLE
Missing services

### DIFF
--- a/src/MigrationTools.Host/MigrationToolHost.cs
+++ b/src/MigrationTools.Host/MigrationToolHost.cs
@@ -121,7 +121,10 @@ namespace MigrationTools.Host
                  services.AddTransient<IDetectOnlineService, DetectOnlineService>();
                  //services.AddTransient<IDetectVersionService, DetectVersionService>();
                  services.AddTransient<IDetectVersionService2, DetectVersionService2>();
-                 
+
+                 services.AddSingleton<IMigrationToolVersionInfo, MigrationToolVersionInfo>();
+                 services.AddSingleton<IMigrationToolVersion, MigrationToolVersion>();
+
 
                  // Config
                  services.AddSingleton<IEngineConfigurationBuilder, EngineConfigurationBuilder>();


### PR DESCRIPTION
✨ (MigrationToolHost.cs): add singleton services for migration tool version info and version

Adding `IMigrationToolVersionInfo` and `IMigrationToolVersion` as singleton services ensures that these instances are shared across the application, improving efficiency and consistency in accessing version information.