### PR TITLE
🐛 (TfsEndpointOptions.cs): improve URL validation logic for Collection property

### DIFF
--- a/src/MigrationTools.Clients.TfsObjectModel/Endpoints/TfsEndpointOptions.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/Endpoints/TfsEndpointOptions.cs
@@ -42,9 +42,14 @@ namespace MigrationTools.Endpoints
             {
                 errors.Add("The Collection property must not be null.");
             }
-            else if (!Uri.IsWellFormedUriString(options.Collection.ToString(), UriKind.Absolute))
+            else
             {
-                errors.Add("The Collection property must be a valid URL.");
+                Uri output;
+                if (!Uri.TryCreate(options.Collection.ToString(), UriKind.Absolute, out output))
+                {
+                    errors.Add("The Collection property must be a valid URL.");
+                }
+
             }
 
             // Validate Project - Must not be null or empty
@@ -66,7 +71,7 @@ namespace MigrationTools.Endpoints
             }
             else
             {
-               ValidateOptionsResult lmr= options.LanguageMaps.Validate(name, options.LanguageMaps);
+                ValidateOptionsResult lmr = options.LanguageMaps.Validate(name, options.LanguageMaps);
                 if (lmr != ValidateOptionsResult.Success)
                 {
                     errors.AddRange(lmr.Failures);

--- a/src/MigrationTools.Clients.TfsObjectModel/Endpoints/TfsEndpointOptions.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/Endpoints/TfsEndpointOptions.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
+using System.Text.Encodings.Web;
 using Microsoft.Extensions.Options;
 using MigrationTools.Endpoints.Infrastructure;
 using Newtonsoft.Json;
@@ -44,8 +45,8 @@ namespace MigrationTools.Endpoints
             }
             else
             {
-                Uri output;
-                if (!Uri.TryCreate(options.Collection.ToString(), UriKind.Absolute, out output))
+                Uri output; 
+                if (!Uri.TryCreate(Uri.UnescapeDataString(options.Collection.ToString()), UriKind.Absolute, out output))
                 {
                     errors.Add("The Collection property must be a valid URL.");
                 }


### PR DESCRIPTION

The previous implementation used `Uri.IsWellFormedUriString` which is less robust. The new implementation uses `Uri.TryCreate` to ensure the Collection property is a valid URL, providing more accurate validation and error handling. This change enhances the reliability of the URL validation process.