### PR TITLE
UsersToMap can be null

### DIFF
--- a/src/MigrationTools.Clients.TfsObjectModel/Processors/TfsWorkItemMigrationProcessor.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/Processors/TfsWorkItemMigrationProcessor.cs
@@ -229,7 +229,7 @@ namespace MigrationTools.Processors
         {
             contextLog.Information("Validating::Check that all users in the source exist in the target or are mapped!");
             IdentityMapResult usersToMap = CommonTools.UserMapping.GetUsersInSourceMappedToTargetForWorkItems(this, sourceWorkItems);
-            if (usersToMap.IdentityMap != null && usersToMap.IdentityMap.Count > 0)
+            if (usersToMap != null && usersToMap.IdentityMap != null && usersToMap.IdentityMap.Count > 0)
             {
                 Log.LogWarning("Validating Failed! There are {usersToMap} users that exist in the source that do not exist "
                     + "in the target. This will not cause any errors, but may result in disconnected users that could have "


### PR DESCRIPTION
🐛 (TfsWorkItemMigrationProcessor.cs): add null check for usersToMap to prevent potential null reference exception

The change adds a null check for the `usersToMap` object before accessing its `IdentityMap` property. This prevents a potential null reference exception if `usersToMap` is null, ensuring the application handles such cases gracefully and improves overall stability.

FYI @satano 

Closes: #2544
Discussion: https://github.com/nkdAgility/azure-devops-migration-tools/discussions/2540