### PR TITLE
Bug fix for lame FieldDefinitionNotExistException

### DIFF
--- a/src/MigrationTools.Clients.TfsObjectModel/Processors/TfsWorkItemMigrationProcessor.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/Processors/TfsWorkItemMigrationProcessor.cs
@@ -422,9 +422,16 @@ namespace MigrationTools.Processors
                 newWorkItem.Fields["Microsoft.VSTS.Common.ClosedDate"].Value = oldWorkItem.Fields["Microsoft.VSTS.Common.ClosedDate"].Value;
             }
             newWorkItem.State = oldWorkItem.State;
-            if (newWorkItem.Fields.Contains("Microsoft.VSTS.Common.ClosedDate") && newWorkItem.Fields["Microsoft.VSTS.Common.ClosedDate"].IsEditable)
+            try
             {
-                newWorkItem.Fields["Microsoft.VSTS.Common.ClosedDate"].Value = oldWorkItem.Fields["Microsoft.VSTS.Common.ClosedDate"].Value;
+                if (newWorkItem.Fields.Contains("Microsoft.VSTS.Common.ClosedDate") && newWorkItem.Fields["Microsoft.VSTS.Common.ClosedDate"].IsEditable)
+                {
+                    newWorkItem.Fields["Microsoft.VSTS.Common.ClosedDate"].Value = oldWorkItem.Fields["Microsoft.VSTS.Common.ClosedDate"].Value;
+                }
+            }
+            catch (FieldDefinitionNotExistException ex)
+            {
+                // Eat exception coz the TFS API Sucks
             }
             newWorkItem.Reason = oldWorkItem.Reason;
 


### PR DESCRIPTION
🐛 (TfsWorkItemMigrationProcessor.cs): handle FieldDefinitionNotExistException when setting ClosedDate field

Wraps the assignment of the "ClosedDate" field in a try-catch block to handle the FieldDefinitionNotExistException. This change prevents the application from crashing when the field definition does not exist, which can occur due to inconsistencies in the TFS API. The exception is caught and ignored to ensure the migration process continues smoothly.

Co-Authored: @anderssonpof 