### PR TITLE
Fix warnings and some errors

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,64 +2,67 @@
   <ItemGroup>
     <PackageVersion Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.3.0" />
     <PackageVersion Include="Ben.Demystifier" Version="0.4.1" />
-    <PackageVersion Include="coverlet.collector" Version="6.0.2" />
+    <PackageVersion Include="coverlet.collector" Version="6.0.4" />
     <PackageVersion Include="DotNet.Glob" Version="3.1.3" />
-    <PackageVersion Include="Elmah.Io.Client" Version="5.1.76" />
-    <PackageVersion Include="GitInfo" Version="3.3.5" />
-    <PackageVersion Include="Microsoft.ApplicationInsights.WorkerService" Version="2.22.0" />
+    <PackageVersion Include="Elmah.Io.Client" Version="5.2.118" />
+    <PackageVersion Include="GitInfo" Version="3.5.0" />
+    <PackageVersion Include="Microsoft.ApplicationInsights.WorkerService" Version="2.23.0" />
     <PackageVersion Include="Microsoft.AspNet.WebApi.Client" Version="6.0.0" />
-    <PackageVersion Include="Microsoft.Azure.Functions.Worker" Version="1.23.0" />
-    <PackageVersion Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="1.4.0" />
-    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.2.0" />
-    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="1.3.2" />
-    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.17.4" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Azure.Functions.Worker" Version="2.0.0" />
+    <PackageVersion Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="2.0.0" />
+    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.3.0" />
+    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="2.0.1" />
+    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.2" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="9.0.0" />
     <PackageVersion Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.3.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageVersion Include="Microsoft.TeamFoundation.DistributedTask.Common.Contracts" Version="19.225.1" />
     <PackageVersion Include="Microsoft.TeamFoundation.DistributedTask.WebApi" Version="19.225.1" />
     <PackageVersion Include="Microsoft.TeamFoundationServer.Client" Version="19.225.1" />
     <PackageVersion Include="Microsoft.TeamFoundationServer.ExtendedClient" Version="19.225.1" />
     <PackageVersion Include="Microsoft.VisualStudio.Services.Client" Version="19.225.1" />
     <PackageVersion Include="Microsoft.VisualStudio.Services.ServiceEndpoints.WebApi" Version="19.225.1" />
-    <PackageVersion Include="MSTest.TestAdapter" Version="3.6.0" />
-    <PackageVersion Include="MSTest.TestFramework" Version="3.6.0" />
+    <PackageVersion Include="MSTest.TestAdapter" Version="3.8.3" />
+    <PackageVersion Include="MSTest.TestFramework" Version="3.8.3" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="Newtonsoft.Json.Schema" Version="4.0.1" />
-    <PackageVersion Include="NuGet.Protocol" Version="6.11.0" />
-    <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.9.0" />
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.9.0" />
+    <PackageVersion Include="NuGet.Protocol" Version="6.13.2" />
+    <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.12.0" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.12.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.12.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Process" Version="0.5.0-beta.6" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.9.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.12.0" />
     <PackageVersion Include="OxyPlot.Core" Version="2.2.0" />
     <PackageVersion Include="OxyPlot.ImageSharp" Version="2.2.0" />
-    <PackageVersion Include="Riok.Mapperly" Version="4.1.0" />
-    <PackageVersion Include="Serilog" Version="4.0.1" />
+    <PackageVersion Include="Riok.Mapperly" Version="4.2.1" />
+    <PackageVersion Include="Serilog" Version="4.2.0" />
     <PackageVersion Include="Serilog.Enrichers.Environment" Version="3.0.1" />
     <PackageVersion Include="Serilog.Enrichers.Process" Version="3.0.0" />
-    <PackageVersion Include="Serilog.Extensions.Hosting" Version="8.0.0" />
-    <PackageVersion Include="Serilog.Extensions.Logging" Version="8.0.0" />
-    <PackageVersion Include="Serilog.Settings.Configuration" Version="8.0.2" />
+    <PackageVersion Include="Serilog.Extensions.Hosting" Version="9.0.0" />
+    <PackageVersion Include="Serilog.Extensions.Logging" Version="9.0.1" />
+    <PackageVersion Include="Serilog.Settings.Configuration" Version="9.0.0" />
     <PackageVersion Include="Serilog.Sinks.Console" Version="6.0.0" />
     <PackageVersion Include="Serilog.Sinks.Debug" Version="3.0.0" />
-    <PackageVersion Include="Serilog.Sinks.File" Version="6.0.0" />
+    <PackageVersion Include="Serilog.Sinks.File" Version="7.0.0" />
     <PackageVersion Include="Serilog.Sinks.InMemory" Version="0.11.0" />
     <PackageVersion Include="Spectre.Console.Cli" Version="0.49.1" />
     <PackageVersion Include="Spectre.Console.Extensions.Hosting" Version="0.2.0" />
     <PackageVersion Include="Spectre.Console.Json" Version="0.49.1" />
     <PackageVersion Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <PackageVersion Include="System.ComponentModel.Annotations" Version="5.0.0" />
-    <PackageVersion Include="System.Drawing.Common" Version="8.0.8" />
+    <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="9.0.0" />
+    <PackageVersion Include="System.Drawing.Common" Version="9.0.0" />
     <PackageVersion Include="System.Security.Principal.Windows" Version="5.0.0" />
     <PackageVersion Include="TfsUrlParser" Version="1.5.0" />
-    <PackageVersion Include="WGet.NET" Version="4.2.0" />
-    <PackageVersion Include="YamlDotNet" Version="16.1.0" />
+    <PackageVersion Include="WGet.NET" Version="4.4.1" />
+    <PackageVersion Include="YamlDotNet" Version="16.3.0" />
   </ItemGroup>
 </Project>

--- a/src/MigrationTools.Clients.AzureDevops.Rest/Processors/OutboundLinkCheckingProcessor.cs
+++ b/src/MigrationTools.Clients.AzureDevops.Rest/Processors/OutboundLinkCheckingProcessor.cs
@@ -9,7 +9,6 @@ using Microsoft.Extensions.Options;
 using MigrationTools.DataContracts.WorkItems;
 using MigrationTools.Endpoints;
 using MigrationTools.Enrichers;
-using MigrationTools.Processors;
 using MigrationTools.Processors.Infrastructure;
 using MigrationTools.Tools;
 
@@ -17,8 +16,6 @@ namespace MigrationTools.Clients.AzureDevops.Rest.Processors
 {
     internal class OutboundLinkCheckingProcessor : Processor
     {
-        private OutboundLinkCheckingProcessorOptions _options;
-
         public OutboundLinkCheckingProcessor(IOptions<OutboundLinkCheckingProcessorOptions> options, CommonTools commonTools, ProcessorEnricherContainer processorEnrichers, IServiceProvider services, ITelemetryLogger telemetry, ILogger<Processor> logger) : base(options, commonTools, processorEnrichers, services, telemetry, logger)
         {
         }
@@ -43,7 +40,7 @@ namespace MigrationTools.Clients.AzureDevops.Rest.Processors
         private void EnsureConfigured()
         {
             Log.LogInformation("Processor::EnsureConfigured");
-            if (_options == null)
+            if (Options == null)
             {
                 throw new Exception("You must call Configure() first");
             }
@@ -62,7 +59,7 @@ namespace MigrationTools.Clients.AzureDevops.Rest.Processors
             var wiqlClient = Source.GetHttpClient("wit/wiql");
             var query = new WiqlRequest
             {
-                Query = _options.WIQLQuery
+                Query = Options.WIQLQuery
             };
 
             var wiqlResult = await wiqlClient.PostAsJsonAsync("", query);
@@ -130,12 +127,12 @@ namespace MigrationTools.Clients.AzureDevops.Rest.Processors
                     }
                 }
             }
-            var fileInfo = new FileInfo(_options.ResultFileName);
+            var fileInfo = new FileInfo(Options.ResultFileName);
             if (fileInfo.Directory.Exists == false)
             {
                 fileInfo.Directory.Create();
             }
-            File.WriteAllLines(_options.ResultFileName, foundLinks);
+            File.WriteAllLines(Options.ResultFileName, foundLinks);
             Log.LogInformation("");
             Log.LogInformation("---------------------------");
 

--- a/src/MigrationTools.Clients.TfsObjectModel/Clients/TfsWorkItemMigrationClient.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/Clients/TfsWorkItemMigrationClient.cs
@@ -106,7 +106,6 @@ namespace MigrationTools.Clients
                 activity?.SetTag("http.request.method", "GET");
                 activity?.SetTag("http.response.status_code", "500");
                 activity?.SetTag("migrationtools.client", "TfsObjectModel");
-                activity?.SetEndTime(activity.StartTimeUtc.AddSeconds(10));
 
                 Project y = null;
                 try
@@ -177,7 +176,6 @@ namespace MigrationTools.Clients
                 activity?.SetTag("http.request.method", "GET");
                 activity?.SetTag("http.response.status_code", "500");
                 activity?.SetTag("migrationtools.client", "TfsObjectModel");
-                activity?.SetEndTime(activity.StartTimeUtc.AddSeconds(10));
                 if (id == 0)
                 {
                     throw new ArgumentOutOfRangeException("id", id, "id cant be empty.");
@@ -317,7 +315,6 @@ namespace MigrationTools.Clients
                 activity?.SetTag("migrationtools.client", "TfsObjectModel");
                 activity?.SetTag("migrationtools.WorkItemStoreFlags", _bypassRules.ToString());
                 activity?.SetTagsFromOptions(Options);
-                activity?.SetEndTime(activity.StartTimeUtc.AddSeconds(10));
                 WorkItemStore store = null;
                 try
                 {

--- a/src/MigrationTools.Clients.TfsObjectModel/Clients/TfsWorkItemMigrationClient.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/Clients/TfsWorkItemMigrationClient.cs
@@ -1,19 +1,15 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Diagnostics.Metrics;
 using System.Linq;
 using System.Text;
 using Microsoft.Extensions.Options;
 using Microsoft.TeamFoundation.Client;
 using Microsoft.TeamFoundation.WorkItemTracking.Client;
-using MigrationTools._EngineV1.Configuration;
 using MigrationTools._EngineV1.DataContracts;
 using MigrationTools.DataContracts;
 using MigrationTools.Endpoints;
-using MigrationTools.Endpoints.Infrastructure;
 using MigrationTools.Services;
-using OpenTelemetry.Metrics;
 using Serilog;
 
 namespace MigrationTools.Clients
@@ -111,11 +107,10 @@ namespace MigrationTools.Clients
                 activity?.SetTag("http.response.status_code", "500");
                 activity?.SetTag("migrationtools.client", "TfsObjectModel");
                 activity?.SetEndTime(activity.StartTimeUtc.AddSeconds(10));
-                
+
                 Project y = null;
                 try
                 {
-                    activity?.Start();
                     y = (from Project x in Store.Projects where string.Equals(x.Name, Options.Project, StringComparison.OrdinalIgnoreCase) select x).SingleOrDefault(); // Use Single instead of SingleOrDefault to force an exception here
                     if (y == null)
                     {
@@ -190,7 +185,6 @@ namespace MigrationTools.Clients
                 WorkItem y = null;
                 try
                 {
-                    activity?.Start();
                     Log.Debug("TfsWorkItemMigrationClient::GetWorkItem({id})", id);
                     y = Store.GetWorkItem(id);
                     activity?.Stop();
@@ -254,7 +248,7 @@ namespace MigrationTools.Clients
             }
         }
 
- 
+
 
         public override WorkItemData PersistWorkItem(WorkItemData workItem)
         {

--- a/src/MigrationTools.Clients.TfsObjectModel/Clients/TfsWorkItemQuery.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/Clients/TfsWorkItemQuery.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Windows.Forms;
 using Microsoft.TeamFoundation.WorkItemTracking.Client;
 using MigrationTools.DataContracts;
 using MigrationTools.Services;
@@ -38,7 +37,6 @@ namespace MigrationTools.Clients
                 activity?.SetTag("server.address", MigrationClient.Options.Collection);
                 activity?.SetTag("http.request.method", "GET");
                 activity?.SetTag("migrationtools.client", "TfsObjectModel");
-                activity?.SetEndTime(activity.StartTimeUtc.AddSeconds(10));
                 foreach (var item in Parameters)
                 {
                     activity?.SetTag($"wiql.parameters.{item.Key}", item.Value);
@@ -66,7 +64,6 @@ namespace MigrationTools.Clients
                 activity?.SetTag("server.address", MigrationClient.Options.Collection);
                 activity?.SetTag("http.request.method", "GET");
                 activity?.SetTag("migrationtools.client", "TfsObjectModel");
-                activity?.SetEndTime(activity.StartTimeUtc.AddSeconds(10));
                 var results = new List<WorkItem>();
                 try
                 {
@@ -103,7 +100,6 @@ namespace MigrationTools.Clients
                 }
                 catch (Exception ex)
                 {
-
                     activity?.SetTag("http.response.status_code", "500");
                     Telemetry.TrackException(ex, activity.Tags);
                     Log.Error(ex, " Error running query");

--- a/src/MigrationTools.Clients.TfsObjectModel/Endpoints/TfsEndpoint.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/Endpoints/TfsEndpoint.cs
@@ -68,7 +68,6 @@ namespace MigrationTools.Endpoints
                 activity?.SetTag("server.address", Options.Collection);
                 activity?.SetTag("http.request.method", "GET");
                 activity?.SetTag("migrationtools.client", "TfsObjectModel");
-                activity?.SetEndTime(activity.StartTimeUtc.AddSeconds(10));
 
                 if (_Collection is null)
                 {
@@ -129,7 +128,6 @@ namespace MigrationTools.Endpoints
                     activity?.SetTag("server.address", Options?.Collection);
                     activity?.SetTag("http.request.method", "GET");
                     activity?.SetTag("migrationtools.client", "TfsObjectModel");
-                    activity?.SetEndTime(activity.StartTimeUtc.AddSeconds(10));
                     try
                     {
                         _Store = new WorkItemStore(tfs, bypassRules);
@@ -168,8 +166,6 @@ namespace MigrationTools.Endpoints
                     activity?.SetTag("server.address", Options.Collection);
                     activity?.SetTag("http.request.method", "GET");
                     activity?.SetTag("migrationtools.client", "TfsObjectModel");
-                    activity?.SetEndTime(activity.StartTimeUtc.AddSeconds(10));
-
 
                     if (TfsStore.Projects.Contains(Options.Project))
                     {

--- a/src/MigrationTools.Clients.TfsObjectModel/Processors/TfsCreateTeamFoldersProcessor.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/Processors/TfsCreateTeamFoldersProcessor.cs
@@ -4,16 +4,13 @@ using System.Diagnostics;
 using System.Linq;
 using System.Text.RegularExpressions;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Microsoft.TeamFoundation.Client;
 using Microsoft.TeamFoundation.WorkItemTracking.Client;
-using MigrationTools;
 using MigrationTools.Clients;
-using MigrationTools._EngineV1.Configuration;
+using MigrationTools.Enrichers;
 using MigrationTools.Processors.Infrastructure;
 using MigrationTools.Tools;
-using MigrationTools.Processors.Infrastructure;
-using Microsoft.Extensions.Options;
-using MigrationTools.Enrichers;
 
 
 namespace MigrationTools.Processors

--- a/src/MigrationTools.Clients.TfsObjectModel/Processors/TfsTestVariablesMigrationProcessor.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/Processors/TfsTestVariablesMigrationProcessor.cs
@@ -2,21 +2,18 @@
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Microsoft.TeamFoundation.TestManagement.Client;
-using MigrationTools;
-using MigrationTools._EngineV1.Configuration;
+using MigrationTools.Clients;
+using MigrationTools.Enrichers;
 using MigrationTools.Processors.Infrastructure;
 using MigrationTools.Tools;
-using MigrationTools.Processors.Infrastructure;
-using Microsoft.Extensions.Options;
-using MigrationTools.Enrichers;
-using MigrationTools.Clients;
 
 
 namespace MigrationTools.Processors
 {
     /// <summary>
-    /// This processor can migrate test variables that are defined in the test plans / suites. This must run before `TestPlansAndSuitesMigrationConfig`. 
+    /// This processor can migrate test variables that are defined in the test plans / suites. This must run before `TestPlansAndSuitesMigrationConfig`.
     /// </summary>
     /// <status>Beta</status>
     /// <processingtarget>Suites &amp; Plans</processingtarget>

--- a/src/MigrationTools.Clients.TfsObjectModel/Processors/TfsWorkItemMigrationProcessor.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/Processors/TfsWorkItemMigrationProcessor.cs
@@ -1,43 +1,31 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Diagnostics.Metrics;
 using System.Globalization;
 using System.Linq;
 using System.Net;
 using System.Text;
-using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.TeamFoundation.Common;
-using Microsoft.TeamFoundation.TestManagement;
 using Microsoft.TeamFoundation.WorkItemTracking.Client;
-using Microsoft.TeamFoundation.WorkItemTracking.Proxy;
 using Microsoft.TeamFoundation.WorkItemTracking.WebApi;
 using Microsoft.VisualStudio.Services.Common;
 using Microsoft.VisualStudio.Services.WebApi;
 using Microsoft.VisualStudio.Services.WebApi.Patch;
 using Microsoft.VisualStudio.Services.WebApi.Patch.Json;
-using MigrationTools;
-using MigrationTools.Clients;
-using MigrationTools._EngineV1.Configuration;
-using MigrationTools._EngineV1.Configuration.Processing;
-using MigrationTools._EngineV1.Containers;
 using MigrationTools._EngineV1.DataContracts;
-
+using MigrationTools.Clients;
 using MigrationTools.DataContracts;
 using MigrationTools.Enrichers;
 using MigrationTools.Processors.Infrastructure;
 using MigrationTools.Services;
 using MigrationTools.Tools;
-using Newtonsoft.Json.Linq;
 using Serilog.Context;
 using Serilog.Events;
 using ILogger = Serilog.ILogger;
-using MigrationTools.Tools.Interfaces;
 
 namespace MigrationTools.Processors
 {
@@ -425,7 +413,7 @@ namespace MigrationTools.Processors
                     newWorkItem.Fields["Microsoft.VSTS.Common.ClosedDate"].Value = oldWorkItem.Fields["Microsoft.VSTS.Common.ClosedDate"].Value;
                 }
             }
-            catch (FieldDefinitionNotExistException ex)
+            catch (FieldDefinitionNotExistException)
             {
                 // Eat exception coz the TFS API Sucks
             }

--- a/src/MigrationTools.Clients.TfsObjectModel/Processors/TfsWorkItemOverwriteAreasAsTagsProcessor.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/Processors/TfsWorkItemOverwriteAreasAsTagsProcessor.cs
@@ -4,16 +4,12 @@ using System.Diagnostics;
 using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using MigrationTools;
-using MigrationTools.Clients;
-using MigrationTools._EngineV1.Configuration;
-using MigrationTools._EngineV1.Configuration.Processing;
-using MigrationTools.DataContracts;
-
 using Microsoft.Extensions.Options;
-using MigrationTools.Tools;
-using MigrationTools.Processors.Infrastructure;
+using MigrationTools.Clients;
+using MigrationTools.DataContracts;
 using MigrationTools.Enrichers;
+using MigrationTools.Processors.Infrastructure;
+using MigrationTools.Tools;
 
 namespace MigrationTools.Processors
 {
@@ -24,11 +20,9 @@ namespace MigrationTools.Processors
     /// <processingtarget>Work Item</processingtarget>
     public class TfsWorkItemOverwriteAreasAsTagsProcessor : TfsProcessor
     {
-        private TfsWorkItemOverwriteAreasAsTagsProcessorOptions _config;
-
         public TfsWorkItemOverwriteAreasAsTagsProcessor(IOptions<TfsWorkItemOverwriteAreasAsTagsProcessorOptions> options, TfsCommonTools tfsStaticTools, ProcessorEnricherContainer processorEnrichers, IServiceProvider services, ITelemetryLogger telemetry, ILogger<Processor> logger) : base(options, tfsStaticTools, processorEnrichers, services, telemetry, logger)
         {
-          
+
         }
 
         new TfsWorkItemOverwriteAreasAsTagsProcessorOptions Options => (TfsWorkItemOverwriteAreasAsTagsProcessorOptions)base.Options;
@@ -43,7 +37,7 @@ namespace MigrationTools.Processors
             //////////////////////////////////////////////////
 
             IWorkItemQueryBuilder wiqb = Services.GetRequiredService<IWorkItemQueryBuilder>();
-            wiqb.AddParameter("AreaPath", _config.AreaIterationPath);
+            wiqb.AddParameter("AreaPath", Options.AreaIterationPath);
             wiqb.Query = @"SELECT [System.Id], [System.Tags] FROM WorkItems WHERE  [System.TeamProject] = @TeamProject and [System.AreaPath] under @AreaPath";
             List<WorkItemData> workitems = Target.WorkItems.GetWorkItems(wiqb);
             Log.LogInformation("Update {0} work items?", workitems.Count);

--- a/src/MigrationTools.Clients.TfsObjectModel/Processors/TfsWorkItemOverwriteAreasAsTagsProcessorOptions.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/Processors/TfsWorkItemOverwriteAreasAsTagsProcessorOptions.cs
@@ -1,20 +1,13 @@
-﻿using System.Collections.Generic;
-using MigrationTools.Enrichers;
-using MigrationTools.Processors;
-using MigrationTools._EngineV1.Configuration;
-using MigrationTools.Processors.Infrastructure;
-using MigrationTools.Processors.Infrastructure;
+﻿using MigrationTools.Processors.Infrastructure;
 
 namespace MigrationTools.Processors
 {
     public class TfsWorkItemOverwriteAreasAsTagsProcessorOptions : ProcessorOptions
     {
-
         /// <summary>
-        /// This is a required parameter. That define the root path of the iteration. To get the full path use `\` 
+        /// This is a required parameter. That define the root path of the iteration. To get the full path use `\`
         /// </summary>
         /// <default>\</default>
         public string AreaIterationPath { get; set; }
-
     }
 }

--- a/src/MigrationTools.Clients.TfsObjectModel/Tools/TfsAttachmentToolOptions.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/Tools/TfsAttachmentToolOptions.cs
@@ -1,15 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
-using Microsoft.TeamFoundation.Build.Client;
-using MigrationTools.Enrichers;
-using MigrationTools.Tools.Infrastructure;
-using MigrationTools.Tools.Infrastructure;
+﻿using MigrationTools.Tools.Infrastructure;
 
 namespace MigrationTools.Tools
 {
     public class TfsAttachmentToolOptions : ToolOptions, ITfsAttachmentToolOptions
     {
-
         /// <summary>
         /// `AttachmentMigration` is set to true then you need to specify a working path for attachments to be saved locally.
         /// </summary>
@@ -22,13 +16,11 @@ namespace MigrationTools.Tools
         /// </summary>
         /// <default>480000000</default>
         public int MaxAttachmentSize { get; set; }
-
     }
 
     public interface ITfsAttachmentToolOptions
     {
         public string ExportBasePath { get; set; }
         public int MaxAttachmentSize { get; set; }
-
     }
 }

--- a/src/MigrationTools.ConsoleCore/Program.cs
+++ b/src/MigrationTools.ConsoleCore/Program.cs
@@ -1,5 +1,4 @@
 ﻿using System.Threading.Tasks;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using MigrationTools.Host;
 
@@ -19,7 +18,7 @@ namespace MigrationTools.ConsoleCore
                 .ConfigureServices((context, services) =>
                 {
                     // Field Mapps
-                    
+
 
                     // Processors
 

--- a/src/MigrationTools.ConsoleFull/Program.cs
+++ b/src/MigrationTools.ConsoleFull/Program.cs
@@ -1,20 +1,12 @@
 ﻿using System;
-using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Hosting;
-using Microsoft.TeamFoundation.TestManagement.WebApi;
 using MigrationTools;
 using MigrationTools.Host;
-using OpenTelemetry.Metrics;
-using OpenTelemetry.Trace;
-using OpenTelemetry.Metrics;
-using OpenTelemetry.Trace;
 using MigrationTools.Services;
-using System.Linq;
-using System.Configuration.Assemblies;
-using System.Reflection;
-using System.IO;
-using System.Runtime.InteropServices;
 
 namespace VstsSyncMigrator.ConsoleApp
 {

--- a/src/MigrationTools.Host.Tests/MigrationHostTests.cs
+++ b/src/MigrationTools.Host.Tests/MigrationHostTests.cs
@@ -1,7 +1,6 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using MigrationTools._EngineV1.Configuration;
 
 namespace MigrationTools.Host.Tests
 {

--- a/src/MigrationTools.Host.Tests/Services/DetectOnlineServiceTests.cs
+++ b/src/MigrationTools.Host.Tests/Services/DetectOnlineServiceTests.cs
@@ -2,7 +2,6 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using MigrationTools.Services;
 using Serilog;
-using Serilog.Debugging;
 using Serilog.Events;
 
 namespace MigrationTools.Host.Services.Tests

--- a/src/MigrationTools.Host.Tests/Services/DetectVersionService2Tests.cs
+++ b/src/MigrationTools.Host.Tests/Services/DetectVersionService2Tests.cs
@@ -1,13 +1,9 @@
-﻿using MigrationTools.Host.Services;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
+﻿using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using MigrationTools.Services;
+using MigrationTools.Services.Shadows;
 using Serilog;
 using Serilog.Events;
-using MigrationTools.Host.Tests;
-using MigrationTools.Tests;
-using MigrationTools.Services.Shadows;
 
 namespace MigrationTools.Host.Services.Tests
 {

--- a/src/MigrationTools.Host.Tests/Services/DetectVersionServiceTests.cs
+++ b/src/MigrationTools.Host.Tests/Services/DetectVersionServiceTests.cs
@@ -1,11 +1,10 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using MigrationTools.Services;
 
 namespace MigrationTools.Host.Services.Tests
 {
     [TestClass]
     public class DetectVersionServiceTests
     {
-        
+
     }
 }

--- a/src/MigrationTools.Host/Commands/CommandBase.cs
+++ b/src/MigrationTools.Host/Commands/CommandBase.cs
@@ -1,19 +1,12 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
-using System.Reflection;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using MigrationTools.Host.Services;
-using MigrationTools.Options;
 using MigrationTools.Services;
-using OpenTelemetry.Metrics;
 using OpenTelemetry.Trace;
 using Serilog;
 using Spectre.Console;
@@ -67,7 +60,6 @@ namespace MigrationTools.Host.Commands
             using (CommandActivity = ActivitySource.StartActivity(this.GetType().Name))
             {
                 CommandActivity.SetTagsFromObject(settings);
-                CommandActivity?.Start();
                 // Disable Telemetry
                 if (settings.DisableTelemetry)
                 {
@@ -201,6 +193,4 @@ namespace MigrationTools.Host.Commands
 
 
     }
-
-
 }

--- a/src/MigrationTools.Host/MigrationTools.Host.csproj
+++ b/src/MigrationTools.Host/MigrationTools.Host.csproj
@@ -18,11 +18,8 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Hosting" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
     <PackageReference Include="NuGet.Protocol" />
     <PackageReference Include="OpenTelemetry.Exporter.Console" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Process" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" />
     <PackageReference Include="Serilog" />
@@ -42,10 +39,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\MigrationTools\MigrationTools.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Folder Include="CustomDiagnostics\" />
   </ItemGroup>
 
 </Project>

--- a/src/MigrationTools.Host/Services/DetectOnlineService.cs
+++ b/src/MigrationTools.Host/Services/DetectOnlineService.cs
@@ -26,9 +26,8 @@ namespace MigrationTools.Host.Services
                 activity?.SetTag("url.full", "8.8.4.4");
                 activity?.SetTag("server.address", "8.8.4.4");
                 activity?.SetTag("http.request.method", "GET");
-                
+
                 activity?.SetTag("migrationtools.client", "TfsObjectModel");
-                activity?.SetEndTime(activity.StartTimeUtc.AddSeconds(1));
 
                 DateTime startTime = DateTime.Now;
                 Stopwatch mainTimer = Stopwatch.StartNew();

--- a/src/MigrationTools/MigrationEngine.cs
+++ b/src/MigrationTools/MigrationEngine.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Diagnostics.Metrics;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using MigrationTools.Endpoints;
@@ -65,7 +64,6 @@ namespace MigrationTools
             using (var activity = ActivitySourceProvider.ActivitySource.StartActivity("MigrationEngine:Run", ActivityKind.Internal))
             {
                 activity?.SetTag("migrationtools.engine.processors", Processors.Count);
-                activity?.Start();
 
                 _logger.LogInformation("Logging has been configured and is set to: {LogLevel}. ", "unknown");
                 _logger.LogInformation("                              Max Logfile: {FileLogLevel}. ", "Verbose");
@@ -74,9 +72,9 @@ namespace MigrationTools
                 _logger.LogInformation("The Max log levels above show where to go look for extra info. e.g. Even if you set the log level to Verbose you will only see that info in the Log File, however everything up to Debug will be in the Console.");
                 ProcessingStatus ps = ProcessingStatus.Running;
                 _logger.LogInformation("Beginning run of {ProcessorCount} processors", Processors.Count.ToString());
-               
+
                 foreach (IOldProcessor process in Processors.Processors)
-                {                   
+                {
                     using (var activityForProcessor = ActivitySourceProvider.ActivitySource.StartActivity($"Processor[{process.GetType().Name}]", ActivityKind.Internal))
                     {
                         activityForProcessor.AddTag("ProcessorName", process.Name);
@@ -86,7 +84,7 @@ namespace MigrationTools
                         Stopwatch processorTimer = Stopwatch.StartNew();
                         process.Execute();
                         processorTimer.Stop();
-                       
+
                         processorMetrics.Duration.Record(processorTimer.ElapsedMilliseconds, new KeyValuePair<string, object?>("processor", nameof(process)));
                         if (process.Status == ProcessingStatus.Failed)
                         {

--- a/src/MigrationTools/MigrationTools.csproj
+++ b/src/MigrationTools/MigrationTools.csproj
@@ -28,12 +28,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Remove="Infrastructure\**" />
-    <EmbeddedResource Remove="Infrastructure\**" />
-    <None Remove="Infrastructure\**" />
-  </ItemGroup>
-
-  <ItemGroup>
     <Compile Include="..\..\GlobalUsings.cs" Link="GlobalUsings.cs" />
   </ItemGroup>
 
@@ -52,7 +46,6 @@
     <PackageReference Include="Microsoft.VisualStudio.Services.Client" />
     <PackageReference Include="Microsoft.VisualStudio.Services.ServiceEndpoints.WebApi" />
     <PackageReference Include="Newtonsoft.Json.Schema" />
-    <PackageReference Include="OpenTelemetry.Exporter.Console" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Process" />
@@ -67,10 +60,6 @@
       <Pack>True</Pack>
       <PackagePath></PackagePath>
     </None>
-  </ItemGroup>
-
-  <ItemGroup>
-    <Folder Include="Host\" />
   </ItemGroup>
 
 </Project>

--- a/src/MigrationTools/Processors/Enrichers/PauseAfterEachItem.cs
+++ b/src/MigrationTools/Processors/Enrichers/PauseAfterEachItem.cs
@@ -2,14 +2,13 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using MigrationTools.DataContracts;
-using MigrationTools.Processors;
 using MigrationTools.Processors.Infrastructure;
 
 namespace MigrationTools.Enrichers
 {
     public class PauseAfterEachItem : WorkItemProcessorEnricher
     {
-        private PauseAfterEachItemOptions _Options;
+        private PauseAfterEachItemOptions _Options = new PauseAfterEachItemOptions();
 
         public PauseAfterEachItemOptions Options
         {

--- a/src/MigrationTools/Tools/FieldMappingToolOptions.cs
+++ b/src/MigrationTools/Tools/FieldMappingToolOptions.cs
@@ -1,10 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Options;
-using MigrationTools._EngineV1.Configuration;
-using MigrationTools.Enrichers;
-using MigrationTools.Options;
 using MigrationTools.Tools.Infrastructure;
 
 namespace MigrationTools.Tools
@@ -25,11 +21,11 @@ namespace MigrationTools.Tools
 
             public void Configure(FieldMappingToolOptions options)
             {
-                 _configuration.GetSection(options.ConfigurationMetadata.PathToInstance).Bind(options);
-                 options.FieldMaps = _configuration.GetSection(options.ConfigurationMetadata.PathToInstance + ":FieldMaps")?.ToMigrationToolsList(child => child.GetMigrationToolsOption<IFieldMapOptions>("FieldMapType"));
-
+                IConfigurationSection cfg = _configuration.GetSection(options.ConfigurationMetadata.PathToInstance);
+                options.Enabled = cfg.GetValue(nameof(Enabled), defaultValue: false);
+                options.FieldMaps = _configuration.GetSection(options.ConfigurationMetadata.PathToInstance + ":FieldMaps")
+                    ?.ToMigrationToolsList(child => child.GetMigrationToolsOption<IFieldMapOptions>("FieldMapType"));
             }
         }
-
     }
 }


### PR DESCRIPTION
I found some errors and also fixed some warnings in project.

_Personally I try to have 0 (zero) warnings in my projects. I treat warning as potential error and when  there are a lot of warnings, people tent to completely ignore them. So I fixed all warnings that could be fixed – there remained 3 warnings regarding references._

## What is changed/fixed in this PR

Every change is a commit on its own.

- Activities were started twice. `ActivitySource.StartActivity` returns started activity, so later `activity.Start();` call was throwing an exception that already started activity cannot be started again.
- `FieldMappingToolOptions` wan not loaded correctly from configuration. The `Bind` call failed with exception, tah it cannot create an instance of interface/abstract classes. This was because of `FieldMaps` property, which is loaded manually, so I loaded manually even `Enabled` property.
- Fixed warnings related to non-existing `using`s and fields which were not initialized, so they had `null` value forever: `_options`/`_config`. I believe the processors with this errors could not work properly (or could not work at all).
- Updated (almost) all references to latest versions. I had some troubles and tried just tried this. It seems everything works – at least all tests are passing and my work items migration also works.
- Fixed calculating average and remainig time in work items migration. This was calculaten incorrectly – the average time was calculated as duration of **last processed item** divided by numer of processed items. So number of processed items is increasing but duration of last processed item is basically still the same (similar). So very quick the average time was very low and hence also the remainig time. In my case I have to migrate 10 000 work items. After migrating couple of hundreds (~400), the average time was very low and remaining time was reported as couple of minutes to complete 9 500 items, which is not possible. Now average time is calculated correctly as **total process time of all processed items** divided by count of processed items.
- Remove call of `SetEndTime` for activities. Basically that meant, that the activity duration was explicitly set to that timespan. This was second problem in calculating remaining time in work items migration.