### PR TITLE
Implement validation of work item fields

### DIFF
--- a/src/MigrationTools.Clients.AzureDevops.Rest.Tests/Processors/AzureDevOpsProcessorTests.cs
+++ b/src/MigrationTools.Clients.AzureDevops.Rest.Tests/Processors/AzureDevOpsProcessorTests.cs
@@ -1,7 +1,5 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
-using Microsoft.VisualStudio.Services.Commerce;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using MigrationTools.EndpointEnrichers;
 using MigrationTools.Endpoints;
 using MigrationTools.Enrichers;
@@ -27,6 +25,7 @@ namespace MigrationTools.Processors.Tests
             services.AddSingleton<CommonTools>();
             services.AddSingleton<IFieldMappingTool, MockFieldMappingTool>();
             services.AddSingleton<IWorkItemTypeMappingTool, MockWorkItemTypeMappingTool>();
+            services.AddSingleton<IFieldReferenceNameMappingTool, MockFieldReferenceNameMappingTool>();
             services.AddSingleton<IStringManipulatorTool, StringManipulatorTool>();
 
             services.AddSingleton<AzureDevOpsPipelineProcessor>();
@@ -37,7 +36,7 @@ namespace MigrationTools.Processors.Tests
                 o.Enabled = options != null ? options.Enabled : true;
                 o.BuildPipelines = options != null ? options.BuildPipelines : null;
                 o.ReleasePipelines = options != null ? options.ReleasePipelines : null;
-                o.SourceName = options != null ? options.SourceName : "Source"; 
+                o.SourceName = options != null ? options.SourceName : "Source";
                 o.TargetName = options != null ? options.SourceName : "Target";
                 o.Enrichers = options != null ? options.Enrichers : null;
                 o.MigrateTaskGroups = options != null ? options.MigrateTaskGroups : true;
@@ -49,7 +48,7 @@ namespace MigrationTools.Processors.Tests
                 o.RefName = options != null ? options.RefName : null;
                 o.RepositoryNameMaps = options != null ? options.RepositoryNameMaps : null;
             }));
-            
+
             return services.BuildServiceProvider().GetService<AzureDevOpsPipelineProcessor>();
         }
 
@@ -77,9 +76,9 @@ namespace MigrationTools.Processors.Tests
 
         public static object GetValueFromProperty(LogEventPropertyValue value) =>
             value switch
-        {
-            ScalarValue v => v.Value,
-            _ => value.ToString(),
-        };
+            {
+                ScalarValue v => v.Value,
+                _ => value.ToString(),
+            };
     }
 }

--- a/src/MigrationTools.Clients.FileSystem.Tests/Endpoints/FileSystemWorkItemEndpointTests.cs
+++ b/src/MigrationTools.Clients.FileSystem.Tests/Endpoints/FileSystemWorkItemEndpointTests.cs
@@ -1,16 +1,14 @@
-﻿using System.Xml.Linq;
+﻿using System;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using MigrationTools.DataContracts;
 using MigrationTools.EndpointEnrichers;
 using MigrationTools.Enrichers;
-using MigrationTools.Tests;
+using MigrationTools.Shadows;
 using MigrationTools.Tools;
 using MigrationTools.Tools.Interfaces;
 using MigrationTools.Tools.Shadows;
-using MigrationTools.Shadows;
-using System;
 
 namespace MigrationTools.Endpoints.Tests
 {
@@ -49,7 +47,7 @@ namespace MigrationTools.Endpoints.Tests
             CleanAndAdd(e1, 10);
             FileSystemWorkItemEndpoint e2 = (FileSystemWorkItemEndpoint)Services.GetKeyedService<IEndpoint>("Target");
             CleanAndAdd(e2, 10);
-            
+
             e1.Filter(e2.GetWorkItems());
             Assert.AreEqual(0, e1.Count);
         }
@@ -60,7 +58,7 @@ namespace MigrationTools.Endpoints.Tests
             FileSystemWorkItemEndpoint e1 = (FileSystemWorkItemEndpoint)Services.GetKeyedService<IEndpoint>("Source");
             CleanAndAdd(e1, 20);
             FileSystemWorkItemEndpoint e2 = (FileSystemWorkItemEndpoint)Services.GetKeyedService<IEndpoint>("Target");
-            CleanAndAdd(e2, 10);            
+            CleanAndAdd(e2, 10);
             e1.Filter(e2.GetWorkItems());
             Assert.AreEqual(10, e1.Count);
         }
@@ -72,7 +70,7 @@ namespace MigrationTools.Endpoints.Tests
             CleanAndAdd(e1, 20);
             FileSystemWorkItemEndpoint e2 = (FileSystemWorkItemEndpoint)Services.GetKeyedService<IEndpoint>("Target");
             CleanAndAdd(e2, 10);
-            
+
             foreach (WorkItemData item in e1.GetWorkItems())
             {
                 e2.PersistWorkItem(item);
@@ -118,6 +116,7 @@ namespace MigrationTools.Endpoints.Tests
             services.AddSingleton<CommonTools>();
             services.AddSingleton<IFieldMappingTool, MockFieldMappingTool>();
             services.AddSingleton<IWorkItemTypeMappingTool, MockWorkItemTypeMappingTool>();
+            services.AddSingleton<IFieldReferenceNameMappingTool, MockFieldReferenceNameMappingTool>();
             services.AddSingleton<IStringManipulatorTool, StringManipulatorTool>();
 
             services.AddKeyedSingleton(typeof(IEndpoint), "Source", (sp, key) =>

--- a/src/MigrationTools.Clients.TfsObjectModel.Tests/Endpoints/TfsWorkItemEndPointTests.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel.Tests/Endpoints/TfsWorkItemEndPointTests.cs
@@ -1,24 +1,23 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using System.Text;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using MigrationTools.Clients;
 using MigrationTools.DataContracts;
 using MigrationTools.EndpointEnrichers;
+using MigrationTools.Endpoints.Infrastructure;
 using MigrationTools.Enrichers;
 using MigrationTools.Options;
-using MigrationTools.Processors;
+using MigrationTools.Shadows;
 using MigrationTools.Tests;
 using MigrationTools.Tools;
 using MigrationTools.Tools.Interfaces;
 using MigrationTools.Tools.Shadows;
-using MigrationTools.Shadows;
-using Microsoft.Extensions.Configuration;
-using System.IO;
-using System.Text;
-using MigrationTools.Endpoints.Infrastructure;
 
 namespace MigrationTools.Endpoints.Tests
 {
@@ -72,6 +71,7 @@ namespace MigrationTools.Endpoints.Tests
             services.AddSingleton<CommonTools>();
             services.AddSingleton<IFieldMappingTool, MockFieldMappingTool>();
             services.AddSingleton<IWorkItemTypeMappingTool, MockWorkItemTypeMappingTool>();
+            services.AddSingleton<IFieldReferenceNameMappingTool, MockFieldReferenceNameMappingTool>();
             services.AddSingleton<IStringManipulatorTool, StringManipulatorTool>();
             services.AddSingleton<IWorkItemQueryBuilderFactory, WorkItemQueryBuilderFactory>();
             services.AddSingleton<IWorkItemQueryBuilder, WorkItemQueryBuilder>();
@@ -81,7 +81,7 @@ namespace MigrationTools.Endpoints.Tests
             {
                 IOptions<TfsWorkItemEndpointOptions> wrappedOptions = Microsoft.Extensions.Options.Options.Create(new TfsWorkItemEndpointOptions()
                 {
-                    Collection = options != null? options.Collection : new Uri("https://dev.azure.com/nkdagility-preview/"),
+                    Collection = options != null ? options.Collection : new Uri("https://dev.azure.com/nkdagility-preview/"),
                     Project = options != null ? options.Project : "migrationSource1",
                     Authentication = new TfsAuthenticationOptions()
                     {
@@ -100,7 +100,7 @@ namespace MigrationTools.Endpoints.Tests
                 });
                 return ActivatorUtilities.CreateInstance(sp, typeof(TfsWorkItemEndpoint), wrappedOptions);
             });
-           
+
             return (TfsWorkItemEndpoint)services.BuildServiceProvider().GetRequiredKeyedService<IEndpoint>(key);
         }
 
@@ -175,7 +175,7 @@ namespace MigrationTools.Endpoints.Tests
                       ""IterationPath"": ""Iteration""
                     }
                   }
-                },  
+                },
               }
             }";
             var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));

--- a/src/MigrationTools.Clients.TfsObjectModel.Tests/Processors/TfsProcessorTests.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel.Tests/Processors/TfsProcessorTests.cs
@@ -1,22 +1,19 @@
-﻿using Microsoft.Extensions.DependencyInjection;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using MigrationTools.Tests;
-using MigrationTools.Processors.Infrastructure;
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
-using MigrationTools.Enrichers;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MigrationTools.Clients;
 using MigrationTools.EndpointEnrichers;
+using MigrationTools.Endpoints;
+using MigrationTools.Endpoints.Infrastructure;
+using MigrationTools.Enrichers;
+using MigrationTools.Shadows;
+using MigrationTools.Tests;
 using MigrationTools.Tools;
 using MigrationTools.Tools.Interfaces;
 using MigrationTools.Tools.Shadows;
-using MigrationTools.Shadows;
-using MigrationTools.Endpoints;
-using MigrationTools.Clients;
-using MigrationTools.Endpoints.Infrastructure;
-using System;
-using System.Collections.Generic;
-using System.Xml.Linq;
-using Microsoft.VisualStudio.Services.Commerce;
-using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace MigrationTools.Processors.Tests
 {
@@ -41,6 +38,7 @@ namespace MigrationTools.Processors.Tests
             services.AddSingleton<CommonTools>();
             services.AddSingleton<IFieldMappingTool, MockFieldMappingTool>();
             services.AddSingleton<IWorkItemTypeMappingTool, MockWorkItemTypeMappingTool>();
+            services.AddSingleton<IFieldReferenceNameMappingTool, MockFieldReferenceNameMappingTool>();
             services.AddSingleton<IStringManipulatorTool, StringManipulatorTool>();
             services.AddSingleton<IWorkItemQueryBuilderFactory, WorkItemQueryBuilderFactory>();
             services.AddSingleton<IWorkItemQueryBuilder, WorkItemQueryBuilder>();
@@ -60,7 +58,7 @@ namespace MigrationTools.Processors.Tests
                     },
                     ReflectedWorkItemIdField = "Custom.ReflectedWorkItemId",
                 });
-               return ActivatorUtilities.CreateInstance(sp, typeof(TfsTeamSettingsEndpoint), options);
+                return ActivatorUtilities.CreateInstance(sp, typeof(TfsTeamSettingsEndpoint), options);
             });
             services.AddKeyedSingleton(typeof(IEndpoint), TargetName, (sp, key) =>
             {
@@ -110,6 +108,7 @@ namespace MigrationTools.Processors.Tests
             services.AddSingleton<CommonTools>();
             services.AddSingleton<IFieldMappingTool, MockFieldMappingTool>();
             services.AddSingleton<IWorkItemTypeMappingTool, MockWorkItemTypeMappingTool>();
+            services.AddSingleton<IFieldReferenceNameMappingTool, MockFieldReferenceNameMappingTool>();
             services.AddSingleton<IStringManipulatorTool, StringManipulatorTool>();
             services.TryAddScoped<IWorkItemQueryBuilderFactory, WorkItemQueryBuilderFactory>();
 
@@ -168,7 +167,7 @@ namespace MigrationTools.Processors.Tests
                 o.Enrichers = options != null ? options.Enrichers : null;
                 o.RefName = options != null ? options.RefName : null;
                 /// Add custom
-                o.SourceToTargetFieldMappings = options != null ? options.SourceToTargetFieldMappings : new System.Collections.Generic.Dictionary<string, string> { {"sourceFieldA", "targetFieldB" } };
+                o.SourceToTargetFieldMappings = options != null ? options.SourceToTargetFieldMappings : new System.Collections.Generic.Dictionary<string, string> { { "sourceFieldA", "targetFieldB" } };
                 o.PrefixProjectToNodes = options != null ? options.PrefixProjectToNodes : false;
                 o.SharedFolderName = options != null ? options.SharedFolderName : "Shared Queries";
             }));

--- a/src/MigrationTools.Clients.TfsObjectModel/Processors/TfsWorkItemMigrationProcessorOptions.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/Processors/TfsWorkItemMigrationProcessorOptions.cs
@@ -1,12 +1,7 @@
 ﻿using System.Collections.Generic;
-using MigrationTools.Enrichers;
-using MigrationTools.Processors;
+using System.ComponentModel.DataAnnotations;
 using MigrationTools._EngineV1.Configuration;
 using MigrationTools.Processors.Infrastructure;
-using System.ComponentModel.DataAnnotations;
-using Microsoft.Extensions.Options;
-using System.Text.RegularExpressions;
-using System.DirectoryServices.AccountManagement;
 using Newtonsoft.Json;
 
 namespace MigrationTools.Processors
@@ -16,8 +11,6 @@ namespace MigrationTools.Processors
     /// </summary>
     public class TfsWorkItemMigrationProcessorOptions : ProcessorOptions, IWorkItemProcessorConfig
     {
-
-
         /// <summary>
         /// If this is enabled the creation process on the target project will create the items with the original creation date.
         /// (Important: The item history is always pointed to the date of the migration, it's change only the data column CreateDate,
@@ -35,7 +28,6 @@ namespace MigrationTools.Processors
         /// <default>true</default>
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public bool UpdateCreatedBy { get; set; } = true;
-
 
         /// <summary>
         /// A work item query based on WIQL to select only important work items. To migrate all leave this empty. See [WIQL Query Bits](#wiql-query-bits)
@@ -115,7 +107,20 @@ namespace MigrationTools.Processors
         /// </summary>
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public bool SkipRevisionWithInvalidAreaPath { get; set; } = false;
-    }
 
- 
+        /// <summary>
+        /// Validates if all fields in source work item exist in the target work item type.
+        /// </summary>
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public bool ValidateWorkItemFields { get; set; } = false;
+
+        /// <summary>
+        /// Used when validating work item fields (<see cref="ValidateWorkItemFields"/> is <see langword="true"/>).
+        /// If set to <see langword="true"/>, the migration will continue even if some fields in the source work item
+        /// do not exist in the target work item type. If set to <see langword="false"/>, the migration will stop with
+        /// error in this case. Default value is <see langword="false"/>.
+        /// </summary>
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public bool ContinueIfMissingFieldsInTarget { get; set; } = false;
+    }
 }

--- a/src/MigrationTools.Clients.TfsObjectModel/Tools/TfsStaticTools.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/Tools/TfsStaticTools.cs
@@ -1,11 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
-using MigrationTools.Tools.Interfaces;
+﻿using MigrationTools.Tools.Interfaces;
 
 namespace MigrationTools.Tools
 {
@@ -29,22 +22,24 @@ namespace MigrationTools.Tools
         /// <param name="TfsGitRepositoryTool">Tool for git repository operations</param>
         /// <param name="StringManipulatorTool">Tool for string field manipulation</param>
         /// <param name="workItemTypeMapping">Tool for work item type mapping</param>
+        /// <param name="fieldReferenceNameMappingTool">Tool for work item fields mapping</param>
         /// <param name="fieldMappingTool">Tool for field mapping operations</param>
         public TfsCommonTools(
             TfsUserMappingTool userMappingEnricher,
-                                        TfsAttachmentTool attachmentEnricher,
-                                        TfsNodeStructureTool nodeStructureEnricher,
-                                        TfsRevisionManagerTool revisionManager,
-                                        TfsWorkItemLinkTool workItemLinkEnricher,
-                                        TfsWorkItemEmbededLinkTool workItemEmbeddedLinkEnricher,
-                                        TfsValidateRequiredFieldTool requiredFieldValidator,
-                                        TfsTeamSettingsTool teamSettingsEnricher,
-                                        TfsEmbededImagesTool embededImagesEnricher,
-                                        TfsGitRepositoryTool TfsGitRepositoryTool,
-                                        IStringManipulatorTool StringManipulatorTool,
-                                        IWorkItemTypeMappingTool workItemTypeMapping,
-                                        IFieldMappingTool fieldMappingTool
-            ) : base(StringManipulatorTool, workItemTypeMapping, fieldMappingTool)
+            TfsAttachmentTool attachmentEnricher,
+            TfsNodeStructureTool nodeStructureEnricher,
+            TfsRevisionManagerTool revisionManager,
+            TfsWorkItemLinkTool workItemLinkEnricher,
+            TfsWorkItemEmbededLinkTool workItemEmbeddedLinkEnricher,
+            TfsValidateRequiredFieldTool requiredFieldValidator,
+            TfsTeamSettingsTool teamSettingsEnricher,
+            TfsEmbededImagesTool embededImagesEnricher,
+            TfsGitRepositoryTool TfsGitRepositoryTool,
+            IStringManipulatorTool StringManipulatorTool,
+            IWorkItemTypeMappingTool workItemTypeMapping,
+            IFieldReferenceNameMappingTool fieldReferenceNameMappingTool,
+            IFieldMappingTool fieldMappingTool
+            ) : base(StringManipulatorTool, workItemTypeMapping, fieldReferenceNameMappingTool, fieldMappingTool)
         {
             UserMapping = userMappingEnricher;
             Attachment = attachmentEnricher;

--- a/src/MigrationTools.Shadows/Tools/MockFieldReferenceNameMappingTool.cs
+++ b/src/MigrationTools.Shadows/Tools/MockFieldReferenceNameMappingTool.cs
@@ -1,0 +1,13 @@
+﻿using MigrationTools.Tools.Interfaces;
+
+namespace MigrationTools.Tools.Shadows
+{
+    public class MockFieldReferenceNameMappingTool : IFieldReferenceNameMappingTool
+    {
+        public string? GetTargetFieldName(string workItemType, string sourceFieldName, out bool isMapped)
+        {
+            isMapped = false;
+            return sourceFieldName;
+        }
+    }
+}

--- a/src/MigrationTools.Tests/Tools/FieldReferenceNameMappingToolOptionsTests.cs
+++ b/src/MigrationTools.Tests/Tools/FieldReferenceNameMappingToolOptionsTests.cs
@@ -1,0 +1,131 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MigrationTools.Tools;
+
+namespace MigrationTools.Tests.Tools
+{
+    [TestClass]
+    public class FieldReferenceNameMappingToolOptionsTests
+    {
+        [TestMethod]
+        public void MappingsMustNotBeNullWhenNormalized()
+        {
+            FieldReferenceNameMappingToolOptions options = new() { Enabled = true };
+            options.Mappings = null;
+
+            FieldReferenceNameMappingToolOptions normalized = options.Normalize();
+            Assert.IsNotNull(normalized.Mappings);
+        }
+
+        [TestMethod]
+        public void ShouldReturnSourceValueWhenNotEnabled()
+        {
+            FieldReferenceNameMappingToolOptions options = new()
+            {
+                Enabled = false,
+                Mappings = new()
+                {
+                    ["wit"] = new()
+                    {
+                        ["source"] = "target"
+                    }
+                }
+            };
+            FieldReferenceNameMappingToolOptions normalized = options.Normalize();
+
+            Assert.AreEqual("source", normalized.GetTargetFieldName("wit", "source", out bool _));
+        }
+
+        [TestMethod]
+        public void ShouldLookupValueCaseInsensitively()
+        {
+            FieldReferenceNameMappingToolOptions options = new()
+            {
+                Enabled = true,
+                Mappings = new()
+                {
+                    ["wit"] = new()
+                    {
+                        ["source"] = "target"
+                    }
+                }
+            };
+            FieldReferenceNameMappingToolOptions normalized = options.Normalize();
+
+            Assert.AreEqual("target", normalized.GetTargetFieldName("wit", "source", out bool _));
+            Assert.AreEqual("target", normalized.GetTargetFieldName("WIT", "source", out bool _));
+            Assert.AreEqual("target", normalized.GetTargetFieldName("wit", "SOURCE", out bool _));
+            Assert.AreEqual("target", normalized.GetTargetFieldName("WIT", "SOURCE", out bool _));
+        }
+
+        [TestMethod]
+        public void ShouldReturnSourceValueIfNotMapped()
+        {
+            FieldReferenceNameMappingToolOptions options = new()
+            {
+                Enabled = true,
+                Mappings = new()
+                {
+                    ["wit"] = new()
+                    {
+                        ["source"] = "target"
+                    }
+                }
+            };
+            FieldReferenceNameMappingToolOptions normalized = options.Normalize();
+
+            Assert.AreEqual("not-mapped-source", normalized.GetTargetFieldName("wit", "not-mapped-source", out bool _));
+            Assert.AreEqual("source", normalized.GetTargetFieldName("not-mapped-wit", "source", out bool _));
+        }
+
+        [TestMethod]
+        public void ShouldReturnEmptyStringIfMappedToEmptyString()
+        {
+            FieldReferenceNameMappingToolOptions options = new()
+            {
+                Enabled = true,
+                Mappings = new()
+                {
+                    ["wit"] = new()
+                    {
+                        ["source"] = "target",
+                        ["source-null"] = ""
+                    }
+                }
+            };
+
+            FieldReferenceNameMappingToolOptions normalized = options.Normalize();
+
+            Assert.AreEqual("target", normalized.GetTargetFieldName("wit", "source", out bool _));
+            Assert.IsEmpty(normalized.GetTargetFieldName("wit", "source-null", out bool _));
+        }
+
+        [TestMethod]
+        public void ShouldHandleAllWorkItemTypes()
+        {
+            FieldReferenceNameMappingToolOptions options = new()
+            {
+                Enabled = true,
+                Mappings = new()
+                {
+                    [FieldReferenceNameMappingToolOptions.AllWorkItemTypes] = new()
+                    {
+                        ["source-all"] = "target-all"
+                    },
+                    ["wit"] = new()
+                    {
+                        ["source"] = "target"
+                    },
+                    ["wit2"] = new()
+                    {
+                        ["source-all"] = "target-wit2"
+                    }
+                }
+            };
+            FieldReferenceNameMappingToolOptions normalized = options.Normalize();
+
+            Assert.AreEqual("target-wit2", normalized.GetTargetFieldName("wit2", "source-all", out bool _));
+            Assert.AreEqual("target-all", normalized.GetTargetFieldName("wit", "source-all", out bool _));
+            Assert.AreEqual("target-all", normalized.GetTargetFieldName("not-mapped-wit", "source-all", out bool _));
+        }
+    }
+}

--- a/src/MigrationTools/ServiceCollectionExtensions.cs
+++ b/src/MigrationTools/ServiceCollectionExtensions.cs
@@ -1,26 +1,19 @@
 ﻿using System;
-using System.Configuration;
-using System.Linq;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
-using MigrationTools._EngineV1.Containers;
 using MigrationTools.EndpointEnrichers;
-using MigrationTools.Endpoints;
 using MigrationTools.Enrichers;
 using MigrationTools.Options;
 using MigrationTools.Processors;
 using MigrationTools.Processors.Infrastructure;
-using MigrationTools.Services;
 using MigrationTools.Tools;
 using MigrationTools.Tools.Interfaces;
-using Serilog;
 
 namespace MigrationTools
 {
     public static partial class ServiceCollectionExtensions
     {
-
         public static OptionsBuilder<TOptions> AddMigrationToolsOptions<TOptions>(this IServiceCollection services, IConfiguration configuration) where TOptions : class
         {
             IOptions options = (IOptions)Activator.CreateInstance<TOptions>();
@@ -31,7 +24,7 @@ namespace MigrationTools
         {
             IOptions options = (IOptions)Activator.CreateInstance<TOptions>();
             services.AddSingleton<IValidateOptions<TOptions>, TOptionsValidator>();
-           return services.AddOptions<TOptions>().Bind(configuration.GetSection(options.ConfigurationMetadata.PathToInstance));
+            return services.AddOptions<TOptions>().Bind(configuration.GetSection(options.ConfigurationMetadata.PathToInstance));
         }
 
         public static void AddMigrationToolServices(this IServiceCollection context, IConfiguration configuration, string configFile = "configuration.json")
@@ -39,9 +32,6 @@ namespace MigrationTools
             // Infra
             context.AddSingleton<OptionsConfigurationBuilder>();
             context.AddSingleton<OptionsConfigurationUpgrader>();
-
-
-            
 
             context.AddConfiguredEndpoints(configuration);
             //Containers
@@ -54,9 +44,11 @@ namespace MigrationTools
             //context.AddTransient<FilterWorkItemsThatAlreadyExistInTarget>();
             //context.AddTransient<SkipToFinalRevisedWorkItemType>();
 
-                    context.AddSingleton<IStringManipulatorTool, StringManipulatorTool>().AddMigrationToolsOptions<StringManipulatorToolOptions>(configuration);
-                    context.AddSingleton<IWorkItemTypeMappingTool, WorkItemTypeMappingTool>().AddMigrationToolsOptions<WorkItemTypeMappingToolOptions>(configuration);
-                   // context.AddSingleton<GitRepoMappingTool>().AddMigrationToolsOptions<GitRepoMappingToolOptions>(configuration);
+            context.AddSingleton<IStringManipulatorTool, StringManipulatorTool>().AddMigrationToolsOptions<StringManipulatorToolOptions>(configuration);
+            context.AddSingleton<IWorkItemTypeMappingTool, WorkItemTypeMappingTool>().AddMigrationToolsOptions<WorkItemTypeMappingToolOptions>(configuration);
+            context.AddSingleton<IFieldReferenceNameMappingTool, FieldReferenceNameMappingTool>().AddMigrationToolsOptions<FieldReferenceNameMappingToolOptions>(configuration);
+
+            // context.AddSingleton<GitRepoMappingTool>().AddMigrationToolsOptions<GitRepoMappingToolOptions>(configuration);
 
             context.AddSingleton<ProcessorContainer>()
                 .AddSingleton<IConfigureOptions<ProcessorContainerOptions>, ProcessorContainerOptions.ConfigureOptions>()
@@ -65,11 +57,9 @@ namespace MigrationTools
             //    return new WritableOptions<ProcessorContainerOptions>(sp.GetRequiredService<IOptionsMonitor<ProcessorContainerOptions>>(),ProcessorContainerOptions.ConfigurationSectionName, configFile);
             //});
 
-
             context.AddSingleton<IFieldMappingTool, FieldMappingTool>().AddSingleton<IConfigureOptions<FieldMappingToolOptions>, FieldMappingToolOptions.ConfigureOptions>();
             context.AddSingleton<VersionOptions>().AddSingleton<IConfigureOptions<VersionOptions>, VersionOptions.ConfigureOptions>();
             context.AddSingleton<CommonTools>();
-
 
             //context.AddTransient<WorkItemAttachmentEnricher>();
             //context.AddTransient<WorkItemCreatedEnricher>();
@@ -78,8 +68,6 @@ namespace MigrationTools
             //context.AddTransient<WorkItemLinkEnricher>();
             // processor Enrichers
             context.AddTransient<PauseAfterEachItem>();
-
-            
         }
 
         [Obsolete("This is the v1 Archtiecture, we are movign to V2", false)]

--- a/src/MigrationTools/Tools/FieldReferenceNameMappingTool.cs
+++ b/src/MigrationTools/Tools/FieldReferenceNameMappingTool.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using MigrationTools.Tools.Infrastructure;
+using MigrationTools.Tools.Interfaces;
+
+namespace MigrationTools.Tools
+{
+    /// <summary>
+    /// Tool for mapping fields from source to target. This tool is for just checking if all fields in source really
+    /// exists in target. It does not perform any copying or transformation of field values´between source and target.
+    /// To work with values, use <see cref="FieldMappingTool"/>.
+    /// </summary>
+    public class FieldReferenceNameMappingTool : Tool<FieldReferenceNameMappingToolOptions>, IFieldReferenceNameMappingTool
+    {
+        public FieldReferenceNameMappingTool(
+            IOptions<FieldReferenceNameMappingToolOptions> options,
+            IServiceProvider services,
+            ILogger<ITool>
+            logger,
+            ITelemetryLogger telemetry)
+            : base(new OptionsWrapper<FieldReferenceNameMappingToolOptions>(options.Value.Normalize()),
+                  services, logger, telemetry)
+        {
+        }
+
+        /// <inheritdoc/>
+        public string GetTargetFieldName(string workItemType, string sourceFieldName, out bool isMapped)
+            => Options.GetTargetFieldName(workItemType, sourceFieldName, out isMapped);
+    }
+}

--- a/src/MigrationTools/Tools/FieldReferenceNameMappingToolOptions.cs
+++ b/src/MigrationTools/Tools/FieldReferenceNameMappingToolOptions.cs
@@ -1,0 +1,123 @@
+﻿using System;
+using System.Collections.Generic;
+using MigrationTools.Tools.Infrastructure;
+
+namespace MigrationTools.Tools
+{
+    /// <summary>
+    /// <para>
+    /// Configuration options for the <see cref="FieldReferenceNameMappingTool"/> defining how work item fields
+    /// are mapped between source and target systems. Mapped target value can be empty string to indicate
+    /// that the source field is not mapped to target at all.
+    /// </para>
+    /// <para>
+    /// Field mappings can be defined for specific work item type, or for all work item types by using special work item
+    /// type name <c>*</c> (<see cref="AllWorkItemTypes"/>). If no mapping is defined for the source field, the same value
+    /// is returned as target field. For correct handling all this, use <see cref="GetTargetFieldName(string, string)"/> method.
+    /// </para>
+    /// <para>
+    /// Before use, this options should be normalized using <see cref="Normalize"/> method to ensure that all comparisons
+    /// of work item and field names are case-insensitive.
+    /// </para>
+    /// </summary>
+    public class FieldReferenceNameMappingToolOptions : ToolOptions
+    {
+        /// <summary>
+        /// Special key, meaning this mapping applied to all work item types.
+        /// </summary>
+        public const string AllWorkItemTypes = "*";
+
+        private static readonly StringComparer _normalizedComparer = StringComparer.OrdinalIgnoreCase;
+        private bool _isNormalized = false;
+
+        /// <summary>
+        /// Field reference name mappings. Key is work item type name, value is dictionary of mapping source filed name to
+        /// target field name. Target field name can be empty string to indicate that the source field is not mapped
+        /// to target at all. As work item type name, you can use <see cref="AllWorkItemTypes"/> to define mappings which will
+        /// be applied to all work item types.
+        /// </summary>
+        public Dictionary<string, Dictionary<string, string>> Mappings { get; set; } = [];
+
+        /// <summary>
+        /// Search for mapped target field name for given <paramref name="sourceFieldName"/>. If there is no mapping for source
+        /// field name, its value is returned as target field name.
+        /// Handles also mappings defined for all work item types (<c>*</c>).
+        /// </summary>
+        /// <param name="workItemType">Work item type name.</param>
+        /// <param name="sourceFieldName">Source field reference name.</param>
+        /// <param name="isMapped">Flag if returned value was mapped, or just returned the original.</param>
+        /// <returns>
+        /// Returns:
+        /// <list type="bullet">
+        /// <item>Target field name if it is foung in mappings. This can be empty string, which means that the source
+        /// field is not mapped.</item>
+        /// <item>Source filed name <paramref name="sourceFieldName"/> if there is no mapping defined for this field.</item>
+        /// </list>
+        /// </returns>
+        public string GetTargetFieldName(string workItemType, string sourceFieldName, out bool isMapped)
+        {
+            if (Enabled)
+            {
+                if (TryGetTargetFieldName(workItemType, sourceFieldName, out string targetFieldName))
+                {
+                    isMapped = true;
+                    return targetFieldName;
+                }
+                if (TryGetTargetFieldName(AllWorkItemTypes, sourceFieldName, out targetFieldName))
+                {
+                    isMapped = true;
+                    return targetFieldName;
+                }
+            }
+            isMapped = false;
+            return sourceFieldName;
+        }
+
+        private bool TryGetTargetFieldName(string workItemType, string sourceFieldName, out string targetFieldName)
+        {
+            if (Mappings.TryGetValue(workItemType, out Dictionary<string, string> mappings))
+            {
+                if (mappings.TryGetValue(sourceFieldName, out targetFieldName))
+                {
+                    return true;
+                }
+            }
+            targetFieldName = string.Empty;
+            return false;
+        }
+
+        /// <summary>
+        /// Creates a new instance with the same values as current, just the dictionaries lookups are case-insensitive
+        /// and allk eys and values are trimmed.
+        /// </summary>
+        public FieldReferenceNameMappingToolOptions Normalize()
+        {
+            if (_isNormalized)
+            {
+                return this;
+            }
+
+            FieldReferenceNameMappingToolOptions result = new()
+            {
+                _isNormalized = true,
+                Enabled = Enabled,
+                Mappings = new(_normalizedComparer)
+            };
+
+            if (Mappings is not null)
+            {
+                foreach (KeyValuePair<string, Dictionary<string, string>> mapping in Mappings)
+                {
+                    Dictionary<string, string> normalizedValues = new(_normalizedComparer);
+                    foreach (KeyValuePair<string, string> fieldMapping in mapping.Value)
+                    {
+                        normalizedValues[fieldMapping.Key.Trim()] = fieldMapping.Value.Trim();
+                    }
+                    result.Mappings[mapping.Key.Trim()] = normalizedValues;
+                }
+            }
+
+            return result;
+        }
+    }
+}

--- a/src/MigrationTools/Tools/Interfaces/IFieldReferenceNameMappingTool.cs
+++ b/src/MigrationTools/Tools/Interfaces/IFieldReferenceNameMappingTool.cs
@@ -1,0 +1,28 @@
+﻿namespace MigrationTools.Tools.Interfaces
+{
+    /// <summary>
+    /// Tool for mapping fields from source to target. This tool is for just checking if all fields in source really
+    /// exists in target. It does not perform any copying or transformation of field values´between source and target.
+    /// To work with values, use <see cref="IFieldMappingTool"/>.
+    /// </summary>
+    public interface IFieldReferenceNameMappingTool
+    {
+        /// <summary>
+        /// Search for mapped target field name for given <paramref name="sourceFieldName"/>. If there is no mapping for source
+        /// field name, its value is returned as target field name.
+        /// Handles also mappings defined for all work item types (<c>*</c>).
+        /// </summary>
+        /// <param name="workItemType">Work item type name.</param>
+        /// <param name="sourceFieldName">Source field reference name.</param>
+        /// <param name="isMapped">Flag if returned value was mapped, or just returned the original.</param>
+        /// <returns>
+        /// Returns:
+        /// <list type="bullet">
+        /// <item>Target field name if it is foung in mappings. This can be empty string, which means that the source
+        /// field is not mapped.</item>
+        /// <item>Source filed name <paramref name="sourceFieldName"/> if there is no mapping defined for this field.</item>
+        /// </list>
+        /// </returns>
+        string GetTargetFieldName(string workItemType, string sourceFieldName, out bool isMapped);
+    }
+}

--- a/src/MigrationTools/Tools/StaticTools.cs
+++ b/src/MigrationTools/Tools/StaticTools.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using MigrationTools.Tools.Interfaces;
+﻿using MigrationTools.Tools.Interfaces;
 
 namespace MigrationTools.Tools
 {
@@ -14,27 +11,38 @@ namespace MigrationTools.Tools
         /// Gets the string manipulator tool for processing string fields.
         /// </summary>
         public IStringManipulatorTool StringManipulator { get; private set; }
-        
+
         /// <summary>
         /// Gets the work item type mapping tool for transforming work item types.
         /// </summary>
         public IWorkItemTypeMappingTool WorkItemTypeMapping { get; private set; }
 
         /// <summary>
+        /// Gets the work item fields mapping tool for checking work item types compatibility.
+        /// </summary>
+        public IFieldReferenceNameMappingTool FieldReferenceNameMappingTool { get; private set; }
+
+        /// <summary>
         /// Gets the field mapping tool for applying field transformations.
         /// </summary>
         public IFieldMappingTool FieldMappingTool { get; private set; }
-        
+
         /// <summary>
         /// Initializes a new instance of the CommonTools class.
         /// </summary>
-        /// <param name="StringManipulatorTool">Tool for string field manipulation</param>
-        /// <param name="workItemTypeMapping">Tool for work item type mapping</param>
-        /// <param name="fieldMappingTool">Tool for field mapping operations</param>
-        public CommonTools(IStringManipulatorTool StringManipulatorTool, IWorkItemTypeMappingTool workItemTypeMapping, IFieldMappingTool fieldMappingTool)
+        /// <param name="StringManipulatorTool">Tool for string field manipulation.</param>
+        /// <param name="workItemTypeMapping">Tool for work item type mapping.</param>
+        /// <param name="fieldReferenceNameMappingTool">Tool for work item fields mapping.</param>
+        /// <param name="fieldMappingTool">Tool for field mapping operations.</param>
+        public CommonTools(
+            IStringManipulatorTool StringManipulatorTool,
+            IWorkItemTypeMappingTool workItemTypeMapping,
+            IFieldReferenceNameMappingTool fieldReferenceNameMappingTool,
+            IFieldMappingTool fieldMappingTool)
         {
             StringManipulator = StringManipulatorTool;
             WorkItemTypeMapping = workItemTypeMapping;
+            FieldReferenceNameMappingTool = fieldReferenceNameMappingTool;
             FieldMappingTool = fieldMappingTool;
         }
 


### PR DESCRIPTION
Backlog migration do not validate if all fields in source exists in target. If not, those data will not be migrated. This PR implements such a validation and implements new `FieldReferenceNameMappingTool`. This tool is for configuration of fields in source, that do not exist in target. By configuration, we can:

- Set field mapping that field `A` in source is mapped to `B` in target.
- Set, that field is unnecessary and will not be checked in target. This is by setting field mapping to empty string.

The tool itself must be enabled in `TfsWorkItemMigrationProcessorOptions`. There are two new properties:

- `ValidateWorkItemFields`: Turns on the validation. Default is `false` to not introduce automatic new behavior.
- `ContinueIfMissingFieldsInTarget`: If `true`, migration will continue even if some fields are missing in target (current behavior of migration). Default value is `false`, which means that if there are some missing fields, migration will stop early so user can decide what to do.

## Sample configuration

``` json
{
  "Serilog": {
    "MinimumLevel": "Information"
  },
  "MigrationTools": {
    "Version": "16.0",
    "Processors": [
      {
        "ProcessorType": "TfsWorkItemMigrationProcessor",
        "Enabled": true,
        "UpdateCreatedDate": true,
        "UpdateCreatedBy": true,
        "WIQLQuery": "SELECT [System.Id] FROM WorkItems WHERE [System.TeamProject] = @TeamProject AND [System.WorkItemType] NOT IN ('Code Review Request', 'Code Review Response', 'Test Case', 'Test Suite', 'Test Plan', 'Shared Steps', 'Shared Parameter', 'Feedback Request') ORDER BY [System.ChangedDate] desc",
        "FixHtmlAttachmentLinks": true,
        "WorkItemCreateRetryLimit": 5,
        "FilterWorkItemsThatAlreadyExistInTarget": false,
        "GenerateMigrationComment": false,
        "SourceName": "Source",
        "TargetName": "Target",
        "ValidateWorkItemFields": true,
        "ContinueIfMissingFieldsInTarget": false
      }
    ],
    "CommonTools": {
      "WorkItemTypeMappingTool": {
        "Enabled": true,
        "Mappings": {
          "Product Backlog Item": "User Story"
        }
      },
      "FieldReferenceNameMappingTool": {
        "Enabled": true,
        "Mappings": {
          "User Story": {
            "Microsoft.VSTS.Common.Novika": "Custom.Novinka",
            "Microsoft.VSTS.Common.Help": "Custom.Help",
            "Microsoft.VSTS.Common.Planovac": "",
            "Microsoft.VSTS.Common.SuperUserStory": "",
            "Microsoft.VSTS.Scheduling.Effort": "",
            "Microsoft.VSTS.Common.BacklogPriority": "",

            "Microsoft.VSTS.Common.BusinessValue": "",
            "Microsoft.VSTS.Common.RoughOrderOfMagnitude": "",
            "Microsoft.VSTS.Common.ExitCriteria": "",
            "Microsoft.VSTS.Common.Rank": "",
            "Microsoft.VSTS.Common.Issue": ""
          }
        }
      }
    }
  }
}
```

## Sample log output

```
[14:49:15 INF] [16.2.10-Local.4-7-g41825258] Validating::Check that all fields in source work items exists in target work items.
Initializing expensive ProjectData from WorkItemStore...
[14:49:15 INF] [16.2.10-Local.4-7-g41825258] Validating fields of 6 work item types in the full source history: Bug, Task, User Story, Epic, Feature, Product Backlog Item.
[14:49:15 INF] [16.2.10-Local.4-7-g41825258] Available target work item types are: Bug, Code Review Request, Code Review Response, Epic, Feature, Feedback Request, Feedback Response, Shared Steps, Task, Test Case, Test Plan, Test Suite, User Story, Issue, Shared Parameter.
[14:49:15 INF] [16.2.10-Local.4-7-g41825258] Validating fields of work item type 'Product Backlog Item'
[14:49:15 INF] [16.2.10-Local.4-7-g41825258]   This work item type is mapped to 'User Story' in target.
[14:49:15 INF] [16.2.10-Local.4-7-g41825258]   Source field 'Microsoft.VSTS.Common.Novika' is mapped as 'Custom.Novinka' in target.
[14:49:15 WRN] [16.2.10-Local.4-7-g41825258]   Missing field 'Microsoft.VSTS.Common.Prirucka'
[14:49:15 INF] [16.2.10-Local.4-7-g41825258]     Name: Microsoft.VSTS.Common.Prirucka
[14:49:15 INF] [16.2.10-Local.4-7-g41825258]     Field type: String
[14:49:15 INF] [16.2.10-Local.4-7-g41825258]     Allowed values:
[14:49:15 WRN] [16.2.10-Local.4-7-g41825258]   Missing field 'Microsoft.VSTS.Common.StavHelpu'
[14:49:15 INF] [16.2.10-Local.4-7-g41825258]     Name: Microsoft.VSTS.Common.StavHelpu
[14:49:15 INF] [16.2.10-Local.4-7-g41825258]     Field type: String
[14:49:15 INF] [16.2.10-Local.4-7-g41825258]     Allowed values: '0-Nezačaté', '1-Rozrobené', '2-Dokončené'
[14:49:15 INF] [16.2.10-Local.4-7-g41825258]   Source field 'Microsoft.VSTS.Common.Help' is mapped as 'Custom.Help' in target.
[14:49:15 INF] [16.2.10-Local.4-7-g41825258]   Source field 'Microsoft.VSTS.Common.SuperUserStory' is explicitly mapped as empty string, so it is not checked in target.
[14:49:15 INF] [16.2.10-Local.4-7-g41825258]   Source field 'Microsoft.VSTS.Common.Planovac' is explicitly mapped as empty string, so it is not checked in target.
[14:49:15 INF] [16.2.10-Local.4-7-g41825258]   Source field 'Microsoft.VSTS.Common.BusinessValue' is explicitly mapped as empty string, so it is not checked in target.
[14:49:15 INF] [16.2.10-Local.4-7-g41825258]   Source field 'Microsoft.VSTS.Scheduling.Effort' is explicitly mapped as empty string, so it is not checked in target.
[14:49:15 INF] [16.2.10-Local.4-7-g41825258]   Source field 'Microsoft.VSTS.Common.BacklogPriority' is explicitly mapped as empty string, so it is not checked in target.
[14:49:15 ERR] [16.2.10-Local.4-7-g41825258] Some fields are not present in the target system (see previous logs). If the migration will continue, you will not have all information in work items in target system. Either add these fields into target work items, or map source fields to other target fields using 'FieldReferenceNameMappingTool'.
[14:49:15 INF] [16.2.10-Local.4-7-g41825258] 'ContinueIfMissingFieldsInTarget' is set to 'false' so migration process will stop now.
```