### PR TITLE
Topic/remove default string maniplulaot

### DIFF
--- a/appsettings.json
+++ b/appsettings.json
@@ -150,15 +150,7 @@
       "StringManipulatorTool": {
         "Enabled": true,
         "MaxStringLength": 1000000,
-        "Manipulators": [
-          {
-            "$type": "RegexStringManipulator",
-            "Enabled": true,
-            "Pattern": "[^( -~)\n\r\t]+",
-            "Replacement": "",
-            "Description": "Remove invalid characters from the end of the string"
-          }
-        ]
+        "Manipulators": []
       },
       "TfsUserMappingTool": {
         "Enabled": false,

--- a/src/MigrationTools/Tools/StringManipulatorTool.cs
+++ b/src/MigrationTools/Tools/StringManipulatorTool.cs
@@ -34,9 +34,11 @@ namespace MigrationTools.Tools
             }
             if (fieldItem.FieldType == "String" && fieldItem.Value != null)
             {
-                if (HasManipulators())
+                if (!HasManipulators())
                 {
-                    foreach (var manipulator in Options.Manipulators)
+                    AddDefaultManipulator();
+                }
+                foreach (var manipulator in Options.Manipulators)
                     {
                         if (manipulator.Enabled)
                         {
@@ -49,13 +51,22 @@ namespace MigrationTools.Tools
                             Log.LogDebug("{WorkItemProcessorEnricher}::ProcessorExecutionWithFieldItem::Disabled::{Description}", GetType().Name, manipulator.Description);
                         }
                     }
-                }
+                
                 if (HasStringTooLong(fieldItem))
                 {
                     fieldItem.Value = fieldItem.Value.ToString().Substring(0, Math.Min(fieldItem.Value.ToString().Length, Options.MaxStringLength));
                 }
             }
 
+        }
+
+        private void AddDefaultManipulator()
+        {
+            if (Options.Manipulators == null)
+            {
+                Options.Manipulators = new List<RegexStringManipulator>();
+            }
+            Options.Manipulators.Add(new RegexStringManipulator() { Enabled = true, Description = "Default: Removes invalid chars!", Pattern = "[^( -~)\n\r\t]+", Replacement = "" });
         }
 
         private bool HasStringTooLong(FieldItem fieldItem)


### PR DESCRIPTION
Working with @xci-mrt to identify why StringManipulatorTool is removing danish chars even when he adds a new manipulator...

Turns out the default and the new one are merged. So both run regardless of the desirement.

I have moved the default manipultor to code and it will only present if the manipulators list is empty. this allows an override.

Clodes https://github.com/nkdAgility/azure-devops-migration-tools/pull/2424