### PR TITLE
Do not corrupt access token for downloading embedded images

### DIFF
--- a/src/MigrationTools.Clients.TfsObjectModel/Tools/TfsEmbededImagesTool.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/Tools/TfsEmbededImagesTool.cs
@@ -132,16 +132,7 @@ namespace MigrationTools.Tools
                 {
                     if (!string.IsNullOrEmpty(sourcePersonalAccessToken))
                     {
-                        var host = new Uri(matchedSourceUri).Host.ToLowerInvariant();
-                        if (host.Contains("dev.azure.com") || host.Contains("visualstudio.com"))
-                        {
-                            httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", sourcePersonalAccessToken);
-                        }
-                        else
-                        {
-                            string credentials = Convert.ToBase64String(Encoding.ASCII.GetBytes(string.Format("{0}:{1}", "", sourcePersonalAccessToken)));
-                            httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", credentials);
-                        }
+                        httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", sourcePersonalAccessToken);
                     }
 
                     var result = DownloadFile(httpClient, matchedSourceUri, fullImageFilePath);


### PR DESCRIPTION
Two weeks ago I fixed using access token when downloading embedded images in #2853. Now it was broken again in #2877.
