### PR TITLE
Validator for TfsGitRepositoryTool and honor the enabled:false

### DIFF
--- a/src/MigrationTools.Clients.TfsObjectModel/Tools/TfsGitRepositoryTool.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/Tools/TfsGitRepositoryTool.cs
@@ -78,6 +78,11 @@ namespace MigrationTools.Tools
             {
                 throw new ArgumentNullException(nameof(targetWorkItem));
             }
+            if (!Options.Enabled)
+            {
+                Log.LogWarning("TfsGitRepositoryEnricher is not enabled! We will not fix any git commit links in Work items and they will be ignored.");
+                return 0;
+            }
 
             Log.LogInformation("GitRepositoryEnricher: Enriching {Id} To fix Git Repo Links", targetWorkItem.Id);
             var changeSetMappings = Services.GetService<TfsChangeSetMappingTool>();

--- a/src/MigrationTools.Clients.TfsObjectModel/Tools/TfsGitRepositoryToolOptions.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/Tools/TfsGitRepositoryToolOptions.cs
@@ -1,5 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+using DotNet.Globbing;
+using Microsoft.Extensions.Options;
+using System.Text.RegularExpressions;
 using Microsoft.TeamFoundation.Build.Client;
 using MigrationTools.Enrichers;
 using MigrationTools.Tools.Infrastructure;
@@ -12,6 +15,7 @@ namespace MigrationTools.Tools
         /// List of work item mappings. 
         /// </summary>
         /// <default>{}</default>
-        public Dictionary<string, string> Mappings { get; set; }
+        public Dictionary<string, string> Mappings { get; set; } = new Dictionary<string, string>();
     }
+
 }

--- a/src/MigrationTools.Clients.TfsObjectModel/Tools/TfsGitRepositoryToolOptionsValidator.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/Tools/TfsGitRepositoryToolOptionsValidator.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
+
+namespace MigrationTools.Tools
+{
+    internal class TfsGitRepositoryToolOptionsValidator : IValidateOptions<TfsGitRepositoryToolOptions>
+    {
+        public ValidateOptionsResult Validate(string name, TfsGitRepositoryToolOptions options)
+        {
+            if (options.Mappings == null)
+            {
+                return ValidateOptionsResult.Fail("Mappings must be set to at least an empty array");
+            }
+            return ValidateOptionsResult.Success;
+        }
+    }
+}


### PR DESCRIPTION
✨ (TfsGitRepositoryTool): add validation and logging for TfsGitRepositoryTool options

Add a check to ensure the TfsGitRepositoryEnricher is enabled before proceeding, logging a warning if it is not. This prevents unnecessary operations when the feature is disabled. Introduce a default initialization for the Mappings dictionary to avoid null references. Implement a new options validator class, TfsGitRepositoryToolOptionsValidator, to ensure that Mappings is always initialized, enhancing robustness and preventing runtime errors. These changes improve the reliability and maintainability of the tool by ensuring proper configuration and logging.

Closes #2410 