### PR TITLE
Fix error on Embeded Link for Work item that does not exist.

### DIFF
--- a/docs/Reference/Generated/MigrationTools.xml
+++ b/docs/Reference/Generated/MigrationTools.xml
@@ -609,32 +609,32 @@
         </member>
         <member name="F:ThisAssembly.Git.Commit">
             <summary>
-            => @"cd49e40"
+            => @"e3c4db3"
             </summary>
         </member>
         <member name="F:ThisAssembly.Git.Sha">
             <summary>
-            => @"cd49e4061f2759b8ba15da035f13f8d39f6dbf0a"
+            => @"e3c4db3b671341c147f9da376578f29329e6f116"
             </summary>
         </member>
         <member name="F:ThisAssembly.Git.CommitDate">
             <summary>
-            => @"2024-07-26T15:59:36+01:00"
+            => @"2024-08-08T15:58:09+01:00"
             </summary>
         </member>
         <member name="F:ThisAssembly.Git.Commits">
             <summary>
-            => @"0"
+            => @"36"
             </summary>
         </member>
         <member name="F:ThisAssembly.Git.Tag">
             <summary>
-            => @"v15.1.6"
+            => @"v15.1.8-Preview.4-36-ge3c4db3"
             </summary>
         </member>
         <member name="F:ThisAssembly.Git.BaseTag">
             <summary>
-            => @"v15.1.6"
+            => @"v15.1.8-Preview.4"
             </summary>
         </member>
         <member name="F:ThisAssembly.Git.BaseVersion.Major">
@@ -649,7 +649,7 @@
         </member>
         <member name="F:ThisAssembly.Git.BaseVersion.Patch">
             <summary>
-            => @"6"
+            => @"8"
             </summary>
         </member>
         <member name="F:ThisAssembly.Git.SemVer.Major">
@@ -664,17 +664,17 @@
         </member>
         <member name="F:ThisAssembly.Git.SemVer.Patch">
             <summary>
-            => @"6"
+            => @"44"
             </summary>
         </member>
         <member name="F:ThisAssembly.Git.SemVer.Label">
             <summary>
-            => @""
+            => @"Preview.4"
             </summary>
         </member>
         <member name="F:ThisAssembly.Git.SemVer.DashLabel">
             <summary>
-            => @""
+            => @"-Preview.4"
             </summary>
         </member>
         <member name="F:ThisAssembly.Git.SemVer.Source">

--- a/src/MigrationTools.Clients.AzureDevops.ObjectModel/Enrichers/TfsWorkItemEmbededLinkEnricher.cs
+++ b/src/MigrationTools.Clients.AzureDevops.ObjectModel/Enrichers/TfsWorkItemEmbededLinkEnricher.cs
@@ -91,7 +91,7 @@ namespace MigrationTools.Enrichers
                         {
                             var workItemId = workItemLinkMatch.Groups["id"].Value;
                             Log.LogDebug("{LogTypeName}: Source work item {workItemId} mention link traced on field {fieldName} on target work item {targetWorkItemId}.", LogTypeName, workItemId, field.Name, targetWorkItem.Id);
-                            var sourceLinkWi = Engine.Source.WorkItems.GetWorkItem(workItemId);
+                            var sourceLinkWi = Engine.Source.WorkItems.GetWorkItem(workItemId, false);
                             if (sourceLinkWi != null)
                             {
                                 var linkWI = Engine.Target.WorkItems.FindReflectedWorkItemByReflectedWorkItemId(sourceLinkWi);
@@ -113,7 +113,9 @@ namespace MigrationTools.Enrichers
                             }
                             else
                             {
-                                Log.LogInformation("{LogTypeName}: [SKIP] Source work item {workItemId} mention link on field {fieldName} on target work item {targetWorkItemId} was not found on the source collection.", LogTypeName, workItemId, field.Name, targetWorkItem.Id);
+                                var replaceValue = value;
+                                field.Value = field.Value.ToString().Replace(anchorTagMatch.Value, replaceValue);
+                                Log.LogInformation("{LogTypeName}: [SKIP] Source work item {workItemId} mention link on field {fieldName} was not found on the source collection.", LogTypeName, workItemId, field.Name, targetWorkItem.Id);
                             }
                         }
                         else if ((href.StartsWith("mailto:") || href.StartsWith("#")) && value.StartsWith("@"))

--- a/src/MigrationTools.Clients.AzureDevops.ObjectModel/_Enginev1/Clients/TfsWorkItemMigrationClient.cs
+++ b/src/MigrationTools.Clients.AzureDevops.ObjectModel/_Enginev1/Clients/TfsWorkItemMigrationClient.cs
@@ -142,12 +142,12 @@ namespace MigrationTools._EngineV1.Clients
             throw new NotImplementedException("GetRevision in combination with WorkItemData is buggy");
         }
 
-        public override WorkItemData GetWorkItem(string id)
+        public override WorkItemData GetWorkItem(string id, bool stopOnError = true)
         {
-            return GetWorkItem(int.Parse(id));
+            return GetWorkItem(int.Parse(id), stopOnError);
         }
 
-        public override WorkItemData GetWorkItem(int id)
+        public override WorkItemData GetWorkItem(int id, bool stopOnError = true)
         {
             if (id == 0)
             {
@@ -175,7 +175,10 @@ namespace MigrationTools._EngineV1.Clients
                             { "Time",timer.ElapsedMilliseconds }
                        });
                 Log.Error(ex, "Unable to GetWorkItem with id[{id}]", id);
-                Environment.Exit(-1);
+                if (stopOnError)
+                {
+                    Environment.Exit(-1);
+                }                   
             } finally
             {
                 timer.Stop();

--- a/src/MigrationTools.Tests/Core/Clients/WorkItemMigrationClientMock.cs
+++ b/src/MigrationTools.Tests/Core/Clients/WorkItemMigrationClientMock.cs
@@ -112,7 +112,7 @@ namespace MigrationTools.Clients.Tests
             throw new System.NotImplementedException();
         }
 
-        public WorkItemData GetWorkItem(string id)
+        public WorkItemData GetWorkItem(string id, bool stopOnError = true)
         {
             throw new System.NotImplementedException();
         }
@@ -127,7 +127,7 @@ namespace MigrationTools.Clients.Tests
             throw new System.NotImplementedException();
         }
 
-        public WorkItemData GetWorkItem(int id)
+        public WorkItemData GetWorkItem(int id, bool stopOnError = true)
         {
             throw new System.NotImplementedException();
         }

--- a/src/MigrationTools/_EngineV1/Clients/IWorkItemMigrationClient.cs
+++ b/src/MigrationTools/_EngineV1/Clients/IWorkItemMigrationClient.cs
@@ -16,9 +16,9 @@ namespace MigrationTools._EngineV1.Clients
 
         List<WorkItemData> GetWorkItems();
 
-        WorkItemData GetWorkItem(string id);
+        WorkItemData GetWorkItem(string id, bool stopOnError = true);
 
-        WorkItemData GetWorkItem(int id);
+        WorkItemData GetWorkItem(int id, bool stopOnError = true);
 
         List<int> GetWorkItemIds(string WIQLQuery);
 

--- a/src/MigrationTools/_EngineV1/Clients/WorkItemMigrationClientBase.cs
+++ b/src/MigrationTools/_EngineV1/Clients/WorkItemMigrationClientBase.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using MigrationTools._EngineV1.Configuration;
 using MigrationTools._EngineV1.DataContracts;
@@ -44,9 +44,9 @@ namespace MigrationTools._EngineV1.Clients
 
         public abstract WorkItemData GetRevision(WorkItemData workItem, int revision);
 
-        public abstract WorkItemData GetWorkItem(string id);
+        public abstract WorkItemData GetWorkItem(string id, bool stopOnError = true);
 
-        public abstract WorkItemData GetWorkItem(int id);
+        public abstract WorkItemData GetWorkItem(int id, bool stopOnError = true);
 
         public abstract List<WorkItemData> GetWorkItems();
 


### PR DESCRIPTION
♻️ (MigrationTools): refactor GetWorkItem method to include stopOnError parameter

The GetWorkItem method now includes an optional stopOnError parameter, which defaults to true. This change allows for more flexible error handling by enabling the caller to decide whether the application should exit on error or continue execution. This is particularly useful for scenarios where non-critical errors should not halt the entire migration process. Additionally, updated the corresponding tests and interfaces to accommodate this new parameter.