### PR TITLE
Remove Trace and Log from Open Telemitery

### DIFF
--- a/src/MigrationTools/Services/ActivitySourceProvider.cs
+++ b/src/MigrationTools/Services/ActivitySourceProvider.cs
@@ -144,22 +144,22 @@ namespace MigrationTools.Services
                 Assembly entryAssembly = Assembly.GetEntryAssembly();
                 string entryAssemblyName = entryAssembly?.GetName().Name;
                 services.AddOpenTelemetry()
-                    .WithTracing(builder =>
-                    {
-                        builder
-                            .SetSampler(new AlwaysOnSampler())
-                            .SetResourceBuilder(ResourceBuilder.CreateDefault().AddService(entryAssemblyName, serviceVersion: versionString))
-                            .AddSource(ActivitySourceProvider.ActivitySourceName) // Register your custom ActivitySource
-                            //.AddConsoleExporter() // Export traces to console
-                            .AddProcessor(new ActivitySourceProvider.ActivityFilteringProcessor())
-                            .AddHttpClientInstrumentation()
-                            .SetErrorStatusOnException()
-                            .AddAzureMonitorTraceExporter(options =>
-                            {
-                                options.ConnectionString = ActivitySourceProvider.GetConnectionString();
+                    //.WithTracing(builder =>
+                    //{
+                    //    builder
+                    //        .SetSampler(new AlwaysOnSampler())
+                    //        .SetResourceBuilder(ResourceBuilder.CreateDefault().AddService(entryAssemblyName, serviceVersion: versionString))
+                    //        .AddSource(ActivitySourceProvider.ActivitySourceName) // Register your custom ActivitySource
+                    //        //.AddConsoleExporter() // Export traces to console
+                    //        .AddProcessor(new ActivitySourceProvider.ActivityFilteringProcessor())
+                    //        .AddHttpClientInstrumentation()
+                    //        .SetErrorStatusOnException()
+                    //        .AddAzureMonitorTraceExporter(options =>
+                    //        {
+                    //            options.ConnectionString = ActivitySourceProvider.GetConnectionString();
 
-                            });
-                    })
+                    //        });
+                    //})
                     .WithMetrics(builder =>
                     {
                         builder
@@ -175,17 +175,17 @@ namespace MigrationTools.Services
                                  options.ConnectionString = ActivitySourceProvider.GetConnectionString();
                              });
                     });
-                services.AddLogging(loggingBuilder =>
-                {
-                    loggingBuilder.AddOpenTelemetry(options =>
-                    {
-                        //options.AddConsoleExporter();
-                        options.AddAzureMonitorLogExporter(config =>
-                        {
-                            config.ConnectionString = ActivitySourceProvider.GetConnectionString();
-                        });
-                    });
-                });
+                //services.AddLogging(loggingBuilder =>
+                //{
+                //    loggingBuilder.AddOpenTelemetry(options =>
+                //    {
+                //        //options.AddConsoleExporter();
+                //        options.AddAzureMonitorLogExporter(config =>
+                //        {
+                //            config.ConnectionString = ActivitySourceProvider.GetConnectionString();
+                //        });
+                //    });
+                //});
                 services.AddSingleton(sp => ActivitySourceProvider.GetActivitySource());
             });
 


### PR DESCRIPTION
♻️ (ActivitySourceProvider.cs): comment out OpenTelemetry tracing and logging configuration

The OpenTelemetry tracing and logging configuration is commented out to temporarily disable these features. This change is likely made to troubleshoot or isolate issues related to telemetry or to reduce overhead during development. The code is preserved for easy reactivation when needed.