### PR TITLE
TfsExportUsersForMappingProcessor: allow matching users by email

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -40,6 +40,7 @@
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.9.0" />
     <PackageVersion Include="OxyPlot.Core" Version="2.2.0" />
     <PackageVersion Include="OxyPlot.ImageSharp" Version="2.2.0" />
+    <PackageVersion Include="Riok.Mapperly" Version="4.1.0" />
     <PackageVersion Include="Serilog" Version="4.0.1" />
     <PackageVersion Include="Serilog.Enrichers.Environment" Version="3.0.1" />
     <PackageVersion Include="Serilog.Enrichers.Process" Version="3.0.0" />

--- a/src/MigrationTools.Clients.TfsObjectModel/MigrationTools.Clients.TfsObjectModel.csproj
+++ b/src/MigrationTools.Clients.TfsObjectModel/MigrationTools.Clients.TfsObjectModel.csproj
@@ -40,6 +40,7 @@
     <PackageReference Include="OpenTelemetry.Exporter.Console" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" />
+    <PackageReference Include="Riok.Mapperly" />
     <PackageReference Include="TfsUrlParser" />
   </ItemGroup>
 

--- a/src/MigrationTools.Clients.TfsObjectModel/Processors/TfsExportUsersForMappingProcessor.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/Processors/TfsExportUsersForMappingProcessor.cs
@@ -65,14 +65,14 @@ namespace MigrationTools.Processors
                 Log.LogInformation("Found {usersToMap} total mapped", usersToMap.Count);
             }
 
-            usersToMap = usersToMap.Where(x => x.Source.FriendlyName != x.Target?.FriendlyName).ToList();
+            usersToMap = usersToMap.Where(x => x.Source.DisplayName != x.Target?.DisplayName).ToList();
             Log.LogInformation("Filtered to {usersToMap} total viable mappings", usersToMap.Count);
             Dictionary<string, string> usermappings = [];
             foreach (IdentityMapData userMapping in usersToMap)
             {
-                // We cannot use ToDictionary(), because there can be multiple users with the same friendly name and so
+                // We cannot use ToDictionary(), because there can be multiple users with the same display name and so
                 // it would throw with duplicate key. This way we just overwrite the value – last item in source wins.
-                usermappings[userMapping.Source.FriendlyName] = userMapping.Target?.FriendlyName;
+                usermappings[userMapping.Source.DisplayName] = userMapping.Target?.DisplayName;
             }
             System.IO.File.WriteAllText(CommonTools.UserMapping.Options.UserMappingFile, JsonConvert.SerializeObject(usermappings, Formatting.Indented));
             Log.LogInformation("Writen to: {LocalExportJsonFile}", CommonTools.UserMapping.Options.UserMappingFile);

--- a/src/MigrationTools.Clients.TfsObjectModel/Tools/TfsUserMappingTool.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/Tools/TfsUserMappingTool.cs
@@ -22,9 +22,9 @@ namespace MigrationTools.Tools
         {
         }
 
-        private List<string> GetUsersFromWorkItems(List<WorkItemData> workitems, List<string> identityFieldsToCheck)
+        private HashSet<string> GetUsersFromWorkItems(List<WorkItemData> workitems, List<string> identityFieldsToCheck)
         {
-            List<string> foundUsers = new List<string>();
+            HashSet<string> foundUsers = new(StringComparer.CurrentCultureIgnoreCase);
             foreach (var wItem in workitems)
             {
                 foreach (var rItem in wItem.Revisions.Values)
@@ -148,7 +148,7 @@ namespace MigrationTools.Tools
             if (Options.Enabled)
             {
                 Dictionary<string, string> result = new Dictionary<string, string>();
-                List<string> workItemUsers = GetUsersFromWorkItems(sourceWorkItems, Options.IdentityFieldsToCheck);
+                HashSet<string> workItemUsers = GetUsersFromWorkItems(sourceWorkItems, Options.IdentityFieldsToCheck);
                 Log.LogDebug($"TfsUserMappingTool::GetUsersInSourceMappedToTargetForWorkItems [workItemUsers|{workItemUsers.Count}]");
                 List<IdentityMapData> mappedUsers = GetUsersInSourceMappedToTarget(processor);
                 Log.LogDebug($"TfsUserMappingTool::GetUsersInSourceMappedToTargetForWorkItems [mappedUsers|{mappedUsers.Count}]");

--- a/src/MigrationTools.Clients.TfsObjectModel/Tools/TfsUserMappingTool.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/Tools/TfsUserMappingTool.cs
@@ -22,6 +22,8 @@ namespace MigrationTools.Tools
         {
         }
 
+        private readonly CaseInsensitiveStringComparer _workItemNameComparer = new();
+
         private HashSet<string> GetUsersFromWorkItems(List<WorkItemData> workitems, List<string> identityFieldsToCheck)
         {
             HashSet<string> foundUsers = new(StringComparer.CurrentCultureIgnoreCase);
@@ -31,7 +33,7 @@ namespace MigrationTools.Tools
                 {
                     foreach (var fItem in rItem.Fields.Values)
                     {
-                        if (identityFieldsToCheck.Contains(fItem.ReferenceName, new CaseInsensativeStringComparer()))
+                        if (identityFieldsToCheck.Contains(fItem.ReferenceName, _workItemNameComparer))
                         {
                             if (!foundUsers.Contains(fItem.Value) && !string.IsNullOrEmpty((string)fItem.Value))
                             {
@@ -162,7 +164,7 @@ namespace MigrationTools.Tools
         }
     }
 
-    public class CaseInsensativeStringComparer : IEqualityComparer<string>
+    internal class CaseInsensitiveStringComparer : IEqualityComparer<string>
     {
         public bool Equals(string x, string y)
         {

--- a/src/MigrationTools.Clients.TfsObjectModel/Tools/TfsUserMappingToolOptions.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/Tools/TfsUserMappingToolOptions.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using Microsoft.TeamFoundation.Build.Client;
-using MigrationTools.Enrichers;
+﻿using System.Collections.Generic;
 using MigrationTools.Tools.Infrastructure;
 
 namespace MigrationTools.Tools
@@ -10,7 +7,7 @@ namespace MigrationTools.Tools
     {
 
         /// <summary>
-        /// This is a list of the Identiy fields in the Source to check for user mapping purposes. You should list all identiy fields that you wan to map.
+        /// This is a list of the Identiy fields in the Source to check for user mapping purposes. You should list all identiy fields that you want to map.
         /// </summary>
         public List<string> IdentityFieldsToCheck { get; set; }
 
@@ -19,11 +16,17 @@ namespace MigrationTools.Tools
         /// </summary>
         public string UserMappingFile { get; set; }
 
+        /// <summary>
+        /// By default, users in source are mapped to target users by their display name. If this is set to true, then the
+        /// users will be mapped by their email address first. If no match is found, then the display name will be used.
+        /// </summary>
+        public bool MatchUsersByEmail { get; set; }
     }
 
     public interface ITfsUserMappingToolOptions
     {
         List<string> IdentityFieldsToCheck { get; set; }
         string UserMappingFile { get; set; }
+        bool MatchUsersByEmail { get; set; }
     }
 }

--- a/src/MigrationTools/DataContracts/IdentityItemData.cs
+++ b/src/MigrationTools/DataContracts/IdentityItemData.cs
@@ -2,8 +2,11 @@
 {
     public class IdentityItemData
     {
-        public string FriendlyName { get; set; }
+        public string Sid { get; set; }
+        public string DisplayName { get; set; }
+        public string Domain { get; set; }
         public string AccountName { get; set; }
+        public string MailAddress { get; set; }
     }
 
     public class IdentityMapData


### PR DESCRIPTION
Our scenario is:

- Source server is on-premise TFS 2018 connected to on-premise Active Directory.
- Target server is Azure DevOps connected to Azure Entra ID (formerly Azure Active Directory).

Even when the users are synchronized between the Active Directiories, the users' display names are often different between the two. So default matchind by display name does not work for us. I implemented the possibility to match users by email (at least for us it works for most cases). This matching is turned off by default. When turned on, it has higher precedence than matching by display name. So first, match by email is looked for and if no match is found, default matching by display name is used.

Because of this I expanded properties of the users loaded from server. I still do not use all of them, but I want to keep them for future use (I have another PR prepared). Because of this, I also added mapper ([Riok.Mapperly](https://github.com/riok/mapperly)), so I do not need to copy properties one by one when creating `IdentityItemData` object from `Identity` object.