### PR TITLE
[Bug]: Target Query not Used

### DIFF
--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemMigrationContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemMigrationContext.cs
@@ -212,7 +212,7 @@ namespace VstsSyncMigrator.Engine
                         Engine.Source.WorkItems.Project.Name, Engine.Target.WorkItems.Project.Name, contextLog);
 
                     sourceWorkItems = ((TfsWorkItemMigrationClient)Engine.Target.WorkItems).FilterExistingWorkItems(
-                        sourceWorkItems, _config.WIQLQuery,
+                        sourceWorkItems, targetWIQLQuery,
                         (TfsWorkItemMigrationClient)Engine.Source.WorkItems);
                     contextLog.Information(
                         "!! After removing all found work items there are {SourceWorkItemCount} remaining to be migrated.",


### PR DESCRIPTION
🐛 (WorkItemMigrationContext.cs): fix variable name from _config.WIQLQuery to targetWIQLQuery

The variable name _config.WIQLQuery is incorrect and should be targetWIQLQuery to match the intended logic and improve code readability. This change ensures that the correct query is used for filtering existing work items, preventing potential migration issues.

Fixes: #2232 