### PR TITLE
Move Docs to https://devopsmigration.io/

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ By submitting a contribution to the project, you agree to this CLA. If you do no
   - Add comments or reactions (e.g., 👍, 👎) to relevant discussions.
 
 - **Use the Comment/Discussion Boxes on Documentation Pages**:  
-  If your topic relates to an existing feature, check the relevant [documentation page](https://nkdagility.com/) for details. Most pages include comment or discussion boxes at the bottom.  
+  If your topic relates to an existing feature, check the relevant [documentation page](https://devopsmigration.io/) for details. Most pages include comment or discussion boxes at the bottom.  
   - Using these boxes for discussions tied to specific features helps keep the conversation contextual and accessible for others with similar questions.
 
 ---

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Created and maintained by [Martin Hinshelwood](https://www.linkedin.com/in/marti
 
 # Azure DevOps Migration Tools
 
-The Azure DevOps Migration Tools allow you to bulk edit and migrate data between Team Projects on both Microsoft Team Foundation Server (TFS) and Azure DevOps Services. Take a look at the  [documentation](https://nkdagility.com/learn/azure-devops-migration-tools/) to find out how. This project is published as [code on GitHub](https://github.com/nkdAgility/azure-devops-migration-tools/) as well as a Winget package a `nkdAgility.AzureDevOpsMigrationTools`.
+The Azure DevOps Migration Tools allow you to bulk edit and migrate data between Team Projects on both Microsoft Team Foundation Server (TFS) and Azure DevOps Services. Take a look at the  [documentation](https://devopsmigration.io/) to find out how. This project is published as [code on GitHub](https://github.com/nkdAgility/azure-devops-migration-tools/) as well as a Winget package a `nkdAgility.AzureDevOpsMigrationTools`.
 
 **Ask Questions on Github: https://github.com/nkdAgility/azure-devops-migration-tools/discussions**
 
@@ -63,16 +63,16 @@ For the most part we support moving data between ((Azure DevOps Server | Team Fo
 
 ## Quick Links
 
-- [Documenation](https://nkdagility.com/docs/azure-devops-migration-tools/)
-- [Installation](https://nkdagility.com/learn/azure-devops-migration-tools/installation/)
-- [Permissions](https://nkdagility.com/learn/azure-devops-migration-tools/permissions/)
-- [Getting Started](https://nkdagility.com/learn/azure-devops-migration-tools/getting-started/)
-- [Configuration Reference](https://nkdagility.com/learn/azure-devops-migration-tools/Reference/)
+- [Documenation](https://devopsmigration.io)
+- [Installation](https://devopsmigration.io/installation/)
+- [Permissions](https://devopsmigration.io/permissions/)
+- [Getting Started](https://devopsmigration.io/getting-started/)
+- [Configuration Reference](https://devopsmigration.io/Reference/)
 - [Community Support](https://github.com/nkdAgility/azure-devops-migration-tools/discussions)
 - [Commercial Support](https://nkdagility.com/capabilities/azure-devops-migration-services/)
-- [Change Log](https://nkdagility.com/learn/azure-devops-migration-tools/change-log/)
+- [Change Log](https://devopsmigration.io/change-log/)
 
-The documentation for the preview is on [Preview](https://nkdagility.com/docs/azure-devops-migration-tools/preview/)]
+The documentation for the preview is on [Preview](https://blue-river-093197403-preview.westeurope.5.azurestaticapps.net/)]
 
 ## Metrics
 

--- a/_config.yml
+++ b/_config.yml
@@ -3,10 +3,10 @@ description: Azure DevOps Migration Tools allow you to migrate Teams, Backlogs, 
 parent_title: The Azure DevOps Migration Tools allow you to bulk edit and migrate data between Team Projects on both Microsoft Team Foundation Server (TFS) and Azure DevOps Services.
 parent_url: https://nkdagility.com
 
-website: https://nkdagility.com
-baseurl: /learn/azure-devops-migration-tools
-cannonicalBase: https://nkdagility.com/learn/azure-devops-migration-tools
-url: "https://nkdagility.com"
+website: https://devopsmigration.io
+baseurl: /
+cannonicalBase: https://devopsmigration.io
+url: https://devopsmigration.io
 githuburl: https://github.com/nkdAgility/azure-devops-migration-tools
 source: ./docs
 destination: ./_site

--- a/docs/_includes/header.html
+++ b/docs/_includes/header.html
@@ -31,7 +31,7 @@
                     <div class="d-flex w-100 justify-content-between">
                         <div class="d-flex">
                             <a class="navbar-brand" href="#">
-                                <img src="/blob/images/nkdagility-with-martin-hinshelwood-light.png" alt="Naked Agility Ltd" width="234" height="99">
+                                <img src="{{site.parent_url}}/blob/images/nkdagility-with-martin-hinshelwood-light.png" alt="Naked Agility Ltd" width="234" height="99">
                             </a>
                         </div>
                         <div class="d-flex text-uppercase align-items-center">

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -85,11 +85,11 @@
                                 <ul class="list-group">
                                     <li class="list-group-item">
                                         <i class="fas fa-question-circle"></i>
-                                        <a href="https://nkdagility.com/learn/azure-devops-migration-tools{{page.url}}" class="ml-2" target="_blank">Release</a>  (<a href="https://blue-river-093197403.5.azurestaticapps.net/{{page.url}}" rel="nofollow noindex" class="ml-2" target="_blank">without AFD</a>)
+                                        <a href="https://devopsmigration.io{{page.url}}" class="ml-2" target="_blank">Release</a>
                                     </li>
                                     <li class="list-group-item">
                                         <i class="fab fa-twitter"></i>
-                                        <a href="https://preview.nkdagility.com/learn/azure-devops-migration-tools{{page.url}}" rel="nofollow noindex" class="ml-2" target="_blank">Preview</a> (<a href="https://blue-river-093197403-preview.westeurope.5.azurestaticapps.net{{page.url}}" rel="nofollow noindex" class="ml-2" target="_blank">without AFD</a>)
+                                        <a href="https://blue-river-093197403-preview.westeurope.5.azurestaticapps.net{{page.url}}" rel="nofollow noindex" class="ml-2" target="_blank">Preview</a>
                                     </li>
                                 </ul>
                             </li>

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,7 @@ pageStatus: published
 discussionId:
 ---
 
-The Azure DevOps Migration Tools allow you to bulk edit and migrate data between Team Projects on both Microsoft Team Foundation Server (TFS) and Azure DevOps Services. Take a look at the [documentation](https://nkdagility.com/learn/azure-devops-migration-tools/) to find out how. This project is published as [code on GitHub](https://github.com/nkdAgility/azure-devops-migration-tools/) as well as a Winget package a `nkdAgility.AzureDevOpsMigrationTools`.
+The Azure DevOps Migration Tools allow you to bulk edit and migrate data between Team Projects on both Microsoft Team Foundation Server (TFS) and Azure DevOps Services. Take a look at the [documentation](https://devopsmigration.io) to find out how. This project is published as [code on GitHub](https://github.com/nkdAgility/azure-devops-migration-tools/) as well as a Winget package a `nkdAgility.AzureDevOpsMigrationTools`.
 
 **[Ask Questions on Github](https://github.com/nkdAgility/azure-devops-migration-tools/discussions)**
 
@@ -61,7 +61,7 @@ For the most part we support moving data between `((Azure DevOps Server | Team F
 - [Community Support](https://github.com/nkdAgility/azure-devops-migration-tools/discussions)
 - [Commercial Support](https://nkdagility.com/capabilities/azure-devops-migration-services/)
 
-The documentation for the preview is on [Preview](https://preview.nkdagility.com/docs/azure-devops-migration-tools/)]
+The documentation for the preview is on [Preview](https://blue-river-093197403-preview.westeurope.5.azurestaticapps.net/)]
 
 #### External Walkthroughs and Reviews
 

--- a/docs/setup/installation.md
+++ b/docs/setup/installation.md
@@ -12,7 +12,7 @@ redirect_from:
 Install the Azure DevOps Migration Tools on Windows.
 
 These tools are available as a portable application and can be installed in a number of ways, including manually from a zip.
-For a more detailed getting started guide please see the [documentation](https://nkdagility.com/learn/azure-devops-migration-tools/getting-started/).
+For a more detailed getting started guide please see the [documentation](/getting-started/).
 
 ## Option 1: Winget
 

--- a/src/MigrationTools.Chocolatey/nkdAgility.AzureDevOpsMigrationTools-Preview.nuspec
+++ b/src/MigrationTools.Chocolatey/nkdAgility.AzureDevOpsMigrationTools-Preview.nuspec
@@ -10,7 +10,7 @@
     <description>Azure Devops Migration Tools allow you to bulk edit data in Microsoft Team Foundation Server (TFS) and Azure DevOps Services. Supports both migration and bulk update scenarios.</description>
     <projectUrl>https://github.com/nkdAgility/azure-devops-migration-tools/</projectUrl>
     <packageSourceUrl>https://chocolatey.org/packages/vsts-sync-migrator/</packageSourceUrl>
-    <docsUrl>https://nkdagility.com/learn/azure-devops-migration-tools/</docsUrl>
+    <docsUrl>https://devopsmigration.io/</docsUrl>
     <bugTrackerUrl>https://github.com/nkdAgility/azure-devops-migration-tools/issues</bugTrackerUrl>
     <tags>WIT WorkItem AzureDevOps TFS VSTS VSO VisualStudioOnline DevOps Microsoft TestManagement</tags>
     <releaseNotes>https://nkdagility.com/docs/azure-devops-migration-tools/</releaseNotes>

--- a/src/MigrationTools.Clients.TfsObjectModel/EndPoints/Infrastructure/TfsTeamProjectAuthentication.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/EndPoints/Infrastructure/TfsTeamProjectAuthentication.cs
@@ -33,7 +33,7 @@ namespace MigrationTools.Endpoints.Infrastructure
                 case AuthenticationMode.AccessToken:
                     if (string.IsNullOrWhiteSpace(options.AccessToken))
                     {
-                        errors.Add("The AccessToken must not be null or empty when AuthenticationMode is set to 'AccessToken'. You must provide a PAT to use 'AccessToken' as the authentication mode. You can set this through the config at 'MigrationTools:Endpoints:{name}:Authentication:AccessToken', or you can set an environment variable of 'MigrationTools__Endpoints__{name}__Authentication__AccessToken'. Check the docs on https://nkdagility.com/learn/azure-devops-migration-tools/Reference/Endpoints/TfsTeamProjectEndpoint/");
+                        errors.Add("The AccessToken must not be null or empty when AuthenticationMode is set to 'AccessToken'. You must provide a PAT to use 'AccessToken' as the authentication mode. You can set this through the config at 'MigrationTools:Endpoints:{name}:Authentication:AccessToken', or you can set an environment variable of 'MigrationTools__Endpoints__{name}__Authentication__AccessToken'. Check the docs on https://devopsmigration.io/Reference/Endpoints/TfsTeamProjectEndpoint/");
                     }
                     break;
 

--- a/src/MigrationTools.Clients.TfsObjectModel/Endpoints/TfsEndpointOptions.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/Endpoints/TfsEndpointOptions.cs
@@ -88,7 +88,7 @@ namespace MigrationTools.Endpoints
             // Validate ReflectedWorkItemIdField - Must not be null or empty
             if (string.IsNullOrWhiteSpace(options.ReflectedWorkItemIdField))
             {
-                errors.Add("The ReflectedWorkItemIdField property must not be null or empty. Check the docs on https://nkdagility.com/learn/azure-devops-migration-tools/setup/reflectedworkitemid/");
+                errors.Add("The ReflectedWorkItemIdField property must not be null or empty. Check the docs on https://devopsmigration.io/setup/reflectedworkitemid/");
             }
 
             // Validate LanguageMaps - Must exist

--- a/src/MigrationTools.Clients.TfsObjectModel/Endpoints/TfsTeamProjectEndpoint.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/Endpoints/TfsTeamProjectEndpoint.cs
@@ -91,7 +91,7 @@ namespace MigrationTools.Clients
                             Log.LogInformation("Connecting with AccessToken ");
                             if (string.IsNullOrEmpty(Options.Authentication.AccessToken))
                             {
-                                Log.LogCritical("You must provide a PAT to use 'AccessToken' as the authentication mode. You can set this through the config at 'MigrationTools:Endpoints:{name}:Authentication:AccessToken', or you can set an environemnt variable of 'MigrationTools__Endpoints__{name}__Authentication__AccessToken'. Check the docs on https://nkdagility.com/learn/azure-devops-migration-tools/Reference/Endpoints/TfsTeamProjectEndpoint/");
+                                Log.LogCritical("You must provide a PAT to use 'AccessToken' as the authentication mode. You can set this through the config at 'MigrationTools:Endpoints:{name}:Authentication:AccessToken', or you can set an environemnt variable of 'MigrationTools__Endpoints__{name}__Authentication__AccessToken'. Check the docs on https://devopsmigration.io/Reference/Endpoints/TfsTeamProjectEndpoint/");
                                 Environment.Exit(-1);
                             }
                             var pat = Options.Authentication.AccessToken;
@@ -102,7 +102,7 @@ namespace MigrationTools.Clients
                             Log.LogInformation("Connecting with NetworkCredential ");
                             if (Options.Authentication.NetworkCredentials == null)
                             {
-                                Log.LogCritical("You must set NetworkCredential to use 'Windows' as the authentication mode. You can set this through the config at 'MigrationTools:Endpoints:{name}:Authentication:AccessToken', or you can set an environemnt variable of 'MigrationTools__Endpoints__{name}__Authentication__AccessToken'. Check the docs on https://nkdagility.com/learn/azure-devops-migration-tools/Reference/Endpoints/TfsTeamProjectEndpoint/");
+                                Log.LogCritical("You must set NetworkCredential to use 'Windows' as the authentication mode. You can set this through the config at 'MigrationTools:Endpoints:{name}:Authentication:AccessToken', or you can set an environemnt variable of 'MigrationTools__Endpoints__{name}__Authentication__AccessToken'. Check the docs on https://devopsmigration.io/Reference/Endpoints/TfsTeamProjectEndpoint/");
                                 Environment.Exit(-1);
                             }
                             var cred = new NetworkCredential(Options.Authentication.NetworkCredentials.UserName, Options.Authentication.NetworkCredentials.Password, Options.Authentication.NetworkCredentials.Domain);

--- a/src/MigrationTools.Clients.TfsObjectModel/Tools/TfsNodeStructureTool.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/Tools/TfsNodeStructureTool.cs
@@ -465,7 +465,7 @@ namespace MigrationTools.Tools
             }
             catch (Exception ex)
             {
-                Exception ex2 = new Exception(string.Format("Unable to load Common Structure for Target.This is usually due to TFS having a different installed langauge version than was expected.. Validate that '{0}' is the correct name in your version. This would be something like 'Fläche' or 'Aire'. If you open the area tree in Visual Studio, or web access, you should see the name your langauage uses for 'Area' or 'Iteration. Do not try to add a specific area or iteration path to this field. Check the defaults on https://nkdagility.com/learn/azure-devops-migration-tools/Reference/Endpoints/TfsTeamProjectEndpoint/ for an example fro English.", localizedTreeTypeName), ex);
+                Exception ex2 = new Exception(string.Format("Unable to load Common Structure for Target.This is usually due to TFS having a different installed langauge version than was expected.. Validate that '{0}' is the correct name in your version. This would be something like 'Fläche' or 'Aire'. If you open the area tree in Visual Studio, or web access, you should see the name your langauage uses for 'Area' or 'Iteration. Do not try to add a specific area or iteration path to this field. Check the defaults on https://devopsmigration.io/Reference/Endpoints/TfsTeamProjectEndpoint/ for an example fro English.", localizedTreeTypeName), ex);
                 throw ex2.AsMigrationToolsException(MigrationToolsException.ExceptionSource.Configuration);
             }
 
@@ -664,7 +664,7 @@ namespace MigrationTools.Tools
             {
                 Log.LogWarning("!! There are MISSING Area or Iteration Paths");
                 Log.LogWarning("NOTE: It is NOT possible to migrate a work item if the Area or Iteration path does not exist on the target project. This is because the work item will be created with the same Area and Iteration path as the source work item with the project name swapped. The work item will not be created if the path does not exist. The only way to resolve this is to follow the instructions:");
-                Log.LogWarning("!! There are {missingAreaPaths} Nodes (Area or Iteration) found in the history of the Source that are missing from the Target! These MUST be added or mapped before we can continue using the instructions on https://nkdagility.com/learn/azure-devops-migration-tools/Reference/Tools/TfsNodeStructureTool/#iteration-maps-and-area-maps", missingItems.Count);
+                Log.LogWarning("!! There are {missingAreaPaths} Nodes (Area or Iteration) found in the history of the Source that are missing from the Target! These MUST be added or mapped before we can continue using the instructions on https://devopsmigration.io/Reference/Tools/TfsNodeStructureTool/#iteration-maps-and-area-maps", missingItems.Count);
                 foreach (NodeStructureItem missingItem in missingItems)
                 {
                     string mapper = GetMappingForMissingItem(missingItem);

--- a/src/MigrationTools.Extension/README.md
+++ b/src/MigrationTools.Extension/README.md
@@ -47,7 +47,7 @@ The Azure DevOps Migration Tools allow you to bulk edit and migrate data between
 ## Quick Links
 
  - [Video Overview](https://www.youtube.com/watch?v=RCJsST0xBCE)
- - [Getting Started](https://nkdagility.com/learn/azure-devops-migration-tools/getting-started.html)
+ - [Getting Started](https://devopsmigration.io/getting-started.html)
  - [Documentation](https://nkdagility.com/docs/azure-devops-migration-tools/)
  - [Questions on Usage](https://stackoverflow.com/questions/tagged/azure-devops-migration-tools)
  - [Bugs and New Features](https://github.com/nkdAgility/azure-devops-migration-tools)

--- a/src/MigrationTools.Extension/vss-extension.json
+++ b/src/MigrationTools.Extension/vss-extension.json
@@ -31,13 +31,13 @@
   ],
   "links": {
     "home": {
-      "uri": "https://nkdagility.com/learn/azure-devops-migration-tools/"
+      "uri": "https://devopsmigration.io/"
     },
     "getstarted": {
-      "uri": "https://nkdagility.com/learn/azure-devops-migration-tools/getting-started.html"
+      "uri": "https://devopsmigration.io/getting-started.html"
     },
     "learn": {
-      "uri": "https://nkdagility.com/learn/azure-devops-migration-tools/"
+      "uri": "https://devopsmigration.io/"
     },
     "support": {
       "uri": "https://github.com/nkdAgility/azure-devops-migration-tools/discussions"

--- a/src/MigrationTools.Host/Commands/ExecuteMigrationCommand.cs
+++ b/src/MigrationTools.Host/Commands/ExecuteMigrationCommand.cs
@@ -64,7 +64,7 @@ namespace MigrationTools.Host.Commands
             catch (OptionsValidationException ex)
             {
                 CommandActivity.RecordException(ex);
-                _logger.LogCritical("The config contains some invalid options. Please check the list below and refer to https://nkdagility.com/learn/azure-devops-migration-tools/ for the specific configration options.");
+                _logger.LogCritical("The config contains some invalid options. Please check the list below and refer to https://devopsmigration.io/ for the specific configration options.");
                 _logger.LogCritical("------------");
                 _logger.LogCritical("OptionName: {OptionsName}", ex.OptionsName);
                 _logger.LogCritical("The following options are invalid:");


### PR DESCRIPTION
📝 (docs): update documentation links to new domain

Update all documentation links from `nkdagility.com` to the new domain `devopsmigration.io`. This change ensures that users are directed to the correct and updated documentation site, improving accessibility and user experience. The update affects various markdown files, configuration files, and source code comments where documentation links are referenced.