### PR TITLE
fix: Auth header when downloading images from tfs

### DIFF
--- a/src/MigrationTools.Clients.TfsObjectModel/Tools/TfsEmbededImagesTool.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/Tools/TfsEmbededImagesTool.cs
@@ -132,7 +132,7 @@ namespace MigrationTools.Tools
                 {
                     if (!string.IsNullOrEmpty(sourcePersonalAccessToken))
                     {
-                        if (!string.IsNullOrEmpty(sourcePersonalAccessToken) && matchedSourceUri.Contains("tfs/DefaultCollection"))
+                        if (!string.IsNullOrEmpty(sourcePersonalAccessToken) && new Uri(matchedSourceUri).PathAndQuery.StartsWith("/tfs/"))
                         {
                             string credentials = Convert.ToBase64String(Encoding.ASCII.GetBytes(string.Format("{0}:{1}", "", sourcePersonalAccessToken)));
                             httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", credentials);

--- a/src/MigrationTools.Clients.TfsObjectModel/Tools/TfsEmbededImagesTool.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/Tools/TfsEmbededImagesTool.cs
@@ -132,7 +132,15 @@ namespace MigrationTools.Tools
                 {
                     if (!string.IsNullOrEmpty(sourcePersonalAccessToken))
                     {
-                        httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", sourcePersonalAccessToken);
+                        if (!string.IsNullOrEmpty(sourcePersonalAccessToken) && matchedSourceUri.Contains("tfs/DefaultCollection"))
+                        {
+                            string credentials = Convert.ToBase64String(Encoding.ASCII.GetBytes(string.Format("{0}:{1}", "", sourcePersonalAccessToken)));
+                            httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", credentials);
+                        }
+                        else if (!string.IsNullOrEmpty(sourcePersonalAccessToken))
+                        {
+                            httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", sourcePersonalAccessToken);
+                        }
                     }
                     var result = DownloadFile(httpClient, matchedSourceUri, fullImageFilePath);
                     if (!result.IsSuccessStatusCode)

--- a/src/MigrationTools.Clients.TfsObjectModel/Tools/TfsEmbededImagesTool.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/Tools/TfsEmbededImagesTool.cs
@@ -132,16 +132,18 @@ namespace MigrationTools.Tools
                 {
                     if (!string.IsNullOrEmpty(sourcePersonalAccessToken))
                     {
-                        if (!string.IsNullOrEmpty(sourcePersonalAccessToken) && new Uri(matchedSourceUri).PathAndQuery.StartsWith("/tfs/"))
+                        var host = new Uri(matchedSourceUri).Host.ToLowerInvariant();
+                        if (host.Contains("dev.azure.com") || host.Contains("visualstudio.com"))
+                        {
+                            httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", sourcePersonalAccessToken);
+                        }
+                        else
                         {
                             string credentials = Convert.ToBase64String(Encoding.ASCII.GetBytes(string.Format("{0}:{1}", "", sourcePersonalAccessToken)));
                             httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", credentials);
                         }
-                        else if (!string.IsNullOrEmpty(sourcePersonalAccessToken))
-                        {
-                            httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", sourcePersonalAccessToken);
-                        }
                     }
+
                     var result = DownloadFile(httpClient, matchedSourceUri, fullImageFilePath);
                     if (!result.IsSuccessStatusCode)
                     {


### PR DESCRIPTION
Updated the logic for setting the `Authorization` header in `HttpClient` to improve security and flexibility. The code now checks if the `sourcePersonalAccessToken` is not empty and if the `matchedSourceUri` contains "tfs/DefaultCollection". If both conditions are met, the token is encoded in Base64 with an empty username; otherwise, the token is set directly if it's not empty.