### PR TITLE
Refactor StringManipulator tool so it works just with string and not work item field

### DIFF
--- a/src/MigrationTools.Clients.TfsObjectModel/Processors/TfsWorkItemMigrationProcessor.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/Processors/TfsWorkItemMigrationProcessor.cs
@@ -449,8 +449,9 @@ namespace MigrationTools.Processors
                     switch (f.FieldDefinition.FieldType)
                     {
                         case FieldType.String:
-                            CommonTools.StringManipulator.ProcessorExecutionWithFieldItem(null, oldWorkItemData.Fields[f.ReferenceName]);
-                            newWorkItem.Fields[f.ReferenceName].Value = oldWorkItemData.Fields[f.ReferenceName].Value;
+                            string oldValue = oldWorkItem.Fields[f.ReferenceName].Value.ToString();
+                            string newValue = CommonTools.StringManipulator.ProcessString(oldValue);
+                            newWorkItem.Fields[f.ReferenceName].Value = newValue;
                             break;
                         default:
                             newWorkItem.Fields[f.ReferenceName].Value = oldWorkItem.Fields[f.ReferenceName].Value;

--- a/src/MigrationTools.Shadows/Tools/MockStringManipulatorTool.cs
+++ b/src/MigrationTools.Shadows/Tools/MockStringManipulatorTool.cs
@@ -1,17 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using MigrationTools.DataContracts;
-using MigrationTools.Processors.Infrastructure;
-using MigrationTools.Tools.Interfaces;
+﻿using MigrationTools.Tools.Interfaces;
 
 namespace MigrationTools.Tools.Shadows
 {
     public class MockStringManipulatorTool : IStringManipulatorTool
     {
-        public void ProcessorExecutionWithFieldItem(IProcessor processor, FieldItem fieldItem)
+        public string? ProcessString(string? value)
         {
             throw new NotImplementedException();
         }

--- a/src/MigrationTools.Tests/ProcessorEnrichers/StringManipulatorEnricherTests.cs
+++ b/src/MigrationTools.Tests/ProcessorEnrichers/StringManipulatorEnricherTests.cs
@@ -2,12 +2,8 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using MigrationTools.DataContracts;
-using MigrationTools.Endpoints;
-using MigrationTools.Processors;
-using MigrationTools.Tests;
-using Microsoft.Extensions.Options;
-using MigrationTools.Tools;
 using MigrationTools.Shadows;
+using MigrationTools.Tools;
 
 namespace MigrationTools.ProcessorEnrichers.Tests
 {
@@ -21,7 +17,7 @@ namespace MigrationTools.ProcessorEnrichers.Tests
             var options = new StringManipulatorToolOptions();
             options.Enabled = true;
             options.MaxStringLength = 10;
-                options.Manipulators = new List<RegexStringManipulator>
+            options.Manipulators = new List<RegexStringManipulator>
                 {
                     new RegexStringManipulator
                     {
@@ -40,10 +36,10 @@ namespace MigrationTools.ProcessorEnrichers.Tests
         [TestMethod(), TestCategory("L1")]
         public void StringManipulatorTool_RegexTest()
         {
-           var options = new StringManipulatorToolOptions();
+            var options = new StringManipulatorToolOptions();
             options.Enabled = true;
-                    options.MaxStringLength = 10;
-                    options.Manipulators = new List<RegexStringManipulator>
+            options.MaxStringLength = 10;
+            options.Manipulators = new List<RegexStringManipulator>
                 {
                     new RegexStringManipulator
                     {
@@ -56,18 +52,10 @@ namespace MigrationTools.ProcessorEnrichers.Tests
 
             var x = GetStringManipulatorTool(options);
 
-            var fieldItem = new FieldItem
-            {
-                FieldType = "String",
-                internalObject = null,
-                ReferenceName = "Custom.Test",
-                Name = "Test",
-                Value = "Test"
-            };
+            string value = "Test";
+            string? newValue = x.ProcessString(value);
 
-            x.ProcessorExecutionWithFieldItem(null, fieldItem);
-
-            Assert.AreEqual("Test 2", fieldItem.Value);
+            Assert.AreEqual("Test 2", newValue);
         }
 
         [TestMethod(), TestCategory("L1")]
@@ -75,21 +63,13 @@ namespace MigrationTools.ProcessorEnrichers.Tests
         {
             var options = new StringManipulatorToolOptions();
             options.Enabled = true;
-                options.MaxStringLength = 10;
+            options.MaxStringLength = 10;
             var x = GetStringManipulatorTool(options);
 
-            var fieldItem = new FieldItem
-            {
-                FieldType = "String",
-                internalObject = null,
-                ReferenceName = "Custom.Test",
-                Name = "Test",
-                Value = "Test"
-            };
+            string value = "Test";
+            string? newValue = x.ProcessString(value);
 
-            x.ProcessorExecutionWithFieldItem(null, fieldItem);
-
-            Assert.AreEqual(4, fieldItem.Value.ToString().Length);
+            Assert.AreEqual(4, newValue.Length);
         }
 
         [TestMethod(), TestCategory("L1")]
@@ -100,24 +80,93 @@ namespace MigrationTools.ProcessorEnrichers.Tests
             options.MaxStringLength = 10;
             var x = GetStringManipulatorTool(options);
 
-            var fieldItem = new FieldItem
-            {
-                FieldType = "String",
-                internalObject = null,
-                ReferenceName = "Custom.Test",
-                Name = "Test",
-                Value = "Test Test Test Test Test Test Test Test Test Test Test Test Test"
-            };
+            string value = "Test Test Test Test Test Test Test Test Test Test Test Test Test";
+            string? newValue = x.ProcessString(value);
 
-            x.ProcessorExecutionWithFieldItem(null, fieldItem);
-
-            Assert.AreEqual(10, fieldItem.Value.ToString().Length);
+            Assert.AreEqual(10, newValue.Length);
         }
 
-        private static StringManipulatorTool GetStringManipulatorTool()
+        [DataTestMethod(), TestCategory("L1")]
+        [DataRow(null, null)]
+        [DataRow("", "")]
+        [DataRow("lorem", "lorem")]
+        public void StringManipulatorTool_Disabled(string? value, string? expected)
         {
-            var options = new StringManipulatorToolOptions();           
-            return GetStringManipulatorTool(options);
+            var options = new StringManipulatorToolOptions();
+            options.Enabled = false;
+            options.MaxStringLength = 15;
+            options.Manipulators = new List<RegexStringManipulator>
+                {
+                    new RegexStringManipulator
+                    {
+                        Enabled = true,
+                        Pattern = "(^.*$)",
+                        Replacement = "$1 $1",
+                        Description = "Test"
+                    }
+                };
+            var x = GetStringManipulatorTool(options);
+
+            string? newValue = x.ProcessString(value);
+            Assert.AreEqual(expected, newValue);
+        }
+
+        [DataTestMethod(), TestCategory("L1")]
+        [DataRow(null, null)]
+        [DataRow("", " ")]
+        [DataRow("lorem", "lorem lorem")]
+        [DataRow("lorem ipsum", "lorem ipsum lor")]
+        public void StringManipulatorTool_Process(string? value, string? expected)
+        {
+            var options = new StringManipulatorToolOptions();
+            options.Enabled = true;
+            options.MaxStringLength = 15;
+            options.Manipulators = new List<RegexStringManipulator>
+                {
+                    new RegexStringManipulator
+                    {
+                        Enabled = true,
+                        Pattern = "(^.*$)",
+                        Replacement = "$1 $1",
+                        Description = "Test"
+                    }
+                };
+            var x = GetStringManipulatorTool(options);
+
+            string? newValue = x.ProcessString(value);
+            Assert.AreEqual(expected, newValue);
+        }
+
+        [DataTestMethod(), TestCategory("L1")]
+        [DataRow(null, null)]
+        [DataRow("", " 1 2")]
+        [DataRow("lorem", "lorem 1 2")]
+        public void StringManipulatorTool_MultipleManipulators(string? value, string? expected)
+        {
+            var options = new StringManipulatorToolOptions();
+            options.Enabled = true;
+            options.MaxStringLength = 15;
+            options.Manipulators = new List<RegexStringManipulator>
+                {
+                    new RegexStringManipulator
+                    {
+                        Enabled = true,
+                        Pattern = "(^.*$)",
+                        Replacement = "$1 1",
+                        Description = "Add 1"
+                    },
+                    new RegexStringManipulator
+                    {
+                        Enabled = true,
+                        Pattern = "(^.*$)",
+                        Replacement = "$1 2",
+                        Description = "Add 2"
+                    }
+                };
+            var x = GetStringManipulatorTool(options);
+
+            string? newValue = x.ProcessString(value);
+            Assert.AreEqual(expected, newValue);
         }
 
         private static StringManipulatorTool GetStringManipulatorTool(StringManipulatorToolOptions options)

--- a/src/MigrationTools/Tools/Interfaces/IStringManipulatorTool.cs
+++ b/src/MigrationTools/Tools/Interfaces/IStringManipulatorTool.cs
@@ -1,13 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using MigrationTools.DataContracts;
-using MigrationTools.Processors.Infrastructure;
-
-namespace MigrationTools.Tools.Interfaces
+﻿namespace MigrationTools.Tools.Interfaces
 {
     public interface IStringManipulatorTool
     {
-        void ProcessorExecutionWithFieldItem(IProcessor processor, FieldItem fieldItem);
+        string? ProcessString(string? value);
     }
 }


### PR DESCRIPTION
This should fix #2538

As mention id that bug report, custom user mapping is not applied during migration. @LudekStipal pointed to the code it was responsible for this. The problem is not the `StringManipulatorTool` itself, but the value which is used in that branch of code. The user mapping and all the other field mapping is done using `oldWorkItem` object, which is of type `Field`. But that specific branch for strings was processed using `oldWorkItemData` object which is of type `FieldItem`. So **it is the different object** and for user fields, it is not working with mapped user names, because the are mapped in the other place.

This is at least a bug for user fields which are mapped as @LudekStipal found. But I think, that is is also a potential source of bugs in the future, if something will be changing here. Because the one who will be changing something here may not notice, that populating work item fields it is done in different way for the strings.

`StringManipulatorTool` was working with `FieldItem` type. At first, I wanted to change it to work with `Field` type, so it would work the same way as user mapping. But this is not possible, because `Field` type is from TFS client library, but `StringManipulatorTool` in in different (lower level) assembly where this is not accessible. So I changes `StringManipulatorTool` that it does not take a whole field as argument, but just a string and returns new string. Basically, it does what it name suggests – takes a plain string, manipulates it and returns a new string. It was used only in this one place.

This may be a breaking change. The potential problem may be, than `FieldItem` was modified by `StringManipulatorTool` until now and now it remains the same. I am not sure if this can be a real issue.