### PR TITLE
🔧 (main.yml): remove trailing slash from docs_baseURL for consistency

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -122,7 +122,7 @@ jobs:
                     $Ring = "Preview";
                     $WingetApplicationId = "nkdagility.azure-devops-migration-tools.Preview";
                     $docs_deploy_folder = "./azure-devops-migration-tools/preview/";
-                    $docs_baseURL = "/learn/azure-devops-migration-tools/preview/"
+                    $docs_baseURL = "/learn/azure-devops-migration-tools/preview"
                     $RunRelease = ( ('${{ inputs.ForceRelease }}' -eq 'true' ) -or ('${{ steps.filter.outputs.src }}' -eq 'true') -or ('${{ steps.filter.outputs.docs }}' -eq 'true') )
                 }
                 default {


### PR DESCRIPTION
The trailing slash is removed from the `docs_baseURL` to ensure consistency in URL formatting and to prevent potential issues with URL resolution in the documentation deployment process.