### PR TITLE
all-globs-to-any-files

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -19,7 +19,7 @@ enhancement-classic:
 
 enhancement-modern:
 - changed-files:
-  - all-globs-to-any-files: ['src/**', '!src/MigrationTools/_EngineV1/**', '!src/VstsSyncMigrator*/**']
+  - all-globs-to-any-file: ['src/**', '!src/MigrationTools/_EngineV1/**', '!src/VstsSyncMigrator*/**']
 
 # Add 'feature' label to any PR where the head branch name starts with `feature` or has a `feature` section in the name
 feature:


### PR DESCRIPTION
🔧 (labeler.yml): correct typo in labeler configuration
Fixes a typo in the labeler configuration file to ensure proper functionality. The key 'all-globs-to-any-files' is corrected to 'all-globs-to-any-file' to match the expected syntax and avoid potential misconfigurations.