### PR TITLE
Improve validation for TfsEndpoint PAT tokens and message

### DIFF
--- a/configuration.json
+++ b/configuration.json
@@ -5,7 +5,7 @@
   "MigrationTools": {
     "Version": "16.0",
     "Endpoints": {
-      "Source2": {
+      "Source": {
         "EndpointType": "TfsTeamProjectEndpoint",
         "Collection": "https://dev.azure.com/nkdagility-preview/",
         "Project": "migrationSource1",
@@ -25,7 +25,7 @@
           "IterationPath": "Iteration"
         }
       },
-      "Target2": {
+      "Target": {
         "EndpointType": "TfsTeamProjectEndpoint",
         "Collection": "https://dev.azure.com/nkdagility-preview/",
         "Project": "migrationTest5",
@@ -147,8 +147,8 @@
         "PauseAfterEachWorkItem": false,
         "AttachRevisionHistory": false,
         "GenerateMigrationComment": true,
-        "SourceName": "Source2",
-        "TargetName": "Target2",
+        "SourceName": "Source",
+        "TargetName": "Target",
         "WorkItemIDs": [ 12 ],
         "MaxGracefulFailures": 0,
         "SkipRevisionWithInvalidIterationPath": false,

--- a/configuration.json
+++ b/configuration.json
@@ -6,7 +6,7 @@
     "Version": "16.0",
     "Endpoints": {
       "Source": {
-        "EndpointType": "TfsTeamProjectEndpoint",
+        "EndpointType": "AzureDevOpsEndpoint",
         "Collection": "https://dev.azure.com/nkdagility-preview/",
         "Project": "migrationSource1",
         "AllowCrossProjectLinking": false,
@@ -26,7 +26,7 @@
         }
       },
       "Target": {
-        "EndpointType": "TfsTeamProjectEndpoint",
+        "EndpointType": "AzureDevOpsEndpoint",
         "Collection": "https://dev.azure.com/nkdagility-preview/",
         "Project": "migrationTest5",
         "TfsVersion": "AzureDevOps",

--- a/configuration.json
+++ b/configuration.json
@@ -6,7 +6,7 @@
     "Version": "16.0",
     "Endpoints": {
       "Source": {
-        "EndpointType": "AzureDevOpsEndpoint",
+        "EndpointType": "TfsTeamProjectEndpoint",
         "Collection": "https://dev.azure.com/nkdagility-preview/",
         "Project": "migrationSource1",
         "AllowCrossProjectLinking": false,
@@ -26,7 +26,7 @@
         }
       },
       "Target": {
-        "EndpointType": "AzureDevOpsEndpoint",
+        "EndpointType": "TfsTeamProjectEndpoint",
         "Collection": "https://dev.azure.com/nkdagility-preview/",
         "Project": "migrationTest5",
         "TfsVersion": "AzureDevOps",

--- a/docs/Reference/Generated/MigrationTools.xml
+++ b/docs/Reference/Generated/MigrationTools.xml
@@ -258,32 +258,32 @@
         </member>
         <member name="F:ThisAssembly.Git.Branch">
             <summary>
-            => @"main"
+            => @"topic/validation-refactor"
             </summary>
         </member>
         <member name="F:ThisAssembly.Git.Commit">
             <summary>
-            => @"927c6118"
+            => @"a249caf1"
             </summary>
         </member>
         <member name="F:ThisAssembly.Git.Sha">
             <summary>
-            => @"927c6118f5ad3f11bded4a786e665b57e5aa1ed7"
+            => @"a249caf19931b605c708dd66691cb9ec44a7ccc0"
             </summary>
         </member>
         <member name="F:ThisAssembly.Git.CommitDate">
             <summary>
-            => @"2024-09-14T07:20:22+01:00"
+            => @"2024-09-15T23:18:28+01:00"
             </summary>
         </member>
         <member name="F:ThisAssembly.Git.Commits">
             <summary>
-            => @"0"
+            => @"1"
             </summary>
         </member>
         <member name="F:ThisAssembly.Git.Tag">
             <summary>
-            => @"v16.0.3-Preview.3"
+            => @"v16.0.3-Preview.3-1-ga249caf1"
             </summary>
         </member>
         <member name="F:ThisAssembly.Git.BaseTag">
@@ -318,7 +318,7 @@
         </member>
         <member name="F:ThisAssembly.Git.SemVer.Patch">
             <summary>
-            => @"3"
+            => @"4"
             </summary>
         </member>
         <member name="F:ThisAssembly.Git.SemVer.Label">

--- a/docs/Reference/Generated/MigrationTools.xml
+++ b/docs/Reference/Generated/MigrationTools.xml
@@ -258,37 +258,37 @@
         </member>
         <member name="F:ThisAssembly.Git.Branch">
             <summary>
-            => @"topic/better-validation-message"
+            => @"main"
             </summary>
         </member>
         <member name="F:ThisAssembly.Git.Commit">
             <summary>
-            => @"cfd2ecbc"
+            => @"927c6118"
             </summary>
         </member>
         <member name="F:ThisAssembly.Git.Sha">
             <summary>
-            => @"cfd2ecbc75ebef85edf99afce6ae914752457888"
+            => @"927c6118f5ad3f11bded4a786e665b57e5aa1ed7"
             </summary>
         </member>
         <member name="F:ThisAssembly.Git.CommitDate">
             <summary>
-            => @"2024-09-14T07:08:51+01:00"
+            => @"2024-09-14T07:20:22+01:00"
             </summary>
         </member>
         <member name="F:ThisAssembly.Git.Commits">
             <summary>
-            => @"2"
+            => @"0"
             </summary>
         </member>
         <member name="F:ThisAssembly.Git.Tag">
             <summary>
-            => @"v16.0.3-Preview.2-2-gcfd2ecbc"
+            => @"v16.0.3-Preview.3"
             </summary>
         </member>
         <member name="F:ThisAssembly.Git.BaseTag">
             <summary>
-            => @"v16.0.3-Preview.2"
+            => @"v16.0.3-Preview.3"
             </summary>
         </member>
         <member name="F:ThisAssembly.Git.BaseVersion.Major">
@@ -318,17 +318,17 @@
         </member>
         <member name="F:ThisAssembly.Git.SemVer.Patch">
             <summary>
-            => @"5"
+            => @"3"
             </summary>
         </member>
         <member name="F:ThisAssembly.Git.SemVer.Label">
             <summary>
-            => @"Preview.2"
+            => @"Preview.3"
             </summary>
         </member>
         <member name="F:ThisAssembly.Git.SemVer.DashLabel">
             <summary>
-            => @"-Preview.2"
+            => @"-Preview.3"
             </summary>
         </member>
         <member name="F:ThisAssembly.Git.SemVer.Source">

--- a/docs/Reference/Generated/MigrationTools.xml
+++ b/docs/Reference/Generated/MigrationTools.xml
@@ -263,27 +263,27 @@
         </member>
         <member name="F:ThisAssembly.Git.Commit">
             <summary>
-            => @"a249caf1"
+            => @"8de62303"
             </summary>
         </member>
         <member name="F:ThisAssembly.Git.Sha">
             <summary>
-            => @"a249caf19931b605c708dd66691cb9ec44a7ccc0"
+            => @"8de6230394166ad9f44bfdbc4fbf304185b2d39e"
             </summary>
         </member>
         <member name="F:ThisAssembly.Git.CommitDate">
             <summary>
-            => @"2024-09-15T23:18:28+01:00"
+            => @"2024-09-15T23:28:00+01:00"
             </summary>
         </member>
         <member name="F:ThisAssembly.Git.Commits">
             <summary>
-            => @"1"
+            => @"3"
             </summary>
         </member>
         <member name="F:ThisAssembly.Git.Tag">
             <summary>
-            => @"v16.0.3-Preview.3-1-ga249caf1"
+            => @"v16.0.3-Preview.3-3-g8de62303"
             </summary>
         </member>
         <member name="F:ThisAssembly.Git.BaseTag">
@@ -318,7 +318,7 @@
         </member>
         <member name="F:ThisAssembly.Git.SemVer.Patch">
             <summary>
-            => @"4"
+            => @"6"
             </summary>
         </member>
         <member name="F:ThisAssembly.Git.SemVer.Label">

--- a/docs/Reference/Generated/MigrationTools.xml
+++ b/docs/Reference/Generated/MigrationTools.xml
@@ -263,27 +263,27 @@
         </member>
         <member name="F:ThisAssembly.Git.Commit">
             <summary>
-            => @"8de62303"
+            => @"a9e012b0"
             </summary>
         </member>
         <member name="F:ThisAssembly.Git.Sha">
             <summary>
-            => @"8de6230394166ad9f44bfdbc4fbf304185b2d39e"
+            => @"a9e012b05801421a57a109dc86b8827c02524855"
             </summary>
         </member>
         <member name="F:ThisAssembly.Git.CommitDate">
             <summary>
-            => @"2024-09-15T23:28:00+01:00"
+            => @"2024-09-15T23:57:44+01:00"
             </summary>
         </member>
         <member name="F:ThisAssembly.Git.Commits">
             <summary>
-            => @"3"
+            => @"6"
             </summary>
         </member>
         <member name="F:ThisAssembly.Git.Tag">
             <summary>
-            => @"v16.0.3-Preview.3-3-g8de62303"
+            => @"v16.0.3-Preview.3-6-ga9e012b0"
             </summary>
         </member>
         <member name="F:ThisAssembly.Git.BaseTag">
@@ -318,7 +318,7 @@
         </member>
         <member name="F:ThisAssembly.Git.SemVer.Patch">
             <summary>
-            => @"6"
+            => @"9"
             </summary>
         </member>
         <member name="F:ThisAssembly.Git.SemVer.Label">

--- a/src/MigrationTools.Clients.TfsObjectModel.Tests/Processors/TfsWorkItemMigrationProcessorTests.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel.Tests/Processors/TfsWorkItemMigrationProcessorTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace MigrationTools.Processors.Tests
@@ -25,7 +26,10 @@ namespace MigrationTools.Processors.Tests
             var validator = new TfsWorkItemMigrationProcessorOptionsValidator();
             var x = new TfsWorkItemMigrationProcessorOptions();
             x.WIQLQuery = "SELECT [System.Id] FROM WorkItems WHERE [System.TeamProject] = @TeamProject";
-            Assert.IsTrue(validator.Validate(null, x).Succeeded);
+            x.SourceName = "source";
+            x.TargetName = "target";
+            ValidateOptionsResult result = validator.Validate(null, x);
+            Assert.IsTrue(result.Succeeded);
         }
 
     }

--- a/src/MigrationTools.Clients.TfsObjectModel.Tests/ServiceProviderHelper.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel.Tests/ServiceProviderHelper.cs
@@ -58,7 +58,7 @@ namespace MigrationTools.Tests
             {
                 Collection = new Uri("https://dev.azure.com/nkdagility-preview/"),
                 Project = project,
-                Authentication = new TfsAuthenticationOptions()
+                Authentication = new Endpoints.Infrastructure.TfsAuthenticationOptions()
                 {
                     AuthenticationMode = AuthenticationMode.AccessToken,
                     AccessToken = TestingConstants.AccessToken,
@@ -82,7 +82,7 @@ namespace MigrationTools.Tests
             {
                 Collection = new Uri("https://dev.azure.com/nkdagility-preview/"),
                 Project = project,
-                Authentication = new TfsAuthenticationOptions()
+                Authentication = new Endpoints.Infrastructure.TfsAuthenticationOptions()
                 {
                     AuthenticationMode = AuthenticationMode.AccessToken,
                     AccessToken = TestingConstants.AccessToken,

--- a/src/MigrationTools.Clients.TfsObjectModel/EndPoints/Infrastructure/TfsTeamProjectAuthentication.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/EndPoints/Infrastructure/TfsTeamProjectAuthentication.cs
@@ -39,6 +39,13 @@ namespace MigrationTools.Endpoints.Infrastructure
                     if (options.NetworkCredentials == null)
                     {
                         errors.Add("The NetworkCredentials must be provided when AuthenticationMode is set to 'Windows'.");
+                    } else
+                    {
+                        ValidateOptionsResult result = options.NetworkCredentials.Validate(name, options.NetworkCredentials);
+                        if (!result.Succeeded)
+                        {
+                            errors.AddRange(result.Failures);
+                        }
                     }
                     break;
                 case AuthenticationMode.Prompt:

--- a/src/MigrationTools.Clients.TfsObjectModel/EndPoints/Infrastructure/TfsTeamProjectAuthentication.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/EndPoints/Infrastructure/TfsTeamProjectAuthentication.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
 using MigrationTools.Options;
 using MigrationTools.Options.Infrastructure;
 using Newtonsoft.Json;
@@ -11,7 +12,7 @@ using Newtonsoft.Json.Converters;
 
 namespace MigrationTools.Endpoints.Infrastructure
 {
-    public class TfsAuthenticationOptions
+    public class TfsAuthenticationOptions : IValidateOptions<TfsAuthenticationOptions>
     {
         [JsonConverter(typeof(StringEnumConverter))]
         public AuthenticationMode AuthenticationMode { get; set; }
@@ -20,5 +21,37 @@ namespace MigrationTools.Endpoints.Infrastructure
 
         [JsonConverter(typeof(DefaultOnlyConverter<string>), "** removed as a secret ***")]
         public string AccessToken { get; set; }
+
+        public ValidateOptionsResult Validate(string name, TfsAuthenticationOptions options)
+        {
+            var errors = new List<string>();
+            // Validate Authentication properties based on AuthenticationMode
+            switch (options.AuthenticationMode)
+            {
+                case AuthenticationMode.AccessToken:
+                    if (string.IsNullOrWhiteSpace(options.AccessToken))
+                    {
+                        errors.Add("The AccessToken must not be null or empty when AuthenticationMode is set to 'AccessToken'.");
+                    }
+                    break;
+
+                case AuthenticationMode.Windows:
+                    if (options.NetworkCredentials == null)
+                    {
+                        errors.Add("The NetworkCredentials must be provided when AuthenticationMode is set to 'Windows'.");
+                    }
+                    break;
+                case AuthenticationMode.Prompt:
+                    break;
+                default:
+                    errors.Add($"The AuthenticationMode '{options.AuthenticationMode}' is not supported.");
+                    break;
+            }
+            if (errors.Any())
+            {
+                return ValidateOptionsResult.Fail(errors);
+            }
+            return ValidateOptionsResult.Success;
+        }
     }
 }

--- a/src/MigrationTools.Clients.TfsObjectModel/EndPoints/Infrastructure/TfsTeamProjectAuthentication.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/EndPoints/Infrastructure/TfsTeamProjectAuthentication.cs
@@ -31,7 +31,7 @@ namespace MigrationTools.Endpoints.Infrastructure
                 case AuthenticationMode.AccessToken:
                     if (string.IsNullOrWhiteSpace(options.AccessToken))
                     {
-                        errors.Add("The AccessToken must not be null or empty when AuthenticationMode is set to 'AccessToken'.");
+                        errors.Add("The AccessToken must not be null or empty when AuthenticationMode is set to 'AccessToken'. You must provide a PAT to use 'AccessToken' as the authentication mode. You can set this through the config at 'MigrationTools:Endpoints:{name}:Authentication:AccessToken', or you can set an environment variable of 'MigrationTools__Endpoints__{name}__Authentication__AccessToken'. Check the docs on https://nkdagility.com/learn/azure-devops-migration-tools/Reference/Endpoints/TfsTeamProjectEndpoint/");
                     }
                     break;
 

--- a/src/MigrationTools.Clients.TfsObjectModel/Endpoints/TfsEndpointOptions.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/Endpoints/TfsEndpointOptions.cs
@@ -56,7 +56,7 @@ namespace MigrationTools.Endpoints
             // Validate ReflectedWorkItemIdField - Must not be null or empty
             if (string.IsNullOrWhiteSpace(options.ReflectedWorkItemIdField))
             {
-                errors.Add("The ReflectedWorkItemIdField property must not be null or empty.");
+                errors.Add("The ReflectedWorkItemIdField property must not be null or empty. Check the docs on https://nkdagility.com/learn/azure-devops-migration-tools/setup/reflectedworkitemid/");
             }
 
             // Validate LanguageMaps - Must exist

--- a/src/MigrationTools.Clients.TfsObjectModel/Endpoints/TfsEndpointOptions.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/Endpoints/TfsEndpointOptions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using System.Linq;
 using Microsoft.Extensions.Options;
 using MigrationTools.Endpoints.Infrastructure;
 using Newtonsoft.Json;
@@ -63,6 +64,14 @@ namespace MigrationTools.Endpoints
             {
                 errors.Add("The LanguageMaps property must exist.");
             }
+            else
+            {
+               ValidateOptionsResult lmr= options.LanguageMaps.Validate(name, options.LanguageMaps);
+                if (lmr != ValidateOptionsResult.Success)
+                {
+                    errors.AddRange(lmr.Failures);
+                }
+            }
 
             // Validate Authentication - Must exist
             if (options.Authentication == null)
@@ -71,34 +80,17 @@ namespace MigrationTools.Endpoints
             }
             else
             {
-                // Validate Authentication properties based on AuthenticationMode
-                switch (options.Authentication.AuthenticationMode)
+                ValidateOptionsResult lmr = options.Authentication.Validate(name, options.Authentication);
+                if (lmr != ValidateOptionsResult.Success)
                 {
-                    case AuthenticationMode.AccessToken:
-                        if (string.IsNullOrWhiteSpace(options.Authentication.AccessToken))
-                        {
-                            errors.Add("The AccessToken must not be null or empty when AuthenticationMode is set to 'AccessToken'.");
-                        }
-                        break;
-
-                    case AuthenticationMode.Windows:
-                        if (options.Authentication.NetworkCredentials == null)
-                        {
-                            errors.Add("The NetworkCredentials must be provided when AuthenticationMode is set to 'Windows'.");
-                        }
-                        break;
-                    case AuthenticationMode.Prompt:
-                        break;
-                    default:
-                        errors.Add($"The AuthenticationMode '{options.Authentication.AuthenticationMode}' is not supported.");
-                        break;
+                    errors.AddRange(lmr.Failures);
                 }
             }
 
             // Return failure if there are errors, otherwise success
-            if (errors.Count > 0)
+            if (errors.Any())
             {
-                return ValidateOptionsResult.Fail(string.Join(Environment.NewLine, errors));
+                return ValidateOptionsResult.Fail(errors);
             }
 
             return ValidateOptionsResult.Success;

--- a/src/MigrationTools.Clients.TfsObjectModel/Endpoints/TfsLanguageMapOptions.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/Endpoints/TfsLanguageMapOptions.cs
@@ -1,8 +1,31 @@
-﻿namespace MigrationTools.Endpoints
+﻿using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.Options;
+
+namespace MigrationTools.Endpoints
 {
-    public class TfsLanguageMapOptions
+    public class TfsLanguageMapOptions : IValidateOptions<TfsLanguageMapOptions>
     {
         public string AreaPath { get; set; }
         public string IterationPath { get; set; }
+
+        public ValidateOptionsResult Validate(string name, TfsLanguageMapOptions options)
+        {
+            var errors = new List<string>();
+
+            if (string.IsNullOrWhiteSpace(options.AreaPath))
+            {
+                errors.Add("The AreaPath property must not be null or empty.");
+            }
+            if (string.IsNullOrWhiteSpace(options.IterationPath))
+            {
+                errors.Add("The IterationPath property must not be null or empty.");
+            }
+            if (errors.Any())
+            {
+                ValidateOptionsResult.Fail(errors);
+            }
+            return ValidateOptionsResult.Success;
+        }
     }
 }

--- a/src/MigrationTools.Clients.TfsObjectModel/Processors/Infra/TfsProcessor.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/Processors/Infra/TfsProcessor.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.Options;
 using MigrationTools;
 using MigrationTools.Clients;
 using MigrationTools.Enrichers;
+using MigrationTools.Exceptions;
 using MigrationTools.Tools;
 
 namespace MigrationTools.Processors.Infrastructure
@@ -19,9 +20,31 @@ namespace MigrationTools.Processors.Infrastructure
   
         }
 
-        new public TfsTeamProjectEndpoint Source => (TfsTeamProjectEndpoint)base.Source;
+        new public TfsTeamProjectEndpoint Source
+        {
+            get
+            {
+                var endpoint = base.Source as TfsTeamProjectEndpoint;
+                if (endpoint == null)
+                {
+                    throw new ConfigurationValidationException(Options, ValidateOptionsResult.Fail($"The Endpoint '{Options.SourceName}' specified for `{this.GetType().Name}` is of the wrong type! {nameof(TfsTeamProjectEndpoint)} was expected."));
+                }
+                return endpoint;
+            }
+        }
 
-        new public TfsTeamProjectEndpoint Target => (TfsTeamProjectEndpoint)base.Target;
+        new public TfsTeamProjectEndpoint Target
+        {
+            get
+            {
+                var endpoint = base.Target as TfsTeamProjectEndpoint;
+                if (endpoint == null)
+                {
+                    throw new ConfigurationValidationException(Options, ValidateOptionsResult.Fail($"The Endpoint '{Options.TargetName}' specified for `{this.GetType().Name}` is of the wrong type! {nameof(TfsTeamProjectEndpoint)} was expected."));
+                }
+                return endpoint;
+            }
+        }
 
         new public TfsCommonTools CommonTools => (TfsCommonTools)base.CommonTools;
 

--- a/src/MigrationTools.Clients.TfsObjectModel/Processors/TfsWorkItemMigrationProcessorOptions.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/Processors/TfsWorkItemMigrationProcessorOptions.cs
@@ -11,7 +11,7 @@ using System.DirectoryServices.AccountManagement;
 namespace MigrationTools.Processors
 {
 
-    public class TfsWorkItemMigrationProcessorOptions : ProcessorOptions, IWorkItemProcessorConfig, IValidateOptions<TfsWorkItemMigrationProcessorOptions>
+    public class TfsWorkItemMigrationProcessorOptions : ProcessorOptions, IWorkItemProcessorConfig
     {
 
 
@@ -102,59 +102,7 @@ namespace MigrationTools.Processors
         /// </summary>
         public bool SkipRevisionWithInvalidAreaPath { get; set; }
 
-        public ValidateOptionsResult Validate(string name, TfsWorkItemMigrationProcessorOptions options)
-        {
-            var errors = new List<string>();
-            ValidateOptionsResult baseResult = base.Validate(name, options);
-            if (baseResult != ValidateOptionsResult.Success)
-            {
-                errors.AddRange(baseResult.Failures);
-            }
-            // Check if WIQLQuery is provided
-            if (string.IsNullOrWhiteSpace(options.WIQLQuery))
-            {
-                errors.Add($"The WIQLQuery on {name} must be provided.");
-            }
-            else
-            {
-                // Validate the presence of required elements in the WIQL query
-                if (!ContainsTeamProjectCondition(options.WIQLQuery))
-                {
-                    errors.Add("The WIQLQuery on {name} must contain the condition '[System.TeamProject] = @TeamProject'.");
-                }
-
-                if (!UsesWorkItemsTable(options.WIQLQuery))
-                {
-                    errors.Add("The WIQLQuery on {name} must use 'WorkItems' after the 'FROM' clause and not 'WorkItemLinks'.");
-                }
-            }
-            if (errors.Count > 0)
-            {
-                return ValidateOptionsResult.Fail(errors);
-            }
-
-            return ValidateOptionsResult.Success;
-        }
-
-        private bool ContainsTeamProjectCondition(string query)
-        {
-            // Regex to match '[System.TeamProject] = @TeamProject'
-            string teamProjectPattern = @"\[System\.TeamProject\]\s*=\s*@TeamProject";
-
-            return Regex.IsMatch(query, teamProjectPattern, RegexOptions.IgnoreCase);
-        }
-
-        // Check if the WIQL query is using 'WorkItems' and not 'WorkItemLinks'
-        private bool UsesWorkItemsTable(string query)
-        {
-            // Regex to ensure that 'FROM WorkItems' exists and 'WorkItemLinks' does not follow the FROM clause
-            string fromWorkItemsPattern = @"FROM\s+WorkItems\b";
-            string fromWorkItemLinksPattern = @"FROM\s+WorkItemLinks\b";
-
-            // Return true if "WorkItems" is used and "WorkItemLinks" is not
-            return Regex.IsMatch(query, fromWorkItemsPattern, RegexOptions.IgnoreCase) &&
-                   !Regex.IsMatch(query, fromWorkItemLinksPattern, RegexOptions.IgnoreCase);
-        }
+        
     }
 
  

--- a/src/MigrationTools.Clients.TfsObjectModel/Processors/TfsWorkItemMigrationProcessorOptionsValidator.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/Processors/TfsWorkItemMigrationProcessorOptionsValidator.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
+
+namespace MigrationTools.Processors
+{
+    public class TfsWorkItemMigrationProcessorOptionsValidator : IValidateOptions<TfsWorkItemMigrationProcessorOptions>
+    {
+        public ValidateOptionsResult Validate(string name, TfsWorkItemMigrationProcessorOptions options)
+        {
+            var errors = new List<string>();
+            ValidateOptionsResult baseResult = options.Validate(name, options);
+            if (baseResult != ValidateOptionsResult.Success)
+            {
+                errors.AddRange(baseResult.Failures);
+            }
+            // Check if WIQLQuery is provided
+            if (string.IsNullOrWhiteSpace(options.WIQLQuery))
+            {
+                errors.Add($"The WIQLQuery on {name} must be provided.");
+            }
+            else
+            {
+                // Validate the presence of required elements in the WIQL query
+                if (!ContainsTeamProjectCondition(options.WIQLQuery))
+                {
+                    errors.Add("The WIQLQuery on {name} must contain the condition '[System.TeamProject] = @TeamProject'.");
+                }
+
+                if (!UsesWorkItemsTable(options.WIQLQuery))
+                {
+                    errors.Add("The WIQLQuery on {name} must use 'WorkItems' after the 'FROM' clause and not 'WorkItemLinks'.");
+                }
+            }
+            if (errors.Count > 0)
+            {
+                return ValidateOptionsResult.Fail(errors);
+            }
+
+            return ValidateOptionsResult.Success;
+        }
+
+        private bool ContainsTeamProjectCondition(string query)
+        {
+            // Regex to match '[System.TeamProject] = @TeamProject'
+            string teamProjectPattern = @"\[System\.TeamProject\]\s*=\s*@TeamProject";
+
+            return Regex.IsMatch(query, teamProjectPattern, RegexOptions.IgnoreCase);
+        }
+
+        // Check if the WIQL query is using 'WorkItems' and not 'WorkItemLinks'
+        private bool UsesWorkItemsTable(string query)
+        {
+            // Regex to ensure that 'FROM WorkItems' exists and 'WorkItemLinks' does not follow the FROM clause
+            string fromWorkItemsPattern = @"FROM\s+WorkItems\b";
+            string fromWorkItemLinksPattern = @"FROM\s+WorkItemLinks\b";
+
+            // Return true if "WorkItems" is used and "WorkItemLinks" is not
+            return Regex.IsMatch(query, fromWorkItemsPattern, RegexOptions.IgnoreCase) &&
+                   !Regex.IsMatch(query, fromWorkItemLinksPattern, RegexOptions.IgnoreCase);
+        }
+    }
+}

--- a/src/MigrationTools.Clients.TfsObjectModel/ServiceCollectionExtensions.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/ServiceCollectionExtensions.cs
@@ -35,7 +35,7 @@ namespace MigrationTools
         public static void AddMigrationToolServicesForClientTfs_Processors(this IServiceCollection context)
         {
             context.AddSingleton<TfsWorkItemMigrationProcessor>();
-            context.AddSingleton<IValidateOptions<TfsWorkItemMigrationProcessorOptions>, TfsWorkItemMigrationProcessorOptionsValidator>();
+            context.AddTransient<IValidateOptions<TfsWorkItemMigrationProcessorOptions>, TfsWorkItemMigrationProcessorOptions>();
 
             context.AddSingleton<TfsTestConfigurationsMigrationProcessor>();
             context.AddSingleton<TfsTestPlansAndSuitesMigrationProcessor>();

--- a/src/MigrationTools.Clients.TfsObjectModel/ServiceCollectionExtensions.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/ServiceCollectionExtensions.cs
@@ -35,7 +35,7 @@ namespace MigrationTools
         public static void AddMigrationToolServicesForClientTfs_Processors(this IServiceCollection context)
         {
             context.AddSingleton<TfsWorkItemMigrationProcessor>();
-            context.AddTransient<IValidateOptions<TfsWorkItemMigrationProcessorOptions>, TfsWorkItemMigrationProcessorOptions>();
+            context.AddTransient<IValidateOptions<TfsWorkItemMigrationProcessorOptions>, TfsWorkItemMigrationProcessorOptionsValidator>();
 
             context.AddSingleton<TfsTestConfigurationsMigrationProcessor>();
             context.AddSingleton<TfsTestPlansAndSuitesMigrationProcessor>();

--- a/src/MigrationTools/Endpoints/Infrastructure/EndpointRegistrationExtensions.cs
+++ b/src/MigrationTools/Endpoints/Infrastructure/EndpointRegistrationExtensions.cs
@@ -54,7 +54,7 @@ namespace MigrationTools
                     if (validatorType != null)
                     {
                         var validator = Activator.CreateInstance(validatorType);
-                        var validationResult = InvokeValidator(validator, endpointOptionsInstance);
+                        var validationResult = InvokeValidator(validator, endpointOptionsInstance, endpointName);
                         if (validationResult.Failed)
                         {
                             //throw new OptionsValidationException(endpointName, endpointOptionsType, validationResult.Failures);
@@ -120,10 +120,10 @@ namespace MigrationTools
         }
 
 
-        private static ValidateOptionsResult InvokeValidator(object validator, IEndpointOptions optionsInstance)
+        private static ValidateOptionsResult InvokeValidator(object validator, IEndpointOptions optionsInstance, string name)
         {
             var validateMethod = validator.GetType().GetMethod("Validate");
-            var validationResult = validateMethod?.Invoke(validator, new object[] { null, optionsInstance });
+            var validationResult = validateMethod?.Invoke(validator, new object[] { name, optionsInstance });
 
                 return (ValidateOptionsResult)validationResult;
 

--- a/src/MigrationTools/Exceptions/ConfigurationValidationException.cs
+++ b/src/MigrationTools/Exceptions/ConfigurationValidationException.cs
@@ -10,20 +10,27 @@ namespace MigrationTools.Exceptions
 {
     public class ConfigurationValidationException : Exception
     {
-        public IConfigurationSection ConfigrationSection { get; }
+        public string ConfigrationSectionPath { get; }
         public IOptions OptionsInstance { get; }
         public ValidateOptionsResult ValidationResult { get; }
 
         public ConfigurationValidationException(IConfigurationSection configrationSection, IOptions optionsInstance, ValidateOptionsResult validationResult)
         {
-            ConfigrationSection = configrationSection;
+            ConfigrationSectionPath = configrationSection.Path;
+            OptionsInstance = optionsInstance;
+            ValidationResult = validationResult;
+        }
+
+        public ConfigurationValidationException(IOptions optionsInstance, ValidateOptionsResult validationResult)
+        {
+            ConfigrationSectionPath = optionsInstance.ConfigurationMetadata.PathToInstance;
             OptionsInstance = optionsInstance;
             ValidationResult = validationResult;
         }
 
         public override string ToString()
         {
-            return $"The configuration entry at '{ConfigrationSection.Path}' did not pass validation!\n Please check the following failures:\n -{string.Join("\n-", ValidationResult.Failures)}";
+            return $"The configuration entry at '{ConfigrationSectionPath}' did not pass validation!\n Please check the following failures:\n -{string.Join("\n-", ValidationResult.Failures)}";
         }
 
     }

--- a/src/MigrationTools/Options/NetworkCredentialsOptions.cs
+++ b/src/MigrationTools/Options/NetworkCredentialsOptions.cs
@@ -1,4 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.Options;
 using MigrationTools.Options.Infrastructure;
 using Newtonsoft.Json;
 
@@ -11,12 +14,34 @@ namespace MigrationTools.Options
         public NetworkCredentials Target { get; set; }
     }
 
-    public class NetworkCredentials
+    public class NetworkCredentials : IValidateOptions<NetworkCredentials>
     {
         public string Domain { get; set; }
         public string UserName { get; set; }
 
         [JsonConverter(typeof(DefaultOnlyConverter<string>), "** removed as a secret ***")]
         public string Password { get; set; }
+
+        public ValidateOptionsResult Validate(string name, NetworkCredentials options)
+        {
+            var errors = new List<string>();
+            if (string.IsNullOrWhiteSpace(options.Domain))
+            {
+                errors.Add("The Domain must not be null or empty.");
+            }
+            if (string.IsNullOrWhiteSpace(options.UserName))
+            {
+                errors.Add("The UserName must not be null or empty.");
+            }
+            if (string.IsNullOrWhiteSpace(options.Password))
+            {
+                errors.Add("The Password must not be null or empty.");
+            }
+            if (errors.Any())
+            {
+                return ValidateOptionsResult.Fail(errors);
+            }
+            return ValidateOptionsResult.Success;
+        }
     }
 }

--- a/src/MigrationTools/Processors/Infrastructure/Processor.cs
+++ b/src/MigrationTools/Processors/Infrastructure/Processor.cs
@@ -65,10 +65,10 @@ namespace MigrationTools.Processors.Infrastructure
                 throw new ArgumentException("Endpoint name cannot be null or empty", nameof(name));
             }
                 // Assuming GetRequiredKeyedService throws an exception if the service is not found
-                IEndpoint endpoint = Services.GetRequiredKeyedService<IEndpoint>(name);
+                IEndpoint endpoint = Services.GetKeyedService<IEndpoint>(name);
                 if (endpoint == null)
                 {
-                    Log.LogCritical("Processor::GetEndpoint: The endpoint '{EndpointName}' could not be found.", name);
+                throw new ConfigurationValidationException( Options, ValidateOptionsResult.Fail($"The Endpoint '{name}' specified for `{this.GetType().Name}` was not found."));
                 }
                 return endpoint;
         }

--- a/src/MigrationTools/Processors/Infrastructure/Processor.cs
+++ b/src/MigrationTools/Processors/Infrastructure/Processor.cs
@@ -112,7 +112,6 @@ namespace MigrationTools.Processors.Infrastructure
                 {
                     Status = ProcessingStatus.Failed;
                     ProcessorActivity.SetStatus(ActivityStatusCode.Error);
-                    Telemetry.TrackException(ex, ProcessorActivity.Tags);
                     Log.LogCritical(ex, "Validation of your configuration failed:");
                 }
                 catch (Exception ex)

--- a/src/MigrationTools/Processors/Infrastructure/Processor.cs
+++ b/src/MigrationTools/Processors/Infrastructure/Processor.cs
@@ -105,7 +105,6 @@ namespace MigrationTools.Processors.Infrastructure
                 {
                     Status = ProcessingStatus.Failed;
                     ProcessorActivity.SetStatus(ActivityStatusCode.Error);
-                    Telemetry.TrackException(ex, ProcessorActivity.Tags);
                     Log.LogCritical(ex, "Validation of your configuration failed:");
                 }
                 catch (ConfigurationValidationException ex)

--- a/src/MigrationTools/Processors/Infrastructure/ProcessorOptions.cs
+++ b/src/MigrationTools/Processors/Infrastructure/ProcessorOptions.cs
@@ -9,7 +9,7 @@ using Newtonsoft.Json;
 
 namespace MigrationTools.Processors.Infrastructure
 {
-    public abstract class ProcessorOptions : IProcessorOptions
+    public abstract class ProcessorOptions : IProcessorOptions, IValidateOptions<ProcessorOptions>
     {
         [JsonIgnore]
         public string OptionFor => $"{GetType().Name.Replace("Options", "")}";
@@ -53,6 +53,26 @@ namespace MigrationTools.Processors.Infrastructure
         public bool IsProcessorCompatible(IReadOnlyList<IProcessorConfig> otherProcessors)
         {
             return true;
+        }
+
+        public ValidateOptionsResult Validate(string name, ProcessorOptions options)
+        {
+            var errors = new List<string>();
+            if (string.IsNullOrWhiteSpace(options.SourceName))
+            {
+                errors.Add("The `SourceName` field on {name} must contain a value that matches one of the Endpoint names.");
+            }
+            if (string.IsNullOrWhiteSpace(options.TargetName))
+            {
+                errors.Add("The `TargetName` field on {name} must contain a value that matches one of the Endpoint names.");
+            }
+
+            if (errors.Count > 0)
+            {
+                return ValidateOptionsResult.Fail(errors);
+            }
+
+            return ValidateOptionsResult.Success;
         }
     }
 }


### PR DESCRIPTION
Both @soodgautam and @nkofctg ran into issues with the `when you are migrating to Azure DevOps you MUST provide an PAT so that we can call the REST API for certain actions. For example, we would be unable to deal with a Work item Type change.` message! 

This was due to the `SourceName` and/or `TargetName` on the Processor being set to null. The validator now checks for this!

It now checks for:

- [X] `SourceName` and/or `TargetName` being Set
- [X] `SourceName` and/or `TargetName` existing
- [X] `SourceName` and/or `TargetName` of correct type