### PR TITLE
TfsUserMappingTool: make user map public, fix user mapping (de)serialization

### DIFF
--- a/src/MigrationTools.Clients.TfsObjectModel/Processors/TfsExportUsersForMappingProcessor.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/Processors/TfsExportUsersForMappingProcessor.cs
@@ -64,15 +64,14 @@ namespace MigrationTools.Processors
 
             List<IdentityMapData> usersToMap = data.IdentityMap.Where(x => x.Source.DisplayName != x.Target?.DisplayName).ToList();
             Log.LogInformation("Filtered to {usersToMap} total viable mappings", usersToMap.Count);
-            Dictionary<string, string> usermappings = [];
+            Dictionary<string, string> usermappings = new(StringComparer.CurrentCultureIgnoreCase);
             foreach (IdentityMapData userMapping in usersToMap)
             {
                 // We cannot use ToDictionary(), because there can be multiple users with the same display name and so
                 // it would throw with duplicate key. This way we just overwrite the value – last item in source wins.
                 usermappings[userMapping.Source.DisplayName] = userMapping.Target?.DisplayName;
             }
-            File.WriteAllText(CommonTools.UserMapping.Options.UserMappingFile, JsonConvert.SerializeObject(usermappings, Formatting.Indented));
-            Log.LogInformation("User mappings writen to: {LocalExportJsonFile}", CommonTools.UserMapping.Options.UserMappingFile);
+            TfsUserMappingTool.SerializeUserMap(CommonTools.UserMapping.Options.UserMappingFile, usermappings, Log);
             if (Options.ExportAllUsers)
             {
                 ExportAllUsers(data);

--- a/src/MigrationTools.Clients.TfsObjectModel/Tools/TfsUserMappingTool.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/Tools/TfsUserMappingTool.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -8,6 +9,7 @@ using Microsoft.TeamFoundation.WorkItemTracking.Client;
 using MigrationTools.DataContracts;
 using MigrationTools.Processors.Infrastructure;
 using MigrationTools.Tools.Infrastructure;
+using Newtonsoft.Json;
 using Riok.Mapperly.Abstractions;
 
 namespace MigrationTools.Tools
@@ -31,6 +33,27 @@ namespace MigrationTools.Tools
 
         private readonly CaseInsensitiveStringComparer _workItemNameComparer = new();
         private readonly TfsUserMappingToolMapper _mapper = new();
+
+        public static void SerializeUserMap(string fileName, Dictionary<string, string> userMap, ILogger logger)
+        {
+            File.WriteAllText(fileName, JsonConvert.SerializeObject(userMap, Formatting.Indented));
+            logger.LogInformation("User mappings writen to: {fileName}", fileName);
+        }
+
+        public static Dictionary<string, string> DeserializeUserMap(string fileName, ILogger logger)
+        {
+            try
+            {
+                string fileData = File.ReadAllText(fileName);
+                var mapping = JsonConvert.DeserializeObject<Dictionary<string, string>>(fileData);
+                return new Dictionary<string, string>(mapping, StringComparer.CurrentCultureIgnoreCase);
+            }
+            catch (Exception)
+            {
+                logger.LogError($"TfsUserMappingTool::DeserializeUserMap User mapping could not be deserialized from file '{fileName}'.", fileName);
+            }
+            return [];
+        }
 
         private HashSet<string> GetUsersFromWorkItems(List<WorkItemData> workitems, List<string> identityFieldsToCheck)
         {
@@ -72,22 +95,12 @@ namespace MigrationTools.Tools
 
         private Dictionary<string, string> GetMappingFileData()
         {
-            if (!System.IO.File.Exists(Options.UserMappingFile))
+            if (!File.Exists(Options.UserMappingFile))
             {
                 Log.LogError("TfsUserMappingTool::GetMappingFileData:: The UserMappingFile '{UserMappingFile}' cant be found! Provide a valid file or disable TfsUserMappingTool!", Options.UserMappingFile);
                 return [];
             }
-            var fileData = System.IO.File.ReadAllText(Options.UserMappingFile);
-            try
-            {
-                var fileMaps = Newtonsoft.Json.JsonConvert.DeserializeObject<List<IdentityMapData>>(fileData);
-                return fileMaps.ToDictionary(x => x.Source.DisplayName, x => x.Target?.DisplayName);
-            }
-            catch (Exception)
-            {
-                Log.LogError($"TfsUserMappingTool::GetMappingFileData [UserMappingFile|{Options.UserMappingFile}] <-- invalid - No mapping are applied!");
-            }
-            return [];
+            return DeserializeUserMap(Options.UserMappingFile, Log);
         }
 
         private List<IdentityItemData> GetUsersListFromServer(IGroupSecurityService gss)


### PR DESCRIPTION
User mapping was defined in `TfsUserMappingTool._UserMappings` _private_ field and used only in one place by `TfsUserMappingTool.MapUserIdentityField` method. I believe, that user mapping can be used in some other places, for example users are loaded when migrating team backlog capacities. Now it triggers a lot of warning for us, because users in source are not the same as users in target. So I want to use user mapping also in this case. (I do not know yet, but maybe there are more places where user mapping can be used.)

So this PR makes public property `TfsUserMappingTool.UserMappings` as a lazy dictionary, that can be used later anywhere.

During this, I noticed a bug, which means, that probably no-one is using user mappings. The problem is, that user mapping JSON file was generated in `TfsExportUsersForMappingProcessor` and it serialized simple `Dictionary<string, string>`. But when used, the file is deserialized in `TfsUserMappingTool`, but it tried to deserialize data as `List<IdentityMapData>`. I moved serialization and deserialization to `TfsUserMappingTool` as static method, so they are next to each other and both works with `Dictionary<string, string>`.