### PR TITLE
🔧 (main.yml): add GitHub context variables and temporarily disable bu…

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -236,6 +236,14 @@ jobs:
                  - HasChanged_src: ${{needs.Setup.outputs.HasChanged_src}}
                  - HasChanged_docs: ${{needs.Setup.outputs.HasChanged_docs}}
                  - HasChanged_automation: ${{needs.Setup.outputs.HasChanged_automation}}
+               ### Github Bits
+                 - repository: ${{ github.event_name == 'push' && github.repository || github.event.pull_request.head.repo.full_name }}
+                 - ref: ${{ github.event_name == 'push' && github.ref || github.event.pull_request.head.ref }}
+                 - github.repository: ${{github.repository}}
+                 - github.event.pull_request.head.repo.full_name: ${{github.event.pull_request.head.repo.full_name}}
+                 - github.ref: ${{github.ref}}
+                 - github.event.pull_request.head.ref: ${{github.event.pull_request.head.ref}}
+  
             "@
             echo $markdown >> $Env:GITHUB_STEP_SUMMARY
     - name: "Show Release Description"
@@ -256,7 +264,7 @@ jobs:
     name: "Build, Test, Sonar Cloud Analysis, & Package"
     runs-on: windows-latest
     needs: Setup
-    if: ${{ success() }}
+    if: false # ${{ success() }}
     env:
       solution: '**/*.sln'
       buildPlatform: 'Any CPU'
@@ -352,7 +360,7 @@ jobs:
   BuildDocs:
     name: "Build Documentation output"
     runs-on: ubuntu-latest
-    if: ${{ success() }}
+    if: false # ${{ success() }}
     needs: [Setup]
     env:
       GitVersion_SemVer: ${{ needs.Setup.outputs.GitVersion_SemVer }}


### PR DESCRIPTION
…ild jobs

Add GitHub context variables to the workflow to enhance the ability to access repository and reference information dynamically. This change is crucial for workflows that need to differentiate between push and pull request events and access specific repository details accordingly.

Temporarily disable the "Build, Test, Sonar Cloud Analysis, & Package" and "Build Documentation output" jobs by setting their conditions to false. This is likely done to prevent these jobs from running during a specific phase of development or testing, possibly to save resources or focus on other parts of the workflow.