### PR TITLE
Fix most of the code warnings

### DIFF
--- a/src/MigrationTools.Clients.AzureDevops.Rest/Endpoints/AzureDevOpsEndpoint.cs
+++ b/src/MigrationTools.Clients.AzureDevops.Rest/Endpoints/AzureDevOpsEndpoint.cs
@@ -209,10 +209,8 @@ namespace MigrationTools.Endpoints
         /// <typeparam name="DefinitionType"></typeparam>
         /// <param name="routeParameters">strings that are injected into the route parameters of the definitions url</param>
         /// <param name="queryString">additional query string parameters passed to the underlying api call</param>
-        /// <param name="singleDefinitionQueryString">additional query string parameter passed when pulling the single instance details (ie. $expands, etc)</param>
-        /// <param name="queryForDetails">a boolean flag to allow caller to skip the calls for each individual definition details</param>
         /// <returns></returns>
-        public async Task<DefinitionType> GetApiDefinitionAsync<DefinitionType>(string[] routeParameters = null, string queryString = "", string singleDefinitionQueryString = "", bool queryForDetails = true)
+        public async Task<DefinitionType> GetApiDefinitionAsync<DefinitionType>(string[] routeParameters = null, string queryString = "")
             where DefinitionType : RestApiDefinition, new()
         {
             var apiPathAttribute = typeof(DefinitionType).GetCustomAttributes(typeof(ApiPathAttribute), false).OfType<ApiPathAttribute>().FirstOrDefault();
@@ -236,11 +234,10 @@ namespace MigrationTools.Endpoints
         /// <summary>
         /// Make HTTP Request to add Revision / Version of Task Group
         /// </summary>
-        /// <param name="targetDefinitions"></param>
         /// <param name="rootDefinitions"></param>
         /// <param name="updatedDefinitions"></param>
         /// <returns>List of Mappings</returns>
-        public async Task<List<Mapping>> UpdateTaskGroupsAsync(IEnumerable<TaskGroup> targetDefinitions, IEnumerable<TaskGroup> rootDefinitions, IEnumerable<TaskGroup> updatedDefinitions)
+        public async Task<List<Mapping>> UpdateTaskGroupsAsync(IEnumerable<TaskGroup> rootDefinitions, IEnumerable<TaskGroup> updatedDefinitions)
         {
             var migratedDefinitions = new List<Mapping>();
             foreach (var definitionToBeMigrated in updatedDefinitions)

--- a/src/MigrationTools.Clients.AzureDevops.Rest/Endpoints/AzureDevOpsEndpoint.cs
+++ b/src/MigrationTools.Clients.AzureDevops.Rest/Endpoints/AzureDevOpsEndpoint.cs
@@ -22,6 +22,7 @@ namespace MigrationTools.Endpoints
 {
     public class AzureDevOpsEndpoint : Endpoint<AzureDevOpsEndpointOptions>
     {
+        [Obsolete("Dont know what this is for")]
         public override int Count => 0;
 
         public AzureDevOpsEndpoint(IOptions<AzureDevOpsEndpointOptions> optipons, EndpointEnricherContainer endpointEnrichers, IServiceProvider serviceProvider, ITelemetryLogger telemetry, ILogger<AzureDevOpsEndpoint> logger)

--- a/src/MigrationTools.Clients.AzureDevops.Rest/Processors/AzureDevOpsPipelineProcessor.cs
+++ b/src/MigrationTools.Clients.AzureDevops.Rest/Processors/AzureDevOpsPipelineProcessor.cs
@@ -150,8 +150,9 @@ namespace MigrationTools.Processors
         /// <summary>
         /// Filter incompatible TaskGroups
         /// </summary>
-        /// <param name="filteredTaskGroups"></param>
+        /// <param name="sourceDefinitions"></param>
         /// <param name="availableTasks"></param>
+        /// <param name="taskGroupMapping"></param>
         /// <returns>List of filtered Definitions</returns>
         private IEnumerable<BuildDefinition> FilterOutIncompatibleBuildDefinitions(IEnumerable<BuildDefinition> sourceDefinitions, IEnumerable<TaskDefinition> availableTasks, IEnumerable<Mapping> taskGroupMapping)
         {

--- a/src/MigrationTools.Clients.AzureDevops.Rest/Processors/AzureDevOpsPipelineProcessor.cs
+++ b/src/MigrationTools.Clients.AzureDevops.Rest/Processors/AzureDevOpsPipelineProcessor.cs
@@ -632,7 +632,7 @@ namespace MigrationTools.Processors
 
             targetDefinitions = await Target.GetApiDefinitionsAsync<TaskGroup>(queryForDetails: false);
             var rootTargetDefinitions = SortDefinitionsByVersion(targetDefinitions).First();
-            await Target.UpdateTaskGroupsAsync(targetDefinitions, rootTargetDefinitions, updatedSourceDefinitions);
+            await Target.UpdateTaskGroupsAsync(rootTargetDefinitions, updatedSourceDefinitions);
 
             targetDefinitions = await Target.GetApiDefinitionsAsync<TaskGroup>(queryForDetails: false);
             mappings.AddRange(FindExistingMappings(sourceDefinitions, targetDefinitions.Where(d => d.Name != null), mappings));

--- a/src/MigrationTools.Clients.AzureDevops.Rest/Processors/ProcessDefinitionProcessor.cs
+++ b/src/MigrationTools.Clients.AzureDevops.Rest/Processors/ProcessDefinitionProcessor.cs
@@ -19,7 +19,7 @@ using MigrationTools.Tools;
 
 namespace MigrationTools.Processors
 {
-    
+
     internal class ProcessorModel
     {
         public Dictionary<string, ProcessDefinitionModel> ProcessDefinitions { get; set; } = new Dictionary<string, ProcessDefinitionModel>();
@@ -151,7 +151,7 @@ namespace MigrationTools.Processors
             catch (Exception ex)
             {
                 Log.LogError(ex, "Failed to synchronize processes.");
-                throw ex;
+                throw;
             }
         }
 
@@ -215,7 +215,7 @@ namespace MigrationTools.Processors
             foreach (var field in sourceWit.Fields)
             {
                 var existingField = TargetModel.WorkItemFields.Values.FirstOrDefault(x => x.ReferenceName == field.ReferenceName);
-                //if (existingField == null || (existingField != null && field.Customization != "system")) // I don't think you can modify 
+                //if (existingField == null || (existingField != null && field.Customization != "system")) // I don't think you can modify
                 //{
                     await SyncDefinitionType<WorkItemTypeField>(
                         TargetModel.WorkItemFields,
@@ -320,7 +320,7 @@ namespace MigrationTools.Processors
                                     }
                                     else
                                     {
-                                        
+
                                         // Its on a different page .. lets move pages
                                         var tempTargetGroup = existingGroup.Value.CloneAsNew();
                                         tempTargetGroup.Id = existingGroup.Value.Id;
@@ -446,7 +446,7 @@ namespace MigrationTools.Processors
             Log.LogInformation($"Completed sync of work item type [{Source.Options.Name}::{sourceWit.WorkItemType.Name}] in [{Target.Options.Name}::{targetWit.WorkItemType.Name}].");
         }
 
-        
+
 
         private async Task<DefinitionType> SyncDefinitionType<DefinitionType>(Dictionary<string, DefinitionType> DataDictionary, DefinitionType sourceDef, DefinitionType targetDef, params string[] routeParams)
             where DefinitionType : RestApiDefinition, ISynchronizeable<DefinitionType>, new()
@@ -468,7 +468,7 @@ namespace MigrationTools.Processors
         private async Task BuildModel(ProcessorModel model, AzureDevOpsEndpoint endpoint, bool warnOnMissing)
         {
             // Grab all the procs, then iterate over them looking for procs user has configured to be
-            // sync'd. Then grab all Work Item Types for the given process and filter those by the ones user 
+            // sync'd. Then grab all Work Item Types for the given process and filter those by the ones user
             // wants to sync.
 
             Log.LogDebug($"Loading model for [{endpoint.Options.Name}].");

--- a/src/MigrationTools.Clients.AzureDevops.Rest/Processors/ProcessDefinitionProcessor.cs
+++ b/src/MigrationTools.Clients.AzureDevops.Rest/Processors/ProcessDefinitionProcessor.cs
@@ -589,7 +589,7 @@ namespace MigrationTools.Processors
         }
         private async Task LoadLayout(ProcessorModel model, WorkItemTypeModel wit, AzureDevOpsEndpoint endpoint, string processId)
         {
-            wit.Layout = (await endpoint.GetApiDefinitionAsync<WorkItemLayout>(new string[] { processId, wit.WorkItemType.ReferenceName }, queryForDetails: false));
+            wit.Layout = (await endpoint.GetApiDefinitionAsync<WorkItemLayout>(new string[] { processId, wit.WorkItemType.ReferenceName }));
             foreach (var page in wit.Layout.Pages)
             {
                 var pageKey = $"{wit.WorkItemType.Name}::{page.Label}";

--- a/src/MigrationTools.Clients.FileSystem/Endpoints/FileSystemWorkItemEndpoint.cs
+++ b/src/MigrationTools.Clients.FileSystem/Endpoints/FileSystemWorkItemEndpoint.cs
@@ -20,6 +20,7 @@ namespace MigrationTools.Endpoints
             _innerList = new List<WorkItemData>();
         }
 
+        [Obsolete("Dont know what this is for")]
         public override int Count => GetWorkItems().Count();
 
         public void EnsureStore()

--- a/src/MigrationTools.Clients.TfsObjectModel/Endpoints/TfsEndpoint.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/Endpoints/TfsEndpoint.cs
@@ -56,10 +56,8 @@ namespace MigrationTools.Endpoints
             get { return TfsProject.Uri; }
         }
 
+        [Obsolete("Dont know what this is for")]
         public override int Count => 0;
-
-
-
 
         private TfsTeamProjectCollection GetTfsCollection()
         {

--- a/src/MigrationTools.Clients.TfsObjectModel/Endpoints/TfsTeamProjectEndpoint.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/Endpoints/TfsTeamProjectEndpoint.cs
@@ -39,11 +39,10 @@ namespace MigrationTools.Clients
 
             _workItemClient = ActivatorUtilities.CreateInstance<TfsWorkItemMigrationClient>(Services, this, options);
             //networkCredentials IOptions<NetworkCredentialsOptions> networkCredentials,
-         
         }
 
+        [Obsolete("Dont know what this is for")]
         public override int Count => 0;
-
 
         public IWorkItemMigrationClient WorkItems
         {

--- a/src/MigrationTools.Clients.TfsObjectModel/Endpoints/TfsWorkItemConvertor.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/Endpoints/TfsWorkItemConvertor.cs
@@ -58,7 +58,7 @@ namespace MigrationTools.Endpoints
                 var dictionary = items.ToDictionary(item => item.Number);
                 return new SortedDictionary<int, RevisionItem>(dictionary);
             }
-            catch (ArgumentException e)
+            catch (ArgumentException)
             {
                 Log.Warning("For some Reason there are multiple Revisions on {WorkItemId} with the same System.Rev. We will create a renumbered list...", items[0].WorkItemId);
                 var currentNumber = -1;

--- a/src/MigrationTools.Clients.TfsObjectModel/Processors/TfsExportUsersForMappingProcessorOptions.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/Processors/TfsExportUsersForMappingProcessorOptions.cs
@@ -10,7 +10,8 @@ namespace MigrationTools.Processors
 
         public string WIQLQuery { get; set; }
 
-        /// `OnlyListUsersInWorkItems` 
+        /// <summary>
+        /// `OnlyListUsersInWorkItems`
         /// </summary>
         /// <default>true</default>
         public bool OnlyListUsersInWorkItems { get; set; } = true;

--- a/src/MigrationTools.Clients.TfsObjectModel/Processors/TfsTestPlansAndSuitesMigrationProcessorOptions.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/Processors/TfsTestPlansAndSuitesMigrationProcessorOptions.cs
@@ -43,12 +43,6 @@ namespace MigrationTools._EngineV1.Configuration.Processing
 
         public bool FilterCompleted { get; set; }
 
-        /// <inheritdoc />
-        public bool IsProcessorCompatible(IReadOnlyList<IProcessorConfig> otherProcessors)
-        {
-            return true;
-        }
-
         public TfsTestPlansAndSuitesMigrationProcessorOptions()
         {
             MigrationDelay = 0;

--- a/src/MigrationTools.Clients.TfsObjectModel/Processors/TfsTestVariablesMigrationProcessorOptions.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/Processors/TfsTestVariablesMigrationProcessorOptions.cs
@@ -8,18 +8,9 @@ namespace MigrationTools.Processors
     public class TfsTestVariablesMigrationProcessorOptions : ProcessorOptions
     {
         /// <inheritdoc />
-        public bool Enabled { get; set; }
-
-        /// <inheritdoc />
         public string Processor
         {
             get { return "TestVariablesMigrationContext"; }
-        }
-
-        /// <inheritdoc />
-        public bool IsProcessorCompatible(IReadOnlyList<IProcessorConfig> otherProcessors)
-        {
-            return true;
         }
     }
 }

--- a/src/MigrationTools.Clients.TfsObjectModel/Processors/TfsWorkItemMigrationProcessor.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/Processors/TfsWorkItemMigrationProcessor.cs
@@ -52,7 +52,6 @@ namespace MigrationTools.Processors
 
         private static int _count = 0;
         private static int _current = 0;
-        private static long _elapsedms = 0;
         private static int _totalWorkItem = 0;
         private static string workItemLogTemplate = "[{sourceWorkItemTypeName,20}][Complete:{currentWorkItem,6}/{totalWorkItems}][sid:{sourceWorkItemId,6}|Rev:{sourceRevisionInt,3}][tid:{targetWorkItemId,6} | ";
         private List<string> _ignore;
@@ -159,7 +158,6 @@ namespace MigrationTools.Processors
 
                 _current = 1;
                 _count = sourceWorkItems.Count;
-                _elapsedms = 0;
                 _totalWorkItem = sourceWorkItems.Count;
                 ProcessorActivity.SetTag("source_workitems_to_process", sourceWorkItems.Count);
                 foreach (WorkItemData sourceWorkItemData in sourceWorkItems)

--- a/src/MigrationTools.Clients.TfsObjectModel/Processors/TfsWorkItemMigrationProcessor.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/Processors/TfsWorkItemMigrationProcessor.cs
@@ -162,7 +162,7 @@ namespace MigrationTools.Processors
                 ProcessorActivity.SetTag("source_workitems_to_process", sourceWorkItems.Count);
                 foreach (WorkItemData sourceWorkItemData in sourceWorkItems)
                 {
-                    
+
                     var stopwatch = Stopwatch.StartNew();
                     var sourceWorkItem = TfsExtensions.ToWorkItem(sourceWorkItemData);
                     workItemLog = contextLog.ForContext("SourceWorkItemId", sourceWorkItem.Id);
@@ -257,7 +257,7 @@ namespace MigrationTools.Processors
         //    } else
         //    {
         //        contextLog.Error("nodeStructureEnricher is disabled! Please enable it in the config.");
-        //    }            
+        //    }
         //}
 
         private void ValidateAllWorkItemTypesHaveReflectedWorkItemIdField(List<WorkItemData> sourceWorkItems)
@@ -430,7 +430,7 @@ namespace MigrationTools.Processors
 
             foreach (Field f in oldWorkItem.Fields)
             {
-                CommonTools.UserMapping.MapUserIdentityField(this, f);
+                CommonTools.UserMapping.MapUserIdentityField(f);
                 if (newWorkItem.Fields.Contains(f.ReferenceName) == false)
                 {
                     var missedMigratedValue = oldWorkItem.Fields[f.ReferenceName].Value;
@@ -549,7 +549,7 @@ namespace MigrationTools.Processors
                             if (revisionsToMigrate.Count == 0)
                             {
                                 ProcessWorkItemAttachments(sourceWorkItem, targetWorkItem, false);
-                                ProcessWorkItemLinks(Source.WorkItems, Target.WorkItems, sourceWorkItem, targetWorkItem);
+                                ProcessWorkItemLinks(sourceWorkItem, targetWorkItem);
                                 ProcessHTMLFieldAttachements(targetWorkItem);
                                 ProcessWorkItemEmbeddedLinks(sourceWorkItem, targetWorkItem);
                                 TraceWriteLine(LogEventLevel.Information, "Skipping as work item exists and no revisions to sync detected");
@@ -646,7 +646,7 @@ namespace MigrationTools.Processors
             }
         }
 
-        private void ProcessWorkItemLinks(IWorkItemMigrationClient sourceStore, IWorkItemMigrationClient targetStore, WorkItemData sourceWorkItem, WorkItemData targetWorkItem)
+        private void ProcessWorkItemLinks(WorkItemData sourceWorkItem, WorkItemData targetWorkItem)
         {
             if (targetWorkItem != null && CommonTools.WorkItemLink.Enabled && sourceWorkItem.ToWorkItem().Links.Count > 0)
             {
@@ -832,7 +832,7 @@ namespace MigrationTools.Processors
                     ProcessWorkItemAttachments(sourceWorkItem, targetWorkItem, false);
                     if (!string.IsNullOrEmpty(targetWorkItem.Id))
                     {
-                        ProcessWorkItemLinks(Source.WorkItems, Target.WorkItems, sourceWorkItem, targetWorkItem);
+                        ProcessWorkItemLinks(sourceWorkItem, targetWorkItem);
                         // The TFS client seems to plainly ignore the ChangedBy field when saving a link, so we need to put this back in place
                         targetWorkItem.ToWorkItem().Fields["System.ChangedBy"].Value = "Migration";
                     }

--- a/src/MigrationTools.Clients.TfsObjectModel/Tools/TfsAttachmentTool.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/Tools/TfsAttachmentTool.cs
@@ -95,7 +95,7 @@ namespace MigrationTools.Tools
                     Directory.Delete(_exportWiPath, true);
                     _exportWiPath = null;
                 }
-                catch (Exception ex)
+                catch (Exception)
                 {
                     Log.LogWarning(" ERROR: Unable to delete folder {0}! Should be cleaned up at the end.", _exportWiPath);
                 }

--- a/src/MigrationTools.Clients.TfsObjectModel/Tools/TfsAttachmentTool.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/Tools/TfsAttachmentTool.cs
@@ -64,11 +64,11 @@ namespace MigrationTools.Tools
                 {
                     string filepath = null;
                     Directory.CreateDirectory(Path.Combine(_exportWiPath, wia.Id.ToString()));
-                    filepath = ExportAttachment(source.ToWorkItem(), wia, _exportWiPath);
+                    filepath = ExportAttachment(wia, _exportWiPath);
                     Log.LogDebug("AttachmentMigrationEnricher: Exported {Filename} to disk", Path.GetFileName(filepath));
                     if (filepath != null)
                     {
-                        ImportAttachment(target.ToWorkItem(), wia, filepath, save);
+                        ImportAttachment(target.ToWorkItem(), wia, filepath);
                         Log.LogDebug("AttachmentMigrationEnricher: Imported {Filename} from disk", Path.GetFileName(filepath));
                     }
                 }
@@ -102,7 +102,7 @@ namespace MigrationTools.Tools
             }
         }
 
-        private string ExportAttachment(WorkItem wi, Attachment wia, string exportpath)
+        private string ExportAttachment(Attachment wia, string exportpath)
         {
             string fname = GetSafeFilename(wia.Name);
             Log.LogDebug(fname);
@@ -131,7 +131,7 @@ namespace MigrationTools.Tools
             return fpath;
         }
 
-        private void ImportAttachment(WorkItem targetWorkItem, Attachment wia, string filepath, bool save = true)
+        private void ImportAttachment(WorkItem targetWorkItem, Attachment wia, string filepath)
         {
             var filename = Path.GetFileName(filepath);
             FileInfo fi = new FileInfo(filepath);

--- a/src/MigrationTools.Clients.TfsObjectModel/Tools/TfsGitRepositoryTool.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/Tools/TfsGitRepositoryTool.cs
@@ -22,7 +22,6 @@ namespace MigrationTools.Tools
     {
 
         private bool _save = true;
-        private bool _filter = true;
         private GitRepositoryService sourceRepoService;
         private IList<GitRepository> sourceRepos;
         private IList<GitRepository> allSourceRepos;

--- a/src/MigrationTools.Clients.TfsObjectModel/Tools/TfsGitRepositoryTool.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/Tools/TfsGitRepositoryTool.cs
@@ -57,7 +57,7 @@ namespace MigrationTools.Tools
                     targetRepos = targetRepoService.QueryRepositories(_processor.Target.Options.Project);
                     allTargetRepos = targetRepoService.QueryRepositories("");
                 }
-                catch (Exception ex)
+                catch (Exception)
                 {
                     sourceRepoService = null;
                 }

--- a/src/MigrationTools.Clients.TfsObjectModel/Tools/TfsNodeStructureTool.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/Tools/TfsNodeStructureTool.cs
@@ -44,7 +44,7 @@ namespace MigrationTools.Tools
     }
 
     /// <summary>
-    /// The TfsNodeStructureToolEnricher is used to create missing nodes in the target project. To configure it add a `TfsNodeStructureToolOptions` section to `CommonEnrichersConfig` in the config file. Otherwise defaults will be applied. 
+    /// The TfsNodeStructureToolEnricher is used to create missing nodes in the target project. To configure it add a `TfsNodeStructureToolOptions` section to `CommonEnrichersConfig` in the config file. Otherwise defaults will be applied.
     /// </summary>
     public class TfsNodeStructureTool : Tool<TfsNodeStructureToolOptions>
     {
@@ -194,7 +194,7 @@ namespace MigrationTools.Tools
                         {
                             parentNode = _targetCommonStructureService.GetNodeFromPath(currentAncestorPath);
                         }
-                        catch (Exception ex)
+                        catch (Exception)
                         {
                             Log.LogDebug("  Not Found:", currentAncestorPath);
                             parentNode = null;
@@ -564,7 +564,7 @@ namespace MigrationTools.Tools
                     missingItem.targetPath = GetNewNodeName(missingItem.sourcePath, nodeType);
                     Log.LogTrace("TfsNodeStructureTool:CheckForMissingPaths:GetNewNodeName::{@missingItem}", missingItem);
                 }
-                catch (NodePathNotAnchoredException ex)
+                catch (NodePathNotAnchoredException)
                 {
                     Log.LogDebug("TfsNodeStructureTool:CheckForMissingPaths:NodePathNotAnchoredException::{sourceSystemPath}", missingItem.sourceSystemPath);
                     Log.LogTrace("TfsNodeStructureTool:CheckForMissingPaths:NodePathNotAnchoredException::{@missingItem}", missingItem);

--- a/src/MigrationTools.Clients.TfsObjectModel/Tools/TfsNodeStructureTool.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/Tools/TfsNodeStructureTool.cs
@@ -480,6 +480,7 @@ namespace MigrationTools.Tools
         /// Checks node-to-be-created with allowed BasePath's
         /// </summary>
         /// <param name="userFriendlyPath">The user-friendly path of the source node</param>
+        /// <param name="nodeStructureType"></param>
         /// <returns>true/false</returns>
         private bool ShouldCreateNode(string userFriendlyPath, TfsNodeStructureType nodeStructureType)
         {

--- a/src/MigrationTools.Clients.TfsObjectModel/Tools/TfsUserMappingTool.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/Tools/TfsUserMappingTool.cs
@@ -68,7 +68,7 @@ namespace MigrationTools.Tools
             }
         }
 
-        public void MapUserIdentityField(TfsProcessor processor, Field field)
+        public void MapUserIdentityField(Field field)
         {
             if (Options.Enabled && Options.IdentityFieldsToCheck.Contains(field.ReferenceName))
             {

--- a/src/MigrationTools.Clients.TfsObjectModel/Tools/TfsWorkItemLinkTool.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/Tools/TfsWorkItemLinkTool.cs
@@ -16,8 +16,6 @@ namespace MigrationTools.Tools
 {
     public class TfsWorkItemLinkTool : Tool<TfsWorkItemLinkToolOptions>
     {
-        private IMigrationEngine Engine;
-
         public TfsWorkItemLinkTool(IOptions<TfsWorkItemLinkToolOptions> options, IServiceProvider services, ILogger<TfsWorkItemLinkTool> logger, ITelemetryLogger telemetryLogger)
             : base(options, services, logger, telemetryLogger)
         {

--- a/src/MigrationTools.ConsoleDataGenerator/DataSerialization.cs
+++ b/src/MigrationTools.ConsoleDataGenerator/DataSerialization.cs
@@ -113,7 +113,7 @@ namespace MigrationTools.ConsoleDataGenerator
             return true; // This converter applies to all types, but we'll decide whether to include $type inside WriteJson
         }
 
-        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
         {
             JObject jo = JObject.FromObject(value);
 
@@ -126,7 +126,7 @@ namespace MigrationTools.ConsoleDataGenerator
             jo.WriteTo(writer);
         }
 
-        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        public override object ReadJson(JsonReader reader, Type objectType, object? existingValue, JsonSerializer serializer)
         {
             // Deserialize normally
             return serializer.Deserialize(reader, objectType);

--- a/src/MigrationTools.Host/Commands/CommandBase.cs
+++ b/src/MigrationTools.Host/Commands/CommandBase.cs
@@ -111,10 +111,9 @@ namespace MigrationTools.Host.Commands
             }
         }
 
-        internal virtual async Task<int> ExecuteInternalAsync(CommandContext context, TSettings settings)
+        internal virtual Task<int> ExecuteInternalAsync(CommandContext context, TSettings settings)
         {
-            // no-op
-            return 0;
+            return Task.FromResult( 0);
         }
 
         public void RunStartupLogic(TSettings settings)

--- a/src/MigrationTools.Host/Commands/CommandBase.cs
+++ b/src/MigrationTools.Host/Commands/CommandBase.cs
@@ -183,7 +183,7 @@ namespace MigrationTools.Host.Commands
             }
             else
             {
-                /// not online or you have specified not to
+                // not online or you have specified not to
                 Log.Warning("You are either not online or have chosen `skipVersionCheck`. We will not check for a newer version of the tools.", _detectVersionService.PackageId);
             }
         }

--- a/src/MigrationTools.Host/Commands/ConfigurationBuilderCommand.cs
+++ b/src/MigrationTools.Host/Commands/ConfigurationBuilderCommand.cs
@@ -39,7 +39,7 @@ namespace MigrationTools.Host.Commands
         Layout layout = new Layout("Root");
 
 
-        public override async Task<int> ExecuteAsync(CommandContext context, ConfigurationBuilderCommandSettings settings)
+        public override Task<int> ExecuteAsync(CommandContext context, ConfigurationBuilderCommandSettings settings)
         {
             int _exitCode;
 
@@ -57,10 +57,6 @@ namespace MigrationTools.Host.Commands
                 OptionsConfigurationUpgrader optionsUpgrader = _services.GetRequiredService<OptionsConfigurationUpgrader>();
                 optionsUpgrader.UpgradeConfiguration(optionsBuilder, configFile);
                 _logger.LogInformation("Configuration loaded & Upgraded to latest...");
-
-
-          
-
 
                 var configurationEditorOptions = new[]
                 {
@@ -116,7 +112,7 @@ namespace MigrationTools.Host.Commands
                 // Stop the application once the work is done
                 _appLifetime.StopApplication();
             }
-            return _exitCode;
+            return Task.FromResult(_exitCode);
         }
 
         private void DisplayCurrentOptions(OptionsConfigurationBuilder optionsBuilder)
@@ -171,7 +167,7 @@ namespace MigrationTools.Host.Commands
 
         private void SelectTemplateToApply(OptionsConfigurationBuilder optionsBuilder, string configFile)
         {
-            
+
             bool shouldExit = false;
             while (!shouldExit)
             {

--- a/src/MigrationTools.Host/Commands/ExecuteMigrationCommand.cs
+++ b/src/MigrationTools.Host/Commands/ExecuteMigrationCommand.cs
@@ -45,18 +45,18 @@ namespace MigrationTools.Host.Commands
             _appLifetime = appLifetime;
         }
 
-        internal override async Task<int> ExecuteInternalAsync(CommandContext context, ExecuteMigrationCommandSettings settings)
+        internal override Task<int> ExecuteInternalAsync(CommandContext context, ExecuteMigrationCommandSettings settings)
         {
             int _exitCode;
             try
             {
-                    // KILL if the config is not valid
-                    if (!VersionOptions.ConfigureOptions.IsConfigValid(Configuration))
-                    {
-                        CommandActivity.AddEvent(new ActivityEvent("ConfigIsNotValid"));
-                        BoilerplateCli.ConfigIsNotValidMessage(Configuration, Log.Logger);
-                        return -1;
-                    }
+                // KILL if the config is not valid
+                if (!VersionOptions.ConfigureOptions.IsConfigValid(Configuration))
+                {
+                    CommandActivity.AddEvent(new ActivityEvent("ConfigIsNotValid"));
+                    BoilerplateCli.ConfigIsNotValidMessage(Configuration, Log.Logger);
+                    return Task.FromResult(-1);
+                }
                 var migrationEngine = _services.GetRequiredService<IMigrationEngine>();
                 migrationEngine.Run();
                 _exitCode = 0;
@@ -71,7 +71,7 @@ namespace MigrationTools.Host.Commands
                 foreach (var failure in ex.Failures)
                 {
                     _logger.LogCritical(failure);
-                }                
+                }
                 _logger.LogCritical("------------");
                 _exitCode = 1;
             }
@@ -88,7 +88,7 @@ namespace MigrationTools.Host.Commands
                 // Stop the application once the work is done
                 _appLifetime.StopApplication();
             }
-            return _exitCode;
+            return Task.FromResult(_exitCode);
         }
     }
 }

--- a/src/MigrationTools.Host/Commands/InitMigrationCommand.cs
+++ b/src/MigrationTools.Host/Commands/InitMigrationCommand.cs
@@ -32,7 +32,7 @@ namespace MigrationTools.Host.Commands
             _logger = logger;
         }
 
-        internal override async Task<int> ExecuteInternalAsync(CommandContext context, InitMigrationCommandSettings settings)
+        internal override Task<int> ExecuteInternalAsync(CommandContext context, InitMigrationCommandSettings settings)
         {
             int _exitCode;
             try
@@ -81,7 +81,7 @@ namespace MigrationTools.Host.Commands
                 // Stop the application once the work is done
                 Lifetime.StopApplication();
             }
-            return _exitCode;
+            return Task.FromResult(_exitCode);
         }
     }
 }

--- a/src/MigrationTools.Host/Commands/UpgradeConfigCommand.cs
+++ b/src/MigrationTools.Host/Commands/UpgradeConfigCommand.cs
@@ -37,14 +37,12 @@ namespace MigrationTools.Host.Commands
 
         private readonly ILogger _logger;
 
-       
-
         public UpgradeConfigCommand(IHostApplicationLifetime appLifetime, IServiceProvider services, IDetectOnlineService detectOnlineService, IDetectVersionService2 detectVersionService, ILogger<CommandBase<UpgradeConfigCommandSettings>> logger, ITelemetryLogger telemetryLogger, IMigrationToolVersion migrationToolVersion, IConfiguration configuration, ActivitySource activitySource) : base(appLifetime, services, detectOnlineService, detectVersionService, logger, telemetryLogger, migrationToolVersion, configuration, activitySource)
         {
             _logger = logger;
         }
 
-        internal override async Task<int> ExecuteInternalAsync(CommandContext context, UpgradeConfigCommandSettings settings)
+        internal override Task<int> ExecuteInternalAsync(CommandContext context, UpgradeConfigCommandSettings settings)
         {
             CommandActivity.SetTagsFromObject(settings);
             int _exitCode = 0;
@@ -63,7 +61,7 @@ namespace MigrationTools.Host.Commands
             File.WriteAllText(configFile, json);
             _logger.LogInformation("New {configFile} file has been created", configFile);
             Console.WriteLine(json);
-            return _exitCode;
+            return Task.FromResult(_exitCode);
         }
 
 

--- a/src/MigrationTools.Host/MigrationToolHost.cs
+++ b/src/MigrationTools.Host/MigrationToolHost.cs
@@ -34,13 +34,10 @@ using System.Net.NetworkInformation;
 namespace MigrationTools.Host
 {
 
-    
+
 
     public static class MigrationToolHost
     {
-        static int logs = 1;
-        private static bool LoggerHasBeenBuilt = false;
-
         public static IEnumerable<T> GetAll<T>(this IServiceProvider provider)
         {
             var site = typeof(ServiceProvider).GetProperty("CallSiteFactory", BindingFlags.Instance | BindingFlags.NonPublic).GetValue(provider);
@@ -57,7 +54,7 @@ namespace MigrationTools.Host
 
             var hostBuilder = Microsoft.Extensions.Hosting.Host.CreateDefaultBuilder(args);
 
-            var outputTemplate = "[{Timestamp:HH:mm:ss} {Level:u3}] [{versionString}] {Message:lj} {NewLine}{Exception}"; // 
+            var outputTemplate = "[{Timestamp:HH:mm:ss} {Level:u3}] [{versionString}] {Message:lj} {NewLine}{Exception}"; //
 
             hostBuilder.UseSerilog((hostingContext, services, loggerConfiguration) =>
             {
@@ -73,8 +70,6 @@ namespace MigrationTools.Host
                             .Filter.ByExcluding(Matching.FromSource("Microsoft.Extensions.Hosting.Internal.Host"))
                             .WriteTo.Console(theme: AnsiConsoleTheme.Code, outputTemplate: outputTemplate))
                     ;
-                    
-                LoggerHasBeenBuilt = true;
             });
 
             hostBuilder.ConfigureLogging((context, logBuilder) =>

--- a/src/MigrationTools.Host/Services/DetectVersionService2.cs
+++ b/src/MigrationTools.Host/Services/DetectVersionService2.cs
@@ -19,8 +19,6 @@ namespace MigrationTools.Host.Services
         private WinGetPackageManager _packageManager;
         private WinGetPackage _package = null;
         private bool _packageChecked = false;
-        private bool _ServiceInitialised = false;
-        private Guid UniqueID = Guid.NewGuid();
 
         private WinGetPackage Package
         {

--- a/src/MigrationTools.Shadows/Endpoints/FakeEndpoint.cs
+++ b/src/MigrationTools.Shadows/Endpoints/FakeEndpoint.cs
@@ -20,6 +20,7 @@ namespace MigrationTools.Endpoints.Shadows
         {
         }
 
+        [Obsolete("Dont know what this is for")]
         public override int Count => 0;
     }
 

--- a/src/MigrationTools.Telemetery/GetGraphWorkItemMetrics.cs
+++ b/src/MigrationTools.Telemetery/GetGraphWorkItemMetrics.cs
@@ -101,8 +101,8 @@ namespace MigrationTools.Telemetry
             {
                 FileDownloadName = "workitems_graph.png"
             };
-            req.HttpContext.Response.Headers.Add("Cache-Control", "public, max-age=14400");
-            req.HttpContext.Response.Headers.Add("Expires", DateTime.UtcNow.AddHours(1).ToString("R"));
+            req.HttpContext.Response.Headers.CacheControl = "public, max-age=14400";
+            req.HttpContext.Response.Headers.Expires = DateTime.UtcNow.AddHours(1).ToString("R");
 
             // Return the graph image as an HTTP response
             return responseHeaders;
@@ -111,7 +111,8 @@ namespace MigrationTools.Telemetry
         // Method to generate the graph using OxyPlot
         private MemoryStream GenerateGraph(AppInsightsResponse data, string versionLabel)
         {
-            var plotModel = new PlotModel {
+            var plotModel = new PlotModel
+            {
                 Title = $"Work Items Processed ({versionLabel})",
                 TitleColor = OxyColor.Parse("#2575fc"), // Updated title color as requested
                 DefaultColors = new List<OxyColor> { OxyColor.Parse("#2575fc") } // Updated default color as requested
@@ -145,7 +146,7 @@ namespace MigrationTools.Telemetry
             {
                 MarkerType = MarkerType.Circle,
                 MarkerSize = 4,
-                MarkerStroke = OxyColors.Purple                 
+                MarkerStroke = OxyColors.Purple
             };
 
             // Generate list of the last 30 days and pad missing days with zero

--- a/src/MigrationTools/ConfigException.cs
+++ b/src/MigrationTools/ConfigException.cs
@@ -17,9 +17,5 @@ namespace MigrationTools
         public ConfigException(string message, Exception innerException) : base(message, innerException)
         {
         }
-
-        protected ConfigException(SerializationInfo info, StreamingContext context) : base(info, context)
-        {
-        }
     }
 }

--- a/src/MigrationTools/Processors/Infrastructure/ProcessorOptions.cs
+++ b/src/MigrationTools/Processors/Infrastructure/ProcessorOptions.cs
@@ -51,7 +51,6 @@ namespace MigrationTools.Processors.Infrastructure
         public IProcessorOptions GetSample()
         {
             throw new NotImplementedException();
-            return null; 
         }
 
         public bool IsProcessorCompatible(IReadOnlyList<IProcessorConfig> otherProcessors)

--- a/src/MigrationTools/Services/MigrationToolVersionInfo.cs
+++ b/src/MigrationTools/Services/MigrationToolVersionInfo.cs
@@ -33,7 +33,7 @@ namespace MigrationTools.Services
             {
                 // Do nothing
             }
-            
+
         }
     }
 
@@ -84,11 +84,11 @@ namespace MigrationTools.Services
                 }
                 return (version, matches[0].Groups[1].Value, textVersion);
             }
-            catch (Exception ex)
+            catch (Exception)
             {
                 return (new Version(0, 0, 0, 0), "ex", "0.0.0-ex");
             }
-           
+
         }
     }
 

--- a/src/MigrationTools/Tools/Infrastructure/IToolOptions.cs
+++ b/src/MigrationTools/Tools/Infrastructure/IToolOptions.cs
@@ -8,6 +8,5 @@ namespace MigrationTools.Tools.Infrastructure
 {
     public interface IToolOptions : IOptions
     {
-        bool Enabled { get; set; }
     }
 }

--- a/src/MigrationTools/_EngineV1/Configuration/IProcessorConfig.cs
+++ b/src/MigrationTools/_EngineV1/Configuration/IProcessorConfig.cs
@@ -8,12 +8,6 @@ namespace MigrationTools._EngineV1.Configuration
     public interface IProcessorConfig : IOptions
     {
         /// <summary>
-        /// Active the processor if it true.
-        /// </summary>
-        [JsonProperty(Order = -200)]
-        bool Enabled { get; set; }
-
-        /// <summary>
         /// Indicates, if this processor can be added to the list of current processors or not.
         /// Some processors are not compatible with each other.
         /// </summary>


### PR DESCRIPTION
This fixes most of the code warnings that are in the codebase. There is a separate commit for every warning type.

There still are 4 instances of warning **CS0649 Field '…' is never assigned to, and will always have its default value null**:

- `PauseAfterEachItem._Options`
- `KeepOutboundLinkTargetProcessor._options`
- `OutboundLinkCheckingProcessor._options`
- `TfsWorkItemOverwriteAreasAsTagsProcessor._config`

As the warning states, these are fields which are declared, but are never set ad hence the value is `null`. The problem is, I cannot remove these fileds, because _they are used in code_. So I believe, that those classes (or at least those specific code paths) are not used at all, because it would fail with `NullReferenceException`. The only possibility is, that the values are set somewhere by reflection? So I will leave these warnings to someone else to look at them.