### PR TITLE
This fixes #2863

### DIFF
--- a/src/MigrationTools.Clients.TfsObjectModel/ServiceCollectionExtensions.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/ServiceCollectionExtensions.cs
@@ -1,17 +1,12 @@
 ﻿using System;
-using System.Linq;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using MigrationTools.Clients;
-using MigrationTools._EngineV1.Containers;
-using MigrationTools.EndpointEnrichers;
 using MigrationTools.Endpoints;
 using MigrationTools.FieldMaps.AzureDevops.ObjectModel;
-using MigrationTools.Options;
 using MigrationTools.Processors;
 using MigrationTools.Tools;
-using Serilog;
 
 namespace MigrationTools
 {
@@ -30,7 +25,7 @@ namespace MigrationTools
             context.AddSingleton<TfsNodeStructureTool>().AddMigrationToolsOptions<TfsNodeStructureToolOptions, TfsNodeStructureToolOptionsValidator>(configuration);
             context.AddSingleton<TfsRevisionManagerTool>().AddMigrationToolsOptions<TfsRevisionManagerToolOptions>(configuration);
             context.AddSingleton<TfsTeamSettingsTool>().AddMigrationToolsOptions<TfsTeamSettingsToolOptions>(configuration);
-            context.AddSingleton< TfsChangeSetMappingTool>().AddMigrationToolsOptions<TfsChangeSetMappingToolOptions>(configuration);
+            context.AddSingleton<TfsChangeSetMappingTool>().AddMigrationToolsOptions<TfsChangeSetMappingToolOptions>(configuration);
         }
 
         public static void AddMigrationToolServicesForClientTfs_Processors(this IServiceCollection context)
@@ -72,19 +67,20 @@ namespace MigrationTools
         public static void AddMigrationToolServicesForClientLegacyAzureDevOpsObjectModel(this IServiceCollection context)
         {
             // Field Mapps
-            context.AddTransient< FieldSkipMap>();
-            context.AddTransient< FieldLiteralMap>();
-            context.AddTransient< FieldMergeMap>();  
-            context.AddTransient< FieldToFieldMap>();
-            context.AddTransient< FieldToFieldMultiMap>();
-            context.AddTransient< FieldToTagFieldMap>();
-            context.AddTransient< FieldValuetoTagMap>();
-            context.AddTransient< FieldToFieldMap>();
-            context.AddTransient< FieldValueMap>();
-            context.AddTransient< MultiValueConditionalMap>();
-            context.AddTransient< RegexFieldMap>();
-            context.AddTransient< TreeToTagFieldMap>();
-            
+            context.AddTransient<FieldSkipMap>();
+            context.AddTransient<FieldLiteralMap>();
+            context.AddTransient<FieldMergeMap>();
+            context.AddTransient<FieldToFieldMap>();
+            context.AddTransient<FieldToFieldMultiMap>();
+            context.AddTransient<FieldToTagFieldMap>();
+            context.AddTransient<FieldValuetoTagMap>();
+            context.AddTransient<FieldToFieldMap>();
+            context.AddTransient<FieldValueMap>();
+            context.AddTransient<MultiValueConditionalMap>();
+            context.AddTransient<RegexFieldMap>();
+            context.AddTransient<TreeToTagFieldMap>();
+            context.AddTransient<FieldCalculationMap>();
+
             // Core
             context.AddTransient<IMigrationClient, TfsTeamProjectEndpoint>();
             context.AddTransient<IWorkItemMigrationClient, TfsWorkItemMigrationClient>();


### PR DESCRIPTION
This pull request makes minor improvements to the `ServiceCollectionExtensions.cs` file by cleaning up unused `using` directives and adding a new service registration for `FieldCalculationMap`. These changes enhance code readability and extend functionality.

### Code cleanup:
* Removed unused `using` directives such as `System.Linq`, `MigrationTools._EngineV1.Containers`, `MigrationTools.EndpointEnrichers`, `MigrationTools.Options`, and `Serilog` to improve code clarity. (`[src/MigrationTools.Clients.TfsObjectModel/ServiceCollectionExtensions.csL2-L14](diffhunk://#diff-cd74f67f83d1e426c050179996963d643cf3466f4861d6c2d0a92376d72363ffL2-L14)`)

### Functional enhancement:
* Added a new transient service registration for `FieldCalculationMap` in the `AddMigrationToolServicesForClientLegacyAzureDevOpsObjectModel` method, enabling its use within the dependency injection container. (`[src/MigrationTools.Clients.TfsObjectModel/ServiceCollectionExtensions.csR82](diffhunk://#diff-cd74f67f83d1e426c050179996963d643cf3466f4861d6c2d0a92376d72363ffR82)`)

Fixes #2863