### PR TITLE
Error in TfsWorkItemConvertor and Null reference in WorkItemMigrationContext

### DIFF
--- a/src/MigrationTools.Clients.AzureDevops.ObjectModel/Endpoints/TfsWorkItemConvertor.cs
+++ b/src/MigrationTools.Clients.AzureDevops.ObjectModel/Endpoints/TfsWorkItemConvertor.cs
@@ -60,7 +60,7 @@ namespace MigrationTools.Endpoints
             }
             catch (ArgumentException e)
             {
-                Log.Warning(e, "For some Reason there are multiple Revisions on {WorkItemId} with the same System.Rev. We will create a renumbered list...", items[0].WorkItemId);
+                Log.Warning("For some Reason there are multiple Revisions on {WorkItemId} with the same System.Rev. We will create a renumbered list...", items[0].WorkItemId);
                 var currentNumber = -1;
                 foreach (var item in items)
                 {

--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemMigrationContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemMigrationContext.cs
@@ -910,7 +910,7 @@ namespace VstsSyncMigrator.Engine
                 if (targetWorkItem != null)
                 {
                     foreach (Field f in targetWorkItem.ToWorkItem().Fields)
-                        parameters.Add($"{f.ReferenceName} ({f.Name})", f.Value.ToString());
+                        parameters.Add($"{f.ReferenceName} ({f.Name})", f.Value?.ToString());
                 }
                 _telemetry.TrackException(ex, parameters);
                 TraceWriteLine(LogEventLevel.Information, "...FAILED to Save");


### PR DESCRIPTION
🐛 (TfsWorkItemConvertor.cs): fix logging issue by removing exception parameter from Log.Warning

The exception parameter `e` is removed from the `Log.Warning` call because it is not used in the log message. This change ensures that the log message correctly reflects the intended warning without unnecessary information.