### PR TITLE
TfsUserMappingTool: fix loading users from TFS connected to Active Directory

### DIFF
--- a/src/MigrationTools.Clients.TfsObjectModel/Processors/TfsExportUsersForMappingProcessor.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/Processors/TfsExportUsersForMappingProcessor.cs
@@ -1,23 +1,15 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using MigrationTools;
 using MigrationTools.Clients;
-using MigrationTools._EngineV1.Configuration;
-using MigrationTools._EngineV1.Configuration.Processing;
-
 using MigrationTools.DataContracts;
-using MigrationTools.DataContracts.Process;
-using MigrationTools.EndpointEnrichers;
 using MigrationTools.Enrichers;
 using MigrationTools.Processors.Infrastructure;
 using MigrationTools.Tools;
 using Newtonsoft.Json;
-
 
 namespace MigrationTools.Processors
 {
@@ -29,10 +21,16 @@ namespace MigrationTools.Processors
     /// <processingtarget>Work Items</processingtarget>
     public class TfsExportUsersForMappingProcessor : TfsProcessor
     {
-        public TfsExportUsersForMappingProcessor(IOptions<TfsExportUsersForMappingProcessorOptions> options, TfsCommonTools tfsCommonTools, ProcessorEnricherContainer processorEnrichers, IServiceProvider services, ITelemetryLogger telemetry, ILogger<TfsExportUsersForMappingProcessor> logger) : base(options, tfsCommonTools, processorEnrichers, services, telemetry, logger)
+        public TfsExportUsersForMappingProcessor(
+            IOptions<TfsExportUsersForMappingProcessorOptions> options,
+            TfsCommonTools tfsCommonTools,
+            ProcessorEnricherContainer processorEnrichers,
+            IServiceProvider services,
+            ITelemetryLogger telemetry,
+            ILogger<TfsExportUsersForMappingProcessor> logger)
+            : base(options, tfsCommonTools, processorEnrichers, services, telemetry, logger)
         {
         }
-
 
         new TfsExportUsersForMappingProcessorOptions Options => (TfsExportUsersForMappingProcessorOptions)base.Options;
 
@@ -44,13 +42,12 @@ namespace MigrationTools.Processors
         {
             Stopwatch stopwatch = Stopwatch.StartNew();
 
-            if(string.IsNullOrEmpty(CommonTools.UserMapping.Options.UserMappingFile))
+            if (string.IsNullOrEmpty(CommonTools.UserMapping.Options.UserMappingFile))
             {
                 Log.LogError("UserMappingFile is not set");
-
                 throw new ArgumentNullException("UserMappingFile must be set on the TfsUserMappingToolOptions in CommonEnrichersConfig.");
-                       }
-         
+            }
+
             List<IdentityMapData> usersToMap = new List<IdentityMapData>();
             if (Options.OnlyListUsersInWorkItems)
             {
@@ -68,14 +65,15 @@ namespace MigrationTools.Processors
                 Log.LogInformation("Found {usersToMap} total mapped", usersToMap.Count);
             }
 
-            usersToMap = usersToMap.Where(x => x.Source.FriendlyName != x.target?.FriendlyName).ToList();
+            usersToMap = usersToMap.Where(x => x.Source.FriendlyName != x.Target?.FriendlyName).ToList();
             Log.LogInformation("Filtered to {usersToMap} total viable mappings", usersToMap.Count);
-            Dictionary<string, string> usermappings = usersToMap.ToDictionary(x => x.Source.FriendlyName, x => x.target?.FriendlyName);
+            Dictionary<string, string> usermappings = usersToMap.ToDictionary(x => x.Source.FriendlyName, x => x.Target?.FriendlyName);
             System.IO.File.WriteAllText(CommonTools.UserMapping.Options.UserMappingFile, Newtonsoft.Json.JsonConvert.SerializeObject(usermappings, Formatting.Indented));
+            System.IO.File.WriteAllText(CommonTools.UserMapping.Options.UserMappingFile, JsonConvert.SerializeObject(usermappings, Formatting.Indented));
             Log.LogInformation("Writen to: {LocalExportJsonFile}", CommonTools.UserMapping.Options.UserMappingFile);
-            //////////////////////////////////////////////////
+
             stopwatch.Stop();
-            Log.LogInformation("DONE in {Elapsed} seconds");
+            Log.LogInformation("DONE in {Elapsed} seconds", stopwatch.Elapsed);
         }
     }
 }

--- a/src/MigrationTools.Clients.TfsObjectModel/Processors/TfsExportUsersForMappingProcessor.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/Processors/TfsExportUsersForMappingProcessor.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -67,8 +67,13 @@ namespace MigrationTools.Processors
 
             usersToMap = usersToMap.Where(x => x.Source.FriendlyName != x.Target?.FriendlyName).ToList();
             Log.LogInformation("Filtered to {usersToMap} total viable mappings", usersToMap.Count);
-            Dictionary<string, string> usermappings = usersToMap.ToDictionary(x => x.Source.FriendlyName, x => x.Target?.FriendlyName);
-            System.IO.File.WriteAllText(CommonTools.UserMapping.Options.UserMappingFile, Newtonsoft.Json.JsonConvert.SerializeObject(usermappings, Formatting.Indented));
+            Dictionary<string, string> usermappings = [];
+            foreach (IdentityMapData userMapping in usersToMap)
+            {
+                // We cannot use ToDictionary(), because there can be multiple users with the same friendly name and so
+                // it would throw with duplicate key. This way we just overwrite the value – last item in source wins.
+                usermappings[userMapping.Source.FriendlyName] = userMapping.Target?.FriendlyName;
+            }
             System.IO.File.WriteAllText(CommonTools.UserMapping.Options.UserMappingFile, JsonConvert.SerializeObject(usermappings, Formatting.Indented));
             Log.LogInformation("Writen to: {LocalExportJsonFile}", CommonTools.UserMapping.Options.UserMappingFile);
 

--- a/src/MigrationTools/DataContracts/IdentityItemData.cs
+++ b/src/MigrationTools/DataContracts/IdentityItemData.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace MigrationTools.DataContracts
+﻿namespace MigrationTools.DataContracts
 {
     public class IdentityItemData
     {
@@ -13,6 +9,6 @@ namespace MigrationTools.DataContracts
     public class IdentityMapData
     {
         public IdentityItemData Source { get; set; }
-        public IdentityItemData target { get; set; }
+        public IdentityItemData Target { get; set; }
     }
 }


### PR DESCRIPTION
`TfsUserMappingTool` is not working correctly in our scenario, which is:

- As our source server, we have on-premise TFS 2018 connected to on-premise Active Directory.
- As our target server, we have Azure DevOps connected to Azure Entra ID (formerly Azure Active Directory).

`TfsUserMappingTool` is not working at all, because **it will not load any user** from our on-premise TFS server. The problem is this part:

```cs
var people = SIDS.Members.ToList().Where(x => x.Contains("\\")).Select(x => x);
```

It processes only users, whose SID contains `\` character. But none of our users in TFS contains this. All data in `SIDS.Members` are SIDs of some kind of identity and we need to process them all. So the new logic is this:

- All SIDs are processed, so identity for every one of them is retrieved from the server.
- Identity type is checked if we can use this identity. Allowed identity types for mapping are `WindowsUser` and `UnknownIdentityType`.
  - All identities in Entra ID have type `UnknownIdentityType`.

This works as expected and loads correct user lists from TFS and DevOps.