### PR TITLE
Remove failing code from release

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -314,11 +314,7 @@ jobs:
         run: |
              if ($Env:nkdAgility_Ring -eq 'Release') {
                 echo "discussion_category_name=Anouncement" >> $env:GITHUB_OUTPUT    
-             }
-             . .\build\include\Get-ReleaseDescription.ps1
-             $description = Get-ReleaseDescription -mode log -OPEN_AI_KEY ${{ secrets.OPENAI_API_KEY }}
-             echo "release_description=$description" >> $env:GITHUB_OUTPUT    
-             
+             }             
       - name: Release
         uses: softprops/action-gh-release@v2
         with:


### PR DESCRIPTION
🔧 (main.yml): remove redundant release description generation step
The step to generate a release description using the Get-ReleaseDescription script and the OpenAI API key is removed. This simplifies the workflow by eliminating unnecessary complexity and potential points of failure. The focus is now on the essential steps required for the release process.