### PR TITLE
Log a warning if the Microsoft.VSTS.TCM.Steps field does not exist on the source work item.

### DIFF
--- a/src/MigrationTools.Clients.TfsObjectModel/Processors/TfsWorkItemMigrationProcessor.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/Processors/TfsWorkItemMigrationProcessor.cs
@@ -537,9 +537,9 @@ namespace MigrationTools.Processors
                     {
                         newWorkItem.Fields["Microsoft.VSTS.TCM.Steps"].Value = oldWorkItem.Fields["Microsoft.VSTS.TCM.Steps"].Value;
                     }
-                    catch (Exception e)
+                    catch (FieldDefinitionNotExistException ex)
                     {
-                        Log.LogWarning("Microsoft.VSTS.TCM.Steps does not exist on Source Work Item. This field will be skipped, but the all other fields on the revision will be populated.");
+                        Log.LogWarning($"Microsoft.VSTS.TCM.Steps does not exist on Source Work Item. This field will be skipped, but the all other fields on the revision will be populated. Exception details: {ex.Message}");
                     }
                     newWorkItem.Fields["Microsoft.VSTS.Common.Priority"].Value =
                         oldWorkItem.Fields["Microsoft.VSTS.Common.Priority"].Value;

--- a/src/MigrationTools.Clients.TfsObjectModel/Processors/TfsWorkItemMigrationProcessor.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/Processors/TfsWorkItemMigrationProcessor.cs
@@ -533,7 +533,14 @@ namespace MigrationTools.Processors
             switch (destType)
             {
                 case "Test Case":
-                    newWorkItem.Fields["Microsoft.VSTS.TCM.Steps"].Value = oldWorkItem.Fields["Microsoft.VSTS.TCM.Steps"].Value;
+                    try
+                    {
+                        newWorkItem.Fields["Microsoft.VSTS.TCM.Steps"].Value = oldWorkItem.Fields["Microsoft.VSTS.TCM.Steps"].Value;
+                    }
+                    catch (Exception e)
+                    {
+                        Log.LogWarning("Microsoft.VSTS.TCM.Steps does not exist on Source Work Item. This field will be skipped, but the all other fields on the revision will be populated.");
+                    }
                     newWorkItem.Fields["Microsoft.VSTS.Common.Priority"].Value =
                         oldWorkItem.Fields["Microsoft.VSTS.Common.Priority"].Value;
                     break;


### PR DESCRIPTION
**FEATURE SUGGESTION**

This PR adds a try-catch block around the line of code that tries to access the `Microsoft.VSTS.TCM.Steps` field, whcih can fail if the Steps field does not exist on the source work item.

This change has enabled us to map non-Test Case Work Item types to Test Cases, which was previously not possible.

I am submitting this PR in order to raise awareness of the issue. It seems like there are several unchecked attempts to access fields in the `oldWorkItemData` based on the available fields of `newWorkItemData`, without considering if those fields are present on the source work item or not.

The same thing happens for `Microsoft.VSTS.Common.Priority` here, and I can imagine that this will cause the same error if the source Work Item Types does not have the Priority field: https://github.com/nkdAgility/azure-devops-migration-tools/blob/498f1824b62bd04915116a9a76149765393e4377/src/MigrationTools.Clients.TfsObjectModel/Processors/TfsWorkItemMigrationProcessor.cs#L537-L538

Previously, the migrator would throw an exception which casued the whole revision import to fail, resulting in other missing fields, links, attachments, etc.

The relevant error message was:

```txt
Microsoft.TeamFoundation.WorkItemTracking.Client.FieldDefinitionNotExistException: TF26027: A field definition
Microsoft.VSTS.TCM.Steps in the work item type definition file does not exist. Add a definition for this field
or remove the reference to the field and try again.
```

Let me know if you have further suggestions.
