### PR TITLE
Fix for Index Issue

### DIFF
--- a/src/MigrationTools.Clients.TfsObjectModel/Processors/TfsTestPlansAndSuitesMigrationProcessor.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/Processors/TfsTestPlansAndSuitesMigrationProcessor.cs
@@ -615,7 +615,7 @@ namespace MigrationTools.Processors
                 Log.LogWarning("We found multiple test Plans with the name '{TestPlanName}'. They have ID(s) of '{result}'! We only have name at this point as a unique identifier and duplicates will break the code. Ensure that all Test Plans have unique names.", planName, result);
                 throw new Exception(string.Format("Test plans {0} all have the same name!", result));
             }
-            testPlan = testPlans[0];
+            testPlan = testPlans.FirstOrDefault();
 
             if (testPlan != null)
             {


### PR DESCRIPTION
🐛 (TfsTestPlansAndSuitesMigrationProcessor.cs): fix potential index out of range error by using FirstOrDefault

The change from accessing the first element of the testPlans list directly to using FirstOrDefault prevents a potential IndexOutOfRangeException. This ensures that if the list is empty, the testPlan variable will be set to null instead of causing an error, improving the robustness of the code.