### PR TITLE
🔧  centralize log path creation and improve logging

### DIFF
--- a/docs/Reference/Generated/MigrationTools.xml
+++ b/docs/Reference/Generated/MigrationTools.xml
@@ -258,22 +258,22 @@
         </member>
         <member name="F:ThisAssembly.Git.Branch">
             <summary>
-            => @"main"
+            => @"topic/output-log-location"
             </summary>
         </member>
         <member name="F:ThisAssembly.Git.Commit">
             <summary>
-            => @"76c49c7b"
+            => @"718c3190"
             </summary>
         </member>
         <member name="F:ThisAssembly.Git.Sha">
             <summary>
-            => @"76c49c7bd212b11211a22924e6ad4e36339739b8"
+            => @"718c31903c2750f5170ac91a202c51682b4ebb13"
             </summary>
         </member>
         <member name="F:ThisAssembly.Git.CommitDate">
             <summary>
-            => @"2024-09-16T00:57:48+01:00"
+            => @"2024-09-19T09:18:52+01:00"
             </summary>
         </member>
         <member name="F:ThisAssembly.Git.Commits">
@@ -283,12 +283,12 @@
         </member>
         <member name="F:ThisAssembly.Git.Tag">
             <summary>
-            => @"v16.0.4-Preview.2"
+            => @"v16.0.4-Preview.3"
             </summary>
         </member>
         <member name="F:ThisAssembly.Git.BaseTag">
             <summary>
-            => @"v16.0.4-Preview.2"
+            => @"v16.0.4-Preview.3"
             </summary>
         </member>
         <member name="F:ThisAssembly.Git.BaseVersion.Major">
@@ -323,12 +323,12 @@
         </member>
         <member name="F:ThisAssembly.Git.SemVer.Label">
             <summary>
-            => @"Preview.2"
+            => @"Preview.3"
             </summary>
         </member>
         <member name="F:ThisAssembly.Git.SemVer.DashLabel">
             <summary>
-            => @"-Preview.2"
+            => @"-Preview.3"
             </summary>
         </member>
         <member name="F:ThisAssembly.Git.SemVer.Source">

--- a/src/MigrationTools.Host/Commands/CommandBase.cs
+++ b/src/MigrationTools.Host/Commands/CommandBase.cs
@@ -105,6 +105,7 @@ namespace MigrationTools.Host.Commands
                     Lifetime.StopApplication();
                     CommandActivity?.Stop();
                     _logger.LogInformation("Command {CommandName} completed in {Elapsed}", this.GetType().Name, CommandActivity?.Duration);
+                    _logger.LogInformation("Check the logs for errors: {LogPath}", LogLocationService.GetLogPath());
                 }
 
             }
@@ -196,6 +197,7 @@ namespace MigrationTools.Host.Commands
             _logger.LogInformation("Running with settings: {@settings}", settings);
             _logger.LogInformation("OSVersion: {OSVersion}", Environment.OSVersion.ToString());
             _logger.LogInformation("Version (Assembly): {Version}", _MigrationToolVersion.GetRunningVersion().versionString);
+            _logger.LogInformation("Logpath: {LogPath}", LogLocationService.GetLogPath());
         }
 
 

--- a/src/MigrationTools/Services/LogLocationService.cs
+++ b/src/MigrationTools/Services/LogLocationService.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using System.Text;
+
+namespace MigrationTools.Services
+{
+   public class LogLocationService
+    {
+       private static string logDate = DateTime.Now.ToString("yyyyMMddHHmmss");
+
+
+       private static string _logsPath = CreateLogsPath();
+
+        public static string GetLogPath()
+        {
+            // Check if the string has been generated.
+            if (_logsPath == null)
+            {
+                // Generate the string at runtime (e.g., any custom logic).
+                _logsPath = CreateLogsPath();
+            }
+
+            // Return the _logsPath string.
+            return _logsPath;
+        }
+
+        private static string CreateLogsPath()
+        {
+            string exportPath;
+            string assPath = Assembly.GetEntryAssembly().Location;
+            exportPath = Path.Combine(Path.GetDirectoryName(assPath), "logs", logDate);
+            if (!Directory.Exists(exportPath))
+            {
+                Directory.CreateDirectory(exportPath);
+            }
+
+            return exportPath;
+        }
+    }
+}


### PR DESCRIPTION
- change the rolling interval on the main log to hourly, and to rollOnFileSizeLimit
- change the rolling interval on the error log to daily
- Added the log path to the output, beginning and end.