### PR TITLE
TfsExportUsersForMappingProcessor: export all users in source and target server to JSON file

### DIFF
--- a/src/MigrationTools.Clients.TfsObjectModel/Processors/TfsExportUsersForMappingProcessorOptions.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/Processors/TfsExportUsersForMappingProcessorOptions.cs
@@ -1,7 +1,4 @@
-﻿using System.Collections.Generic;
-using MigrationTools._EngineV1.Configuration;
-using MigrationTools.Enrichers;
-using MigrationTools.Processors.Infrastructure;
+﻿using MigrationTools.Processors.Infrastructure;
 
 namespace MigrationTools.Processors
 {
@@ -16,5 +13,17 @@ namespace MigrationTools.Processors
         /// <default>true</default>
         public bool OnlyListUsersInWorkItems { get; set; } = true;
 
+        /// <summary>
+        /// Set to <see langword="true"/>, if you want to export all users in source and target server.
+        /// The lists of user can be useful, if you need tu manually edit mapping file.
+        /// Users will be exported to file set in <see cref="UserExportFile"/>.
+        /// </summary>
+        public bool ExportAllUsers { get; set; }
+
+        /// <summary>
+        /// Path to export file where all source and target servers' users will be exported.
+        /// Users are exported only if <see cref="ExportAllUsers"/> is set to <see langword="true"/>.
+        /// </summary>
+        public string UserExportFile { get; set; }
     }
 }

--- a/src/MigrationTools.Clients.TfsObjectModel/Processors/TfsWorkItemMigrationProcessor.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/Processors/TfsWorkItemMigrationProcessor.cs
@@ -227,15 +227,15 @@ namespace MigrationTools.Processors
 
         private void ValidateAllUsersExistOrAreMapped(List<WorkItemData> sourceWorkItems)
         {
-
             contextLog.Information("Validating::Check that all users in the source exist in the target or are mapped!");
-            List<IdentityMapData> usersToMap = new List<IdentityMapData>();
-            usersToMap = CommonTools.UserMapping.GetUsersInSourceMappedToTargetForWorkItems(this, sourceWorkItems);
-            if (usersToMap != null && usersToMap?.Count > 0)
+            IdentityMapResult usersToMap = CommonTools.UserMapping.GetUsersInSourceMappedToTargetForWorkItems(this, sourceWorkItems);
+            if (usersToMap.IdentityMap != null && usersToMap.IdentityMap.Count > 0)
             {
-                Log.LogWarning("Validating Failed! There are {usersToMap} users that exist in the source that do not exist in the target. This will not cause any errors, but may result in disconnected users that could have been mapped. Use the ExportUsersForMapping processor to create a list of mappable users. Then Import using ", usersToMap.Count);
+                Log.LogWarning("Validating Failed! There are {usersToMap} users that exist in the source that do not exist "
+                    + "in the target. This will not cause any errors, but may result in disconnected users that could have "
+                    + "been mapped. Use the ExportUsersForMapping processor to create a list of mappable users.",
+                    usersToMap.IdentityMap.Count);
             }
-
         }
 
         //private void ValidateAllNodesExistOrAreMapped(List<WorkItemData> sourceWorkItems)

--- a/src/MigrationTools/DataContracts/IdentityItemData.cs
+++ b/src/MigrationTools/DataContracts/IdentityItemData.cs
@@ -1,4 +1,6 @@
-﻿namespace MigrationTools.DataContracts
+﻿using System.Collections.Generic;
+
+namespace MigrationTools.DataContracts
 {
     public class IdentityItemData
     {
@@ -13,5 +15,12 @@
     {
         public IdentityItemData Source { get; set; }
         public IdentityItemData Target { get; set; }
+    }
+
+    public class IdentityMapResult
+    {
+        public List<IdentityMapData> IdentityMap { get; set; } = [];
+        public List<IdentityItemData> SourceUsers { get; set; } = [];
+        public List<IdentityItemData> TargetUsers { get; set; } = [];
     }
 }


### PR DESCRIPTION
Our scenario is:

- Source server is on-premise TFS 2018 connected to on-premise Active Directory.
- Target server is Azure DevOps connected to Azure Entra ID (formerly Azure Active Directory).

Even when the users are synchronized between the Active Directiories, the users' display names are often different and also quite a bunch of email addresses are different. So a lot of people are not matched at all and in exported mapping file, the target name is `null`. So the mapping file needs to be manually edited to add missing users. Usually (almost always), the user is in target server, but has different email and display name. To help find the corresponding user, this PR allows to export all users in source and target server into separate JSON. We can than find the user we need and use his correct display name in mapping file.

Two properties are added to `TfsExportUsersForMappingProcessorOptions`:

- `ExportAllUsers` – turns this feature on.
- `UserExportFile` – path to file, where users will be exported.

## Example of export

``` json
{
    "SourceUsers": [
        {
            "Sid": "24b644ca-b413-4bd5-bdea-466534a69c72:Build:1cf84e9e-e068-4a9a-b12e-bf058294c1f5",
            "DisplayName": "Lorem Ipsum",
            "Domain": "Build",
            "AccountName": "lorem",
            "MailAddress": "lorem@example.com"
        },
        ...
    "TargetUsers": [
        {
            "Sid": "751af7c1-c13a-4f1b-888e-da6f6db86a01:Build:0132d9af-7fab-4f97-8170-b28466e07427",
            "DisplayName": "Dolor Sit",
            "Domain": "Build",
            "AccountName": "dolor",
            "MailAddress": "dolor@example.com"
        },
        ...
}
```