### PR TITLE
📝 (TfsNodeStructureTool.cs): update documentation URL for missing nod…

### DIFF
--- a/src/MigrationTools.Clients.TfsObjectModel/Tools/TfsNodeStructureTool.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/Tools/TfsNodeStructureTool.cs
@@ -659,7 +659,7 @@ namespace MigrationTools.Tools
             {
                 Log.LogWarning("!! There are MISSING Area or Iteration Paths");
                 Log.LogWarning("NOTE: It is NOT possible to migrate a work item if the Area or Iteration path does not exist on the target project. This is because the work item will be created with the same Area and Iteration path as the source work item with the project name swapped. The work item will not be created if the path does not exist. The only way to resolve this is to follow the instructions:");
-                Log.LogWarning("!! There are {missingAreaPaths} Nodes (Area or Iteration) found in the history of the Source that are missing from the Target! These MUST be added or mapped before we can continue using the instructions on https://nkdagility.com/learn/azure-devops-migration-tools//Reference/v2/ProcessorEnrichers/TfsNodeStructureTool/#iteration-maps-and-area-maps", missingItems.Count);
+                Log.LogWarning("!! There are {missingAreaPaths} Nodes (Area or Iteration) found in the history of the Source that are missing from the Target! These MUST be added or mapped before we can continue using the instructions on https://nkdagility.com/learn/azure-devops-migration-tools/Reference/Tools/TfsNodeStructureTool/#iteration-maps-and-area-maps", missingItems.Count);
                 foreach (NodeStructureItem missingItem in missingItems)
                 {
                     string mapper = GetMappingForMissingItem(missingItem);


### PR DESCRIPTION
…es warning

Corrects the URL in the log warning message to point to the accurate documentation reference for handling missing Area or Iteration paths. This ensures users are directed to the correct instructions, improving the usability and effectiveness of the log messages.