### PR TITLE
[Fix] Prompt for Credentails

### DIFF
--- a/src/MigrationTools.Clients.AzureDevops.ObjectModel/_Enginev1/Clients/TfsMigrationClient.cs
+++ b/src/MigrationTools.Clients.AzureDevops.ObjectModel/_Enginev1/Clients/TfsMigrationClient.cs
@@ -4,6 +4,7 @@ using System.Net;
 using Microsoft.ApplicationInsights.DataContracts;
 using Microsoft.TeamFoundation;
 using Microsoft.TeamFoundation.Client;
+using Microsoft.VisualStudio.Services.Client;
 using Microsoft.VisualStudio.Services.Common;
 using Microsoft.VisualStudio.Services.WebApi;
 using MigrationTools._EngineV1.Configuration;
@@ -141,7 +142,9 @@ namespace MigrationTools._EngineV1.Clients
 
                     case AuthenticationMode.Prompt:
                         Log.Information("Prompting for credentials ");
-                        y = new TfsTeamProjectCollection(TfsConfig.Collection);
+                        _vssCredentials = new VssClientCredentials();
+                        _vssCredentials.PromptType = CredentialPromptType.PromptIfNeeded; ;
+                        y = new TfsTeamProjectCollection(TfsConfig.Collection, _vssCredentials);
                         break;
 
                     default:


### PR DESCRIPTION
✨ (TfsMigrationClient.cs): add support for VssClientCredentials in Prompt authentication mode

Import the `Microsoft.VisualStudio.Services.Client` namespace and use `VssClientCredentials` with `PromptIfNeeded` to enhance the authentication process. This change ensures that credentials are prompted only when necessary, improving user experience and security.

 !reported by @v-prvusi999
Discussed in #2303
Closes #2307