### PR TITLE
New flag in Test Plan config "TestPlanIds"

### DIFF
--- a/src/MigrationTools.Clients.TfsObjectModel/Processors/TfsTestPlansAndSuitesMigrationProcessor.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/Processors/TfsTestPlansAndSuitesMigrationProcessor.cs
@@ -86,6 +86,12 @@ namespace MigrationTools.Processors
             var stopwatch = Stopwatch.StartNew();
             var starttime = DateTime.Now;
             var sourcePlans = _sourceTestStore.GetTestPlans();
+            // Using the config flag 'TestPlanIds', we will filter out all test plans except the required ones for migration
+            var testPlanIdsToMigrate = Options.TestPlanIds;
+            if (testPlanIdsToMigrate != null && testPlanIdsToMigrate.Length > 0)
+            {
+                sourcePlans = sourcePlans.Where(tp => testPlanIdsToMigrate.Contains(tp.Id)).ToList();
+            }
             List<ITestPlan> toProcess;
             if (filterByCompleted)
             {

--- a/src/MigrationTools.Clients.TfsObjectModel/Processors/TfsTestPlansAndSuitesMigrationProcessorOptions.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/Processors/TfsTestPlansAndSuitesMigrationProcessorOptions.cs
@@ -2,6 +2,7 @@
 using MigrationTools.Enrichers;
 using MigrationTools.Processors;
 using MigrationTools.Processors.Infrastructure;
+using System;
 
 namespace MigrationTools._EngineV1.Configuration.Processing
 {
@@ -42,6 +43,12 @@ namespace MigrationTools._EngineV1.Configuration.Processing
         public bool RemoveInvalidTestSuiteLinks { get; set; }
 
         public bool FilterCompleted { get; set; }
+
+        /// <summary>
+        /// This flag filters all test plans and retains only the specified ones for migration. Pass the test plan IDs as an array. Example: "TestPlanIds": [123, 456, 789]  
+        /// Works optimally when "TestPlanQuery" is set to null.  
+        /// </summary>
+        public int[] TestPlanIds { get; set; } = Array.Empty<int>();
 
         public TfsTestPlansAndSuitesMigrationProcessorOptions()
         {


### PR DESCRIPTION
This flag filters all test plans and retains only the specified ones for migration. Pass the test plan IDs as an array. Example: "TestPlanIds": [123, 456, 789] . Works optimally when "TestPlanQuery" is set to null.

Idea link - https://github.com/nkdAgility/azure-devops-migration-tools/discussions/2648