### PR TITLE
📝 (index.md): update documentation links and correct preview URL

### DIFF
--- a/.github/workflows/MigrationToolsTelemetery.yml
+++ b/.github/workflows/MigrationToolsTelemetery.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Publish
       run: dotnet publish "${{ env.WORKING_DIRECTORY }}" --configuration ${{ env.CONFIGURATION }} --no-build --output "${{ env.AZURE_FUNCTIONAPP_PACKAGE_PATH }}"
     - name: Publish Artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: functionapp
         path: ${{ env.AZURE_FUNCTIONAPP_PACKAGE_PATH }}
@@ -41,7 +41,7 @@ jobs:
     needs: build
     steps:
     - name: Download artifact from build job
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: functionapp
         path: ${{ env.AZURE_FUNCTIONAPP_PACKAGE_PATH }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,13 +69,13 @@ jobs:
         $newBranchName = "contrib/$branchName"
         git checkout -b $newBranchName
     - name: Install GitVersion
-      uses: gittools/actions/gitversion/setup@v1.1.1
+      uses: gittools/actions/gitversion/setup@v3.0.2
       with:
         versionSpec: '5.x'
         includePrerelease: true
     - name: Execute GitVersion
       id: gitversion
-      uses: gittools/actions/gitversion/execute@v1.1.1
+      uses: gittools/actions/gitversion/execute@v3.0.2
       with:
         useConfigFile: true
     - uses: dorny/paths-filter@v3
@@ -273,7 +273,7 @@ jobs:
       GitVersion_MajorMinorPatch: ${{ needs.Setup.outputs.GitVersion_MajorMinorPatch }}
     steps:
       - name: Set up JDK 17
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         if: ${{ !(github.event.pull_request.head.repo.fork) }}
         with:
           java-version: 17

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/stale@v1
+    - uses: actions/stale@v9
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-label: 'no-issue-activity'

--- a/docs/index.md
+++ b/docs/index.md
@@ -54,15 +54,14 @@ For the most part we support moving data between `((Azure DevOps Server | Team F
 
 - [Installation](/setup/installation.md)
 - [Permissions](/setup/permissions.md)
-- [Getting Started](/getting-started/)
+- [Getting Started](/getting-started/index.md)
 - [Configuration Reference](./Reference/)
 - [FAQ](faq.md)
 - [Support](support.md)
-- [How To Migrate Things](./HowTo/index.md)
 - [Community Support](https://github.com/nkdAgility/azure-devops-migration-tools/discussions)
 - [Commercial Support](https://nkdagility.com/capabilities/azure-devops-migration-services/)
 
-The documentation for the preview is on [Preview](https://nkdagility.com/docs/azure-devops-migration-tools/preview/)]
+The documentation for the preview is on [Preview](https://preview.nkdagility.com/docs/azure-devops-migration-tools/)]
 
 #### External Walkthroughs and Reviews
 


### PR DESCRIPTION
Update the "Getting Started" link to point directly to the index.md file for better navigation. Remove the redundant "How To Migrate Things" link to streamline the documentation. Correct the preview documentation URL to ensure users are directed to the correct preview site. These changes improve the accuracy and usability of the documentation.