### PR TITLE
Fix feature flag

### DIFF
--- a/docs/content/docs/config-wizard.md
+++ b/docs/content/docs/config-wizard.md
@@ -3,18 +3,24 @@ title: Interactive Configuration Wizard
 description: Build your Azure DevOps Migration Tools configuration with our interactive step-by-step wizard supporting three migration type architectures
 weight: 50
 date: 2025-06-26T12:00:00Z
-discussionId: 
+discussionId:
 aliases:
-- /config-wizard/
-- /wizard/
-- /configure/
+  - /config-wizard/
+  - /wizard/
+  - /configure/
 layout: config-wizard
+cascade:
+  - build:
+      list: never
+      render: never
+    target:
+      environment: production
 ---
 
 Use this interactive wizard to build your Azure DevOps Migration Tools configuration. The wizard supports three primary migration types:
 
 - **Work Items**: Standard work item migration with pre-configured TfsWorkItemEndpoint and TfsWorkItemMigrationProcessor
-- **Pipelines**: Pipeline migration with pre-configured AzureDevOpsEndpoint and AzureDevOpsPipelineProcessor  
+- **Pipelines**: Pipeline migration with pre-configured AzureDevOpsEndpoint and AzureDevOpsPipelineProcessor
 - **Custom**: Advanced scenarios with complete flexibility to configure multiple endpoints and processors
 
 The wizard will guide you through each step and generate a complete configuration file based on your selections and the migration type constraints.

--- a/docs/hugo.preview.yaml
+++ b/docs/hugo.preview.yaml
@@ -4,3 +4,7 @@ minifyOutput: true
 
 buildDrafts: true
 buildFuture: true
+
+params:
+  features:
+    configWizard: true

--- a/docs/hugo.yaml
+++ b/docs/hugo.yaml
@@ -9,8 +9,6 @@ summaryLength: 30
 enableRobotsTXT: true
 enableGitInfo: true
 
-
-
 # Disable default taxonomies (tags and categories)
 taxonomies: {}
 
@@ -47,7 +45,7 @@ params:
   menu_image_light: "/images/logo-wide-transparent-light.png"
   menu_image_dark: "/images/logo-wide-transparent-dark.png"
   features:
-    configWizard: "none"
+    configWizard: false # Enable or disable the configuration wizard feature
 
 # Enable sitemap and robots.txt
 sitemap:


### PR DESCRIPTION
This pull request introduces updates to the documentation configuration and feature toggles for the Azure DevOps Migration Tools. The most important changes include adding cascading build rules for the configuration wizard documentation, enabling the configuration wizard feature in the preview environment, and modifying the feature toggle for the configuration wizard in the main configuration.

### Documentation configuration updates:
* [`docs/content/docs/config-wizard.md`](diffhunk://#diff-74164cb9cb5878eb6e196e138531baf584c1f086ed8862941457d32556107e0dR12-R17): Added cascading build rules to exclude the configuration wizard documentation from being listed or rendered in the production environment.

### Feature toggles:
* [`docs/hugo.preview.yaml`](diffhunk://#diff-5b2bc656cefcb3f25cd9717a7a67c9c716a2fd4637ed5495b4add056d8fe71a7R7-R10): Enabled the `configWizard` feature for the preview environment by adding it to the `params.features` section.
* [`docs/hugo.yaml`](diffhunk://#diff-d5c956de42afb7f74e802a33282d709f17378a82367268f07ca3f0fa0ec121d0L50-R48): Updated the `configWizard` feature toggle to `false` (disabled) in the main configuration file, replacing the previous value of `"none"`.