### PR TITLE
all-globs-to-any-file

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -11,7 +11,7 @@ build-action:
 
 enhancement:
 - changed-files:
-  - all-glob-to-any-file: ['src/**']
+  - all-globs-to-any-file: ['src/**']
 
 enhancement-classic:
 - changed-files:


### PR DESCRIPTION
🔧 (labeler.yml): correct typo in labeler configuration
Fixes a typo in the labeler configuration file. The key `all-glob-to-any-file` is corrected to `all-globs-to-any-file` to ensure proper functionality of the labeler. This change ensures that the labeler correctly identifies changes in the `src` directory for the `enhancement` label.