### PR TITLE
SkipValidateAllUsersExistOrAreMapped can be skippt over options

### DIFF
--- a/src/MigrationTools.Clients.TfsObjectModel/Processors/TfsWorkItemMigrationProcessor.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/Processors/TfsWorkItemMigrationProcessor.cs
@@ -215,6 +215,12 @@ namespace MigrationTools.Processors
 
         private void ValidateAllUsersExistOrAreMapped(List<WorkItemData> sourceWorkItems)
         {
+            if (this.Options.SkipValidateAllUsersExistOrAreMapped)
+            {
+                contextLog.Information("Skipped: Validating::Check that all users in the source exist in the target or are mapped!");
+                return;
+            }
+
             contextLog.Information("Validating::Check that all users in the source exist in the target or are mapped!");
             IdentityMapResult usersToMap = CommonTools.UserMapping.GetUsersInSourceMappedToTargetForWorkItems(this, sourceWorkItems);
             if (usersToMap != null && usersToMap.IdentityMap != null && usersToMap.IdentityMap.Count > 0)

--- a/src/MigrationTools.Clients.TfsObjectModel/Processors/TfsWorkItemMigrationProcessor.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/Processors/TfsWorkItemMigrationProcessor.cs
@@ -215,7 +215,7 @@ namespace MigrationTools.Processors
 
         private void ValidateAllUsersExistOrAreMapped(List<WorkItemData> sourceWorkItems)
         {
-            if (this.Options.SkipValidateAllUsersExistOrAreMapped)
+            if (CommonTools.UserMapping.Options.SkipValidateAllUsersExistOrAreMapped)
             {
                 contextLog.Information("Skipped: Validating::Check that all users in the source exist in the target or are mapped!");
                 return;

--- a/src/MigrationTools.Clients.TfsObjectModel/Processors/TfsWorkItemMigrationProcessorOptions.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/Processors/TfsWorkItemMigrationProcessorOptions.cs
@@ -113,12 +113,6 @@ namespace MigrationTools.Processors
         /// </summary>
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public bool SkipRevisionWithInvalidAreaPath { get; set; } = false;
-
-        /// <summary>
-        /// When set to true, this setting will skip a validation that all users exists or mapped
-        /// </summary>
-        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
-        public bool SkipValidateAllUsersExistOrAreMapped { get; set; } = false;
     }
 
  

--- a/src/MigrationTools.Clients.TfsObjectModel/Processors/TfsWorkItemMigrationProcessorOptions.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/Processors/TfsWorkItemMigrationProcessorOptions.cs
@@ -114,7 +114,11 @@ namespace MigrationTools.Processors
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public bool SkipRevisionWithInvalidAreaPath { get; set; } = false;
 
-        
+        /// <summary>
+        /// When set to true, this setting will skip a validation that all users exists or mapped
+        /// </summary>
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public bool SkipValidateAllUsersExistOrAreMapped { get; set; } = false;
     }
 
  

--- a/src/MigrationTools.Clients.TfsObjectModel/Tools/TfsUserMappingToolOptions.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/Tools/TfsUserMappingToolOptions.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using MigrationTools.Tools.Infrastructure;
+using Newtonsoft.Json;
 
 namespace MigrationTools.Tools
 {
@@ -21,6 +22,12 @@ namespace MigrationTools.Tools
         /// users will be mapped by their email address first. If no match is found, then the display name will be used.
         /// </summary>
         public bool MatchUsersByEmail { get; set; }
+
+        /// <summary>
+        /// When set to true, this setting will skip a validation that all users exists or mapped
+        /// </summary>
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public bool SkipValidateAllUsersExistOrAreMapped { get; set; } = false;
     }
 
     public interface ITfsUserMappingToolOptions
@@ -28,5 +35,6 @@ namespace MigrationTools.Tools
         List<string> IdentityFieldsToCheck { get; set; }
         string UserMappingFile { get; set; }
         bool MatchUsersByEmail { get; set; }
+        bool SkipValidateAllUsersExistOrAreMapped { get; set; }
     }
 }


### PR DESCRIPTION
cause uservalidation need mutch time and when create a mapping file before it is not needed. with this option it can be skipped