### PR TITLE
Fix invalidcastexception in multivalueconditionalmap

### DIFF
--- a/src/MigrationTools.Clients.TfsObjectModel/Tools/FieldMappingTool/FieldMaps/MultiValueConditionalMap.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/Tools/FieldMappingTool/FieldMaps/MultiValueConditionalMap.cs
@@ -75,7 +75,7 @@ namespace MigrationTools.FieldMaps.AzureDevops.ObjectModel
             bool matches = true;
             foreach (string field in fieldAndValues.Keys)
             {
-                if ((string)workitem.Fields[field].Value != fieldAndValues[field])
+                if ((workitem.Fields[field].Value?.ToString() ?? string.Empty) != fieldAndValues[field])
                 {
                     matches = false;
                 }


### PR DESCRIPTION
Fix for typecast error if work item field type is not a string (e.g., integer) in fieldmap multivalueconditionalmap -> "Field map fault System.InvalidCastException: Unable to cast object of type 'System.Int32' to type 'System.String'."