### PR TITLE
Skip closedDate field validation when closedDate field doesn't exist

### DIFF
--- a/src/MigrationTools.Clients.TfsObjectModel/Processors/TfsWorkItemMigrationProcessor.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/Processors/TfsWorkItemMigrationProcessor.cs
@@ -895,6 +895,12 @@ namespace MigrationTools.Processors
             {
                 closedDateField = "Microsoft.VSTS.Common.ClosedDate";
             }
+            else if (!targetWorkItem.ToWorkItem().Fields.Contains("System.ClosedDate"))
+            {
+                Log.LogDebug("CheckClosedDateIsValid::ClosedDate field doesn't exist in targetWorkItem: {targetWorkItem} - nothing to validate.", targetWorkItem);
+                return;
+            }
+
             Log.LogDebug("CheckClosedDateIsValid::ClosedDate field is {closedDateField}", closedDateField);
             if (targetWorkItem.ToWorkItem().Fields[closedDateField].Value == null && (targetWorkItem.ToWorkItem().Fields["System.State"].Value.ToString() == "Closed" || targetWorkItem.ToWorkItem().Fields["System.State"].Value.ToString() == "Done"))
             {
@@ -921,7 +927,6 @@ namespace MigrationTools.Processors
                     Log.LogWarning("Target ClosedDate Field: ", "System.ClosedDate");
                 }
             }
-
         }
 
         private bool SkipRevisionWithInvalidIterationPath(WorkItemData targetWorkItemData)


### PR DESCRIPTION
Handle case where there is no closed date field in target workitem. For us it didn't work for Shared parameter. We cannot modify shared parameter workitem in azure devops. Skip field didn't work.
![image](https://github.com/user-attachments/assets/476920af-1dc0-46e2-bc29-b68535a445d1)
