### PR TITLE
Bug in Chaneset Mapping

### DIFF
--- a/src/MigrationTools.Clients.TfsObjectModel/ServiceCollectionExtensions.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/ServiceCollectionExtensions.cs
@@ -30,6 +30,7 @@ namespace MigrationTools
             context.AddSingleton<TfsNodeStructureTool>().AddMigrationToolsOptions<TfsNodeStructureToolOptions, TfsNodeStructureToolOptionsValidator>(configuration);
             context.AddSingleton<TfsRevisionManagerTool>().AddMigrationToolsOptions<TfsRevisionManagerToolOptions>(configuration);
             context.AddSingleton<TfsTeamSettingsTool>().AddMigrationToolsOptions<TfsTeamSettingsToolOptions>(configuration);
+            context.AddSingleton< TfsChangeSetMappingTool>().AddMigrationToolsOptions<TfsChangeSetMappingToolOptions>(configuration);
         }
 
         public static void AddMigrationToolServicesForClientTfs_Processors(this IServiceCollection context)

--- a/src/MigrationTools.Clients.TfsObjectModel/Tools/TfsGitRepositoryTool.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/Tools/TfsGitRepositoryTool.cs
@@ -84,7 +84,7 @@ namespace MigrationTools.Tools
             }
 
             Log.LogInformation("GitRepositoryEnricher: Enriching {Id} To fix Git Repo Links", targetWorkItem.Id);
-            var changeSetMappings = Services.GetService<TfsChangeSetMappingTool>();
+            var changeSetMappings = Services.GetRequiredService<TfsChangeSetMappingTool>();
             List<ExternalLink> newEL = new List<ExternalLink>();
             List<ExternalLink> removeEL = new List<ExternalLink>();
             int count = 0;


### PR DESCRIPTION
Fix #2521 reported by @nirkal \n\n ✨ (ServiceCollectionExtensions.cs, TfsGitRepositoryTool.cs): add TfsChangeSetMappingTool to service collection and ensure required service retrieval

Add `TfsChangeSetMappingTool` to the service collection to enable its configuration and usage within the application. Change the retrieval method of `TfsChangeSetMappingTool` from `GetService` to `GetRequiredService` to ensure that the service is available and to prevent potential null reference exceptions. This change enhances the robustness and configurability of the application by ensuring necessary services are properly registered and retrieved.