### PR TITLE
 refactor exception handling and update XML references

### DIFF
--- a/docs/Reference/Generated/MigrationTools.xml
+++ b/docs/Reference/Generated/MigrationTools.xml
@@ -263,32 +263,32 @@
         </member>
         <member name="F:ThisAssembly.Git.Commit">
             <summary>
-            => @"23fae28b"
+            => @"d589bdde"
             </summary>
         </member>
         <member name="F:ThisAssembly.Git.Sha">
             <summary>
-            => @"23fae28bfbd54ac74475334e64dc733a9fd28131"
+            => @"d589bdde1734dae65833f224ebccf08406e037b3"
             </summary>
         </member>
         <member name="F:ThisAssembly.Git.CommitDate">
             <summary>
-            => @"2024-09-24T15:02:38+01:00"
+            => @"2024-10-03T08:34:11+01:00"
             </summary>
         </member>
         <member name="F:ThisAssembly.Git.Commits">
             <summary>
-            => @"4"
+            => @"3"
             </summary>
         </member>
         <member name="F:ThisAssembly.Git.Tag">
             <summary>
-            => @"v16.0.4-Preview.5-4-g23fae28b"
+            => @"v16.0.4-Preview.6-3-gd589bdde"
             </summary>
         </member>
         <member name="F:ThisAssembly.Git.BaseTag">
             <summary>
-            => @"v16.0.4-Preview.5"
+            => @"v16.0.4-Preview.6"
             </summary>
         </member>
         <member name="F:ThisAssembly.Git.BaseVersion.Major">
@@ -318,17 +318,17 @@
         </member>
         <member name="F:ThisAssembly.Git.SemVer.Patch">
             <summary>
-            => @"8"
+            => @"7"
             </summary>
         </member>
         <member name="F:ThisAssembly.Git.SemVer.Label">
             <summary>
-            => @"Preview.5"
+            => @"Preview.6"
             </summary>
         </member>
         <member name="F:ThisAssembly.Git.SemVer.DashLabel">
             <summary>
-            => @"-Preview.5"
+            => @"-Preview.6"
             </summary>
         </member>
         <member name="F:ThisAssembly.Git.SemVer.Source">

--- a/src/MigrationTools/Exceptions/MigrationToolsException.cs
+++ b/src/MigrationTools/Exceptions/MigrationToolsException.cs
@@ -2,10 +2,18 @@
 using System.Collections.Generic;
 using System.Text;
 using Elmah.Io.Client;
+using static MigrationTools.Exceptions.MigrationToolsException;
 
 namespace MigrationTools.Exceptions
 {
-    
+
+    public static class MigrationToolsExceptionExtensions
+    {
+        public static MigrationToolsException AsMigrationToolsException(this Exception ex, ExceptionSource errorSource)
+        {
+            return new MigrationToolsException(ex, errorSource);
+        }
+    }
 
     public class MigrationToolsException : Exception
     {


### PR DESCRIPTION
♻️ (MigrationTools): refactor exception handling and update XML references

Update the XML documentation to reflect the latest commit and tag information, ensuring that the documentation remains accurate and up-to-date. This change is necessary to maintain consistency with the current state of the codebase.

Refactor exception handling in `TfsNodeStructureTool.cs` by introducing an extension method `AsMigrationToolsException`. This improves code readability and reduces redundancy by centralizing the conversion of exceptions to `MigrationToolsException`. The refactoring also removes unused imports and redundant code, streamlining the codebase for better maintainability.

Should fix #2406