### PR TITLE
Add exclusions for work item types in validation

### DIFF
--- a/appsettings.json
+++ b/appsettings.json
@@ -1,524 +1,529 @@
 {
-  "Serilog": {
-    "Using": [
-      "Serilog.Sinks.Console"
-    ],
-    "MinimumLevel": {
-      "Default": "Information",
-      "Override": {
-        "Microsoft": "Warning",
-        "Microsoft.Hosting.Lifetime": "Verbose"
-      }
-    }
-  },
-  "MigrationTools": {
-    "EndpointDefaults": {
-      "TfsEndpoint": {
-        "Collection": "",
-        "Project": "",
-        "AllowCrossProjectLinking": false,
-        "ReflectedWorkItemIdField": "Custom.ReflectedWorkItemId",
-        "Authentication": {
-          "AuthenticationMode": "AccessToken",
-          "AccessToken": "",
-          "NetworkCredentials": {
-            "UserName": "",
-            "Password": "",
-            "Domain": ""
-          }
-        },
-        "AuthenticationMode": "AccessToken",
-        "LanguageMaps": {
-          "AreaPath": "Area",
-          "IterationPath": "Iteration"
-        }
-      },
-      "TfsTeamProjectEndpoint": {
-        "Collection": "",
-        "Project": "",
-        "AllowCrossProjectLinking": false,
-        "ReflectedWorkItemIdField": "Custom.ReflectedWorkItemId",
-        "Authentication": {
-          "AuthenticationMode": "AccessToken",
-          "AccessToken": "",
-          "NetworkCredentials": {
-            "UserName": "",
-            "Password": "",
-            "Domain": ""
-          }
-        },
-        "AuthenticationMode": "AccessToken",
-        "LanguageMaps": {
-          "AreaPath": "Area",
-          "IterationPath": "Iteration"
-        }
-      }
-    },
-    "EndpointSamples": {
-      "TfsTeamProjectEndpoint": {
-        "Collection": "https://dev.azure.com/nkdagility-preview/",
-        "Project": "migrationSource1",
-        "AllowCrossProjectLinking": false,
-        "ReflectedWorkItemIdField": "Custom.ReflectedWorkItemId",
-        "Authentication": {
-          "AuthenticationMode": "AccessToken",
-          "AccessToken": "jklsadhjksahfkjsdhjksahsadjhksadhsad",
-          "NetworkCredentials": {
-            "UserName": "",
-            "Password": "",
-            "Domain": ""
-          }
-        }
-      },
-      "TfsEndpoint": {
-        "Collection": "https://dev.azure.com/nkdagility-preview/",
-        "Project": "migrationSource1",
-        "AllowCrossProjectLinking": false,
-        "ReflectedWorkItemIdField": "Custom.ReflectedWorkItemId",
-        "Authentication": {
-          "AuthenticationMode": "AccessToken",
-          "AccessToken": "jklsadhjksahfkjsdhjksahsadjhksadhsad",
-          "NetworkCredentials": {
-            "UserName": "",
-            "Password": "",
-            "Domain": ""
-          }
-        },
-        "LanguageMaps": {
-          "AreaPath": "Area",
-          "IterationPath": "Iteration"
-        }
-      },
-      "AzureDevOpsEndpoint": {
-        "AuthenticationMode": "AccessToken",
-        "AccessToken": "jklsadhjksahfkjsdhjksahsadjhksadhsad",
-        "Organisation": "https://dev.azure.com/xxx/",
-        "Project": "myProject",
-        "ReflectedWorkItemIdField": "Custom.ReflectedWorkItemId"
-      }
-    },
-    "CommonTools": {
-      "FieldMappingTool": {
-        "Enabled": false,
-        "FieldMaps": [],
-        "FieldMapDefaults": {
-          "ApplyTo": [ "*" ]
-        }
-      },
-      "TfsChangeSetMappingTool": {
-        "Enabled": false,
-        "File": null
-      },
-      "TfsNodeStructureTool": {
-        "Enabled": true,
-        "Areas": {
-          "Filters": [],
-          "Mappings": []
-        },
-        "Iterations": {
-          "Filters": [],
-          "Mappings": []
-        },
-        "ShouldCreateMissingRevisionPaths": true,
-        "ReplicateAllExistingNodes": true
-      },
-      "TfsTeamSettingsTool": {
-        "Enabled": true,
-        "MigrateTeamSettings": true,
-        "UpdateTeamSettings": true,
-        "MigrateTeamCapacities": true,
-        "Teams": []
-      },
-      "TfsWorkItemLinkTool": {
-        "Enabled": true,
-        "FilterIfLinkCountMatches": true,
-        "SaveAfterEachLinkIsAdded": false
-      },
-      "TfsRevisionManagerTool": {
-        "Enabled": true,
-        "ReplayRevisions": true,
-        "MaxRevisions": 0
-      },
-      "TfsAttachmentTool": {
-        "RefName": "TfsAttachmentTool",
-        "Enabled": true,
-        "ExportBasePath": "c:\\temp\\WorkItemAttachmentExport",
-        "MaxAttachmentSize": 480000000
-      },
-      "StringManipulatorTool": {
-        "Enabled": true,
-        "MaxStringLength": 1000000,
-        "Manipulators": []
-      },
-      "TfsUserMappingTool": {
-        "Enabled": false,
-        "UserMappingFile": "C:\\temp\\userExport.json",
-        "IdentityFieldsToCheck": [
-          "System.AssignedTo",
-          "System.ChangedBy",
-          "System.CreatedBy",
-          "Microsoft.VSTS.Common.ActivatedBy",
-          "Microsoft.VSTS.Common.ResolvedBy",
-          "Microsoft.VSTS.Common.ClosedBy"
-        ]
-      },
-      "WorkItemTypeMappingTool": {
-        "Enabled": false,
-        "Mappings": {
-          "Source Work Item Type Name": "Target Work Item Type Name"
-        }
-      },
-      "TfsWorkItemEmbededLinkTool": {
-        "Enabled": true
-      },
-      "TfsEmbededImagesTool": {
-        "Enabled": true
-      },
-      "TfsGitRepositoryTool": {
-        "Enabled": true,
-        "Mappings": {
-        }
-      }
-    },
-    "CommonToolSamples": {
-      "TfsGitRepositoryTool": {
-        "Enabled": true,
-        "Mappings": {
-          "RepoInSource": "RepoInTarget"
-        }
-      },
-      "FieldMappingTool": {
-        "Enabled": true,
-        "FieldMaps": [
-            {
-                "FieldMapType": "FieldCalculationMap",
-                "ApplyTo": [ "Bug", "Task" ],
-                "expression": "[effort] * [rate]",
-                "parameters": {
-                    "effort": "Custom.EstimatedHours",
-                    "rate": "Custom.HourlyRate"
-                },
-                "targetField": "Custom.EstimatedCost"
-            },
-            {
-                "FieldMapType": "FieldMergeMap",
-                "ApplyTo": [ "SomeWorkItemType" ],
-                "sourceFields": [ "Custom.FieldA", "Custom.FieldB" ],
-                "targetField": "Custom.FieldC",
-                "formatExpression": "{0} \n {1}"
-            },
-            {
-                "FieldMapType": "FieldValueMap",
-                "ApplyTo": [ "SomeWorkItemType" ],
-                "sourceField": "System.State",
-                "targetField": "System.State",
-                "defaultValue": "New",
-                "valueMapping": {
-                    "Active": "InProgress",
-                    "Resolved": "InProgress",
-                    "Closed": "Done"
-                }
-            },
-            {
-                "FieldMapType": "FieldToFieldMap",
-                "ApplyTo": [ "SomeWorkItemType" ],
-                "sourceField": "Microsoft.VSTS.Common.BacklogPriority",
-                "targetField": "Microsoft.VSTS.Common.StackRank",
-                "defaultValue": 42
-            }
+    "Serilog": {
+        "Using": [
+            "Serilog.Sinks.Console"
         ],
-        "FieldMapSamples": {
-            "FieldCalculationMap": {
-                "FieldMapType": "FieldCalculationMap",
-                "ApplyTo": [ "Bug", "Task" ],
-                "expression": "[effort] * [rate]",
-                "parameters": {
-                    "effort": "Custom.EstimatedHours",
-                    "rate": "Custom.HourlyRate"
+        "MinimumLevel": {
+            "Default": "Information",
+            "Override": {
+                "Microsoft": "Warning",
+                "Microsoft.Hosting.Lifetime": "Verbose"
+            }
+        }
+    },
+    "MigrationTools": {
+        "EndpointDefaults": {
+            "TfsEndpoint": {
+                "Collection": "",
+                "Project": "",
+                "AllowCrossProjectLinking": false,
+                "ReflectedWorkItemIdField": "Custom.ReflectedWorkItemId",
+                "Authentication": {
+                    "AuthenticationMode": "AccessToken",
+                    "AccessToken": "",
+                    "NetworkCredentials": {
+                        "UserName": "",
+                        "Password": "",
+                        "Domain": ""
+                    }
                 },
-                "targetField": "Custom.EstimatedCost"
+                "AuthenticationMode": "AccessToken",
+                "LanguageMaps": {
+                    "AreaPath": "Area",
+                    "IterationPath": "Iteration"
+                }
             },
-            "FieldClearMap": {
-                "ApplyTo": [ "SomeWorkItemType" ],
-                "targetField": "Custom.FieldC"
-            },
-            "FieldMergeMap": {
-                "ApplyTo": [ "SomeWorkItemType" ],
-                "sourceFields": [ "Custom.FieldA", "Custom.FieldB" ],
-                "targetField": "Custom.FieldC",
-                "formatExpression": "{0} \n {1}"
-            },
-            "FieldLiteralMap": {
-                "ApplyTo": [ "SomeWorkItemType" ],
-                "targetField": "Custom.SomeField",
-                "value": "New field value"
-            },
-            "MultiValueConditionalMap": {
-                "ApplyTo": [ "SomeWorkItemType" ],
-                "sourceFieldsAndValues": {
-                    "Field1": "Value1",
-                    "Field2": "Value2"
+            "TfsTeamProjectEndpoint": {
+                "Collection": "",
+                "Project": "",
+                "AllowCrossProjectLinking": false,
+                "ReflectedWorkItemIdField": "Custom.ReflectedWorkItemId",
+                "Authentication": {
+                    "AuthenticationMode": "AccessToken",
+                    "AccessToken": "",
+                    "NetworkCredentials": {
+                        "UserName": "",
+                        "Password": "",
+                        "Domain": ""
+                    }
                 },
-                "targetFieldsAndValues": {
-                    "Field1": "Value1",
-                    "Field2": "Value2"
+                "AuthenticationMode": "AccessToken",
+                "LanguageMaps": {
+                    "AreaPath": "Area",
+                    "IterationPath": "Iteration"
+                }
+            }
+        },
+        "EndpointSamples": {
+            "TfsTeamProjectEndpoint": {
+                "Collection": "https://dev.azure.com/nkdagility-preview/",
+                "Project": "migrationSource1",
+                "AllowCrossProjectLinking": false,
+                "ReflectedWorkItemIdField": "Custom.ReflectedWorkItemId",
+                "Authentication": {
+                    "AuthenticationMode": "AccessToken",
+                    "AccessToken": "jklsadhjksahfkjsdhjksahsadjhksadhsad",
+                    "NetworkCredentials": {
+                        "UserName": "",
+                        "Password": "",
+                        "Domain": ""
+                    }
                 }
             },
-            "targetFieldsAndValues": {
-                "ApplyTo": [ "SomeWorkItemType" ],
-                "targetField": "Custom.ReflectedWorkItemId"
-            },
-            "FieldValueMap": {
-                "ApplyTo": [ "SomeWorkItemType" ],
-                "sourceField": "System.State",
-                "targetField": "System.State",
-                "defaultValue": "StateB",
-                "valueMapping": {
-                    "StateA": "StateB"
+            "TfsEndpoint": {
+                "Collection": "https://dev.azure.com/nkdagility-preview/",
+                "Project": "migrationSource1",
+                "AllowCrossProjectLinking": false,
+                "ReflectedWorkItemIdField": "Custom.ReflectedWorkItemId",
+                "Authentication": {
+                    "AuthenticationMode": "AccessToken",
+                    "AccessToken": "jklsadhjksahfkjsdhjksahsadjhksadhsad",
+                    "NetworkCredentials": {
+                        "UserName": "",
+                        "Password": "",
+                        "Domain": ""
+                    }
+                },
+                "LanguageMaps": {
+                    "AreaPath": "Area",
+                    "IterationPath": "Iteration"
                 }
             },
-            "FieldToFieldMap": {
-                "ApplyTo": [ "SomeWorkItemType" ],
-                "sourceField": "Microsoft.VSTS.Common.BacklogPriority",
-                "targetField": "Microsoft.VSTS.Common.StackRank",
-                "defaultValue": 42
-            },
-            "FieldToFieldMultiMap": {
-                "ApplyTo": [ "SomeWorkItemType", "SomeOtherWorkItemType" ],
-                "SourceToTargetMappings": {
-                    "SourceField1": "TargetField1",
-                    "SourceField2": "TargetField2"
+            "AzureDevOpsEndpoint": {
+                "AuthenticationMode": "AccessToken",
+                "AccessToken": "jklsadhjksahfkjsdhjksahsadjhksadhsad",
+                "Organisation": "https://dev.azure.com/xxx/",
+                "Project": "myProject",
+                "ReflectedWorkItemIdField": "Custom.ReflectedWorkItemId"
+            }
+        },
+        "CommonTools": {
+            "FieldMappingTool": {
+                "Enabled": false,
+                "FieldMaps": [],
+                "FieldMapDefaults": {
+                    "ApplyTo": [ "*" ]
                 }
             },
-            "FieldToTagMap": {
-                "ApplyTo": [ "SomeWorkItemType" ],
-                "sourceField": "System.State",
-                "formatExpression": "ScrumState:{0}"
+            "TfsChangeSetMappingTool": {
+                "Enabled": false,
+                "File": null
             },
-            "FieldToTagFieldMap": {
-                "ApplyTo": [ "SomeWorkItemType" ],
-                "sourceFields": [
-                    "System.Description",
-                    "Microsoft.VSTS.Common.AcceptanceCriteria"
+            "TfsNodeStructureTool": {
+                "Enabled": true,
+                "Areas": {
+                    "Filters": [],
+                    "Mappings": []
+                },
+                "Iterations": {
+                    "Filters": [],
+                    "Mappings": []
+                },
+                "ShouldCreateMissingRevisionPaths": true,
+                "ReplicateAllExistingNodes": true
+            },
+            "TfsTeamSettingsTool": {
+                "Enabled": true,
+                "MigrateTeamSettings": true,
+                "UpdateTeamSettings": true,
+                "MigrateTeamCapacities": true,
+                "Teams": []
+            },
+            "TfsWorkItemLinkTool": {
+                "Enabled": true,
+                "FilterIfLinkCountMatches": true,
+                "SaveAfterEachLinkIsAdded": false
+            },
+            "TfsRevisionManagerTool": {
+                "Enabled": true,
+                "ReplayRevisions": true,
+                "MaxRevisions": 0
+            },
+            "TfsAttachmentTool": {
+                "RefName": "TfsAttachmentTool",
+                "Enabled": true,
+                "ExportBasePath": "c:\\temp\\WorkItemAttachmentExport",
+                "MaxAttachmentSize": 480000000
+            },
+            "StringManipulatorTool": {
+                "Enabled": true,
+                "MaxStringLength": 1000000,
+                "Manipulators": []
+            },
+            "TfsUserMappingTool": {
+                "Enabled": false,
+                "UserMappingFile": "C:\\temp\\userExport.json",
+                "IdentityFieldsToCheck": [
+                    "System.AssignedTo",
+                    "System.ChangedBy",
+                    "System.CreatedBy",
+                    "Microsoft.VSTS.Common.ActivatedBy",
+                    "Microsoft.VSTS.Common.ResolvedBy",
+                    "Microsoft.VSTS.Common.ClosedBy"
+                ]
+            },
+            "WorkItemTypeMappingTool": {
+                "Enabled": false,
+                "Mappings": {
+                    "Source Work Item Type Name": "Target Work Item Type Name"
+                }
+            },
+            "TfsWorkItemEmbededLinkTool": {
+                "Enabled": true
+            },
+            "TfsEmbededImagesTool": {
+                "Enabled": true
+            },
+            "TfsGitRepositoryTool": {
+                "Enabled": true,
+                "Mappings": {
+                }
+            }
+        },
+        "CommonToolSamples": {
+            "TfsGitRepositoryTool": {
+                "Enabled": true,
+                "Mappings": {
+                    "RepoInSource": "RepoInTarget"
+                }
+            },
+            "TfsValidateRequiredFieldTool": {
+                "Enabled": true,
+                "Exclusions": [ "Work Request", "Opertunity", "Assumption" ]
+            },
+            "FieldMappingTool": {
+                "Enabled": true,
+                "FieldMaps": [
+                    {
+                        "FieldMapType": "FieldCalculationMap",
+                        "ApplyTo": [ "Bug", "Task" ],
+                        "expression": "[effort] * [rate]",
+                        "parameters": {
+                            "effort": "Custom.EstimatedHours",
+                            "rate": "Custom.HourlyRate"
+                        },
+                        "targetField": "Custom.EstimatedCost"
+                    },
+                    {
+                        "FieldMapType": "FieldMergeMap",
+                        "ApplyTo": [ "SomeWorkItemType" ],
+                        "sourceFields": [ "Custom.FieldA", "Custom.FieldB" ],
+                        "targetField": "Custom.FieldC",
+                        "formatExpression": "{0} \n {1}"
+                    },
+                    {
+                        "FieldMapType": "FieldValueMap",
+                        "ApplyTo": [ "SomeWorkItemType" ],
+                        "sourceField": "System.State",
+                        "targetField": "System.State",
+                        "defaultValue": "New",
+                        "valueMapping": {
+                            "Active": "InProgress",
+                            "Resolved": "InProgress",
+                            "Closed": "Done"
+                        }
+                    },
+                    {
+                        "FieldMapType": "FieldToFieldMap",
+                        "ApplyTo": [ "SomeWorkItemType" ],
+                        "sourceField": "Microsoft.VSTS.Common.BacklogPriority",
+                        "targetField": "Microsoft.VSTS.Common.StackRank",
+                        "defaultValue": 42
+                    }
                 ],
-                "targetField": "System.Description",
-                "formatExpression": "{0} <br/><br/><h3>Acceptance Criteria</h3>{1}"
+
+                "FieldMapSamples": {
+                    "FieldCalculationMap": {
+                        "FieldMapType": "FieldCalculationMap",
+                        "ApplyTo": [ "Bug", "Task" ],
+                        "expression": "[effort] * [rate]",
+                        "parameters": {
+                            "effort": "Custom.EstimatedHours",
+                            "rate": "Custom.HourlyRate"
+                        },
+                        "targetField": "Custom.EstimatedCost"
+                    },
+                    "FieldClearMap": {
+                        "ApplyTo": [ "SomeWorkItemType" ],
+                        "targetField": "Custom.FieldC"
+                    },
+                    "FieldMergeMap": {
+                        "ApplyTo": [ "SomeWorkItemType" ],
+                        "sourceFields": [ "Custom.FieldA", "Custom.FieldB" ],
+                        "targetField": "Custom.FieldC",
+                        "formatExpression": "{0} \n {1}"
+                    },
+                    "FieldLiteralMap": {
+                        "ApplyTo": [ "SomeWorkItemType" ],
+                        "targetField": "Custom.SomeField",
+                        "value": "New field value"
+                    },
+                    "MultiValueConditionalMap": {
+                        "ApplyTo": [ "SomeWorkItemType" ],
+                        "sourceFieldsAndValues": {
+                            "Field1": "Value1",
+                            "Field2": "Value2"
+                        },
+                        "targetFieldsAndValues": {
+                            "Field1": "Value1",
+                            "Field2": "Value2"
+                        }
+                    },
+                    "targetFieldsAndValues": {
+                        "ApplyTo": [ "SomeWorkItemType" ],
+                        "targetField": "Custom.ReflectedWorkItemId"
+                    },
+                    "FieldValueMap": {
+                        "ApplyTo": [ "SomeWorkItemType" ],
+                        "sourceField": "System.State",
+                        "targetField": "System.State",
+                        "defaultValue": "StateB",
+                        "valueMapping": {
+                            "StateA": "StateB"
+                        }
+                    },
+                    "FieldToFieldMap": {
+                        "ApplyTo": [ "SomeWorkItemType" ],
+                        "sourceField": "Microsoft.VSTS.Common.BacklogPriority",
+                        "targetField": "Microsoft.VSTS.Common.StackRank",
+                        "defaultValue": 42
+                    },
+                    "FieldToFieldMultiMap": {
+                        "ApplyTo": [ "SomeWorkItemType", "SomeOtherWorkItemType" ],
+                        "SourceToTargetMappings": {
+                            "SourceField1": "TargetField1",
+                            "SourceField2": "TargetField2"
+                        }
+                    },
+                    "FieldToTagMap": {
+                        "ApplyTo": [ "SomeWorkItemType" ],
+                        "sourceField": "System.State",
+                        "formatExpression": "ScrumState:{0}"
+                    },
+                    "FieldToTagFieldMap": {
+                        "ApplyTo": [ "SomeWorkItemType" ],
+                        "sourceFields": [
+                            "System.Description",
+                            "Microsoft.VSTS.Common.AcceptanceCriteria"
+                        ],
+                        "targetField": "System.Description",
+                        "formatExpression": "{0} <br/><br/><h3>Acceptance Criteria</h3>{1}"
+                    },
+                    "RegexFieldMap": {
+                        "ApplyTo": [ "SomeWorkItemType" ],
+                        "sourceField": "COMPANY.PRODUCT.Release",
+                        "targetField": "COMPANY.DEVISION.MinorReleaseVersion",
+                        "pattern": "PRODUCT \\d{4}.(\\d{1})",
+                        "replacement": "$1"
+                    },
+                    "FieldValueToTagMap": {
+                        "ApplyTo": [ "SomeWorkItemType" ],
+                        "sourceField": "Microsoft.VSTS.CMMI.Blocked",
+                        "pattern": "Yes",
+                        "formatExpression": "{0}"
+                    },
+                    "TreeToTagMap": {
+                        "ApplyTo": [ "SomeWorkItemType" ],
+                        "toSkip": 3,
+                        "timeTravel": 1
+                    }
+                }
             },
-            "RegexFieldMap": {
-                "ApplyTo": [ "SomeWorkItemType" ],
-                "sourceField": "COMPANY.PRODUCT.Release",
-                "targetField": "COMPANY.DEVISION.MinorReleaseVersion",
-                "pattern": "PRODUCT \\d{4}.(\\d{1})",
-                "replacement": "$1"
+            "TfsChangeSetMappingTool": {
+                "Enabled": true,
+                "File": "c:\\changesetmappings.json"
             },
-            "FieldValueToTagMap": {
-                "ApplyTo": [ "SomeWorkItemType" ],
-                "sourceField": "Microsoft.VSTS.CMMI.Blocked",
-                "pattern": "Yes",
-                "formatExpression": "{0}"
+            "TfsNodeStructureTool": {
+                "Enabled": true,
+                "Areas": {
+                    "Filters": [],
+                    "Mappings": [
+                        {
+                            "Match": "^Skypoint Cloud$",
+                            "Replacement": "MigrationTest5"
+                        }
+                    ]
+                },
+                "Iterations": {
+                    "Filters": [],
+                    "Mappings": [
+                        {
+                            "Match": "^Skypoint Cloud\\\\Sprint 1$",
+                            "Replacement": "MigrationTest5\\Sprint 1"
+                        }
+                    ]
+                },
+                "ShouldCreateMissingRevisionPaths": true,
+                "ReplicateAllExistingNodes": true
             },
-            "TreeToTagMap": {
-                "ApplyTo": [ "SomeWorkItemType" ],
-                "toSkip": 3,
-                "timeTravel": 1
+            "TfsTeamSettingsTool": {
+                "Enabled": true,
+                "MigrateTeamSettings": true,
+                "UpdateTeamSettings": true,
+                "MigrateTeamCapacities": true,
+                "Teams": [ "Team 1", "Team 2" ]
+            },
+            "TfsWorkItemLinkTool": {
+                "Enabled": true,
+                "FilterIfLinkCountMatches": true,
+                "SaveAfterEachLinkIsAdded": false
+            },
+            "TfsRevisionManagerTool": {
+                "Enabled": true,
+                "ReplayRevisions": true,
+                "MaxRevisions": 0
+            },
+            "TfsAttachmentTool": {
+                "RefName": "TfsAttachmentTool",
+                "Enabled": true,
+                "ExportBasePath": "c:\\temp\\WorkItemAttachmentExport",
+                "MaxAttachmentSize": 480000000
+            },
+            "StringManipulatorTool": {
+                "Enabled": true,
+                "MaxStringLength": 1000000,
+                "Manipulators": [
+                    {
+                        "$type": "RegexStringManipulator",
+                        "Enabled": true,
+                        "Pattern": "[^( -~)\n\r\t]+",
+                        "Replacement": "",
+                        "Description": "Remove invalid characters from the end of the string"
+                    }
+                ]
+            },
+            "TfsUserMappingTool": {
+                "Enabled": true,
+                "UserMappingFile": "C:\\temp\\userExport.json",
+                "IdentityFieldsToCheck": [
+                    "System.AssignedTo",
+                    "System.ChangedBy",
+                    "System.CreatedBy",
+                    "Microsoft.VSTS.Common.ActivatedBy",
+                    "Microsoft.VSTS.Common.ResolvedBy",
+                    "Microsoft.VSTS.Common.ClosedBy"
+                ]
+            },
+            "WorkItemTypeMappingTool": {
+                "Enabled": true,
+                "Mappings": {
+                    "User Story": "Product Backlog Item"
+                }
+            },
+            "TfsWorkItemEmbededLinkTool": {
+                "Enabled": true
+            },
+            "TfsEmbededImagesTool": {
+                "Enabled": true
+            }
+        },
+        "ProcessorDefaults": {
+            "AzureDevOpsPipelineProcessor": {
+                "Enabled": false,
+                "MigrateBuildPipelines": true,
+                "MigrateReleasePipelines": true,
+                "MigrateTaskGroups": true,
+                "MigrateVariableGroups": true,
+                "MigrateServiceConnections": true,
+                "BuildPipelines": null,
+                "ReleasePipelines": null,
+                "SourceName": "sourceName",
+                "TargetName": "targetName"
+            },
+            "TfsWorkItemMigrationProcessor": {
+                "Enabled": false,
+                "UpdateCreatedDate": true,
+                "UpdateCreatedBy": true,
+                "WIQLQuery": "SELECT [System.Id] FROM WorkItems WHERE [System.TeamProject] = @TeamProject AND [System.WorkItemType] NOT IN ('Test Suite', 'Test Plan','Shared Steps','Shared Parameter','Feedback Request') ORDER BY [System.ChangedDate] desc",
+                "FixHtmlAttachmentLinks": true,
+                "WorkItemCreateRetryLimit": 5,
+                "FilterWorkItemsThatAlreadyExistInTarget": false,
+                "PauseAfterEachWorkItem": false,
+                "AttachRevisionHistory": false,
+                "GenerateMigrationComment": true,
+                "SourceName": "Source",
+                "TargetName": "Target",
+                "WorkItemIDs": [],
+                "MaxGracefulFailures": 0,
+                "SkipRevisionWithInvalidIterationPath": false,
+                "SkipRevisionWithInvalidAreaPath": false
+            }
+        },
+        "ProcessorSamples": {
+            "AzureDevOpsPipelineProcessor": {
+                "Enabled": false,
+                "MigrateBuildPipelines": true,
+                "MigrateReleasePipelines": true,
+                "MigrateTaskGroups": true,
+                "MigrateVariableGroups": true,
+                "MigrateServiceConnections": true,
+                "BuildPipelines": null,
+                "ReleasePipelines": null,
+                "SourceName": "sourceName",
+                "TargetName": "targetName"
+            },
+            "TfsWorkItemMigrationProcessor": {
+                "Enabled": false,
+                "WIQLQuery": "SELECT [System.Id] FROM WorkItems WHERE [System.TeamProject] = @TeamProject AND [System.WorkItemType] NOT IN ('Test Suite', 'Test Plan','Shared Steps','Shared Parameter','Feedback Request') ORDER BY [System.ChangedDate] desc",
+                "FilterWorkItemsThatAlreadyExistInTarget": false,
+                "SourceName": "Source",
+                "TargetName": "Target"
+            },
+            "ExportUsersForMappingProcessor": {
+                "Enabled": true,
+                "WIQLQuery": "SELECT [System.Id] FROM WorkItems WHERE [System.TeamProject] = @TeamProject AND [System.WorkItemType] NOT IN ('Test Suite', 'Test Plan','Shared Steps','Shared Parameter','Feedback Request') ORDER BY [System.ChangedDate] desc",
+                "OnlyListUsersInWorkItems": true,
+                "SourceName": "Source",
+                "TargetName": "Target"
+            }
+        },
+        "Infrastructure": {
+            "ClassNameChangeMappings": {
+                "TfsGitRepositoryTool": "TfsGitRepositoryTool",
+                "TfsTeamSettingsEnricher": "TfsTeamSettingsTool",
+                "TfsWorkItemLinkEnricher": "TfsWorkItemLinkTool",
+                "TfsAttachmentEnricher": "TfsAttachmentTool",
+                "StringManipulatorEnricher": "StringManipulatorTool",
+                "TfsUserMappingEnricher": "TfsUserMappingTool",
+                "FieldBlankMap": "FieldClearMap",
+                "FieldtoTagMap": "FieldToTagFieldMap",
+                "TreeToTagMap": "TreeToTagFieldMap",
+                "TeamMigration": "TfsTeamSettingsProcessor",
+                "WorkItemQueryMigration": "TfsSharedQueryProcessor",
+                "WorkItemMigration": "TfsWorkItemMigrationProcessor",
+                "WorkItemMigrationContext": "TfsWorkItemMigrationProcessor",
+                "TfsTeamProjectConfig": "TfsTeamProjectEndpoint",
+                "WorkItemGitRepoMappingTool": "TfsGitRepositoryTool",
+                "WorkItemFieldMappingTool": "FieldMappingTool",
+                "CreateTeamFolders": "TfsCreateTeamFoldersProcessor",
+                "ExportProfilePicture": "TfsExportProfilePictureFromADProcessor",
+                "ExportProfilePictureFromAD": "TfsExportProfilePictureFromADProcessor",
+                "ImportProfilePicture": "TfsImportProfilePictureProcessor",
+                "ImportProfilePictureFromAD": "TfsImportProfilePictureProcessor",
+                "ExportUsersForMapping": "TfsExportUsersForMappingProcessor",
+                "ExportUsersForMappingContext": "TfsExportUsersForMappingProcessor",
+                "ExportTeamListProcessor": "TfsExportTeamListProcessor",
+                "ExportTeamList": "TfsExportTeamListProcessor",
+                "ExportUsersForMappingProcessor": "TfsExportUsersForMappingProcessor",
+                "TestConfigurationsMigration": "TfsTestConfigurationsMigrationProcessor",
+                "TestConfigurationsMigrationProcessor": "TfsTestConfigurationsMigrationProcessor",
+                "TestConfigurationsMigrationContext": "TfsTestConfigurationsMigrationProcessor",
+                "TestPlansAndSuitesMigration": "TfsTestPlansAndSuitesMigrationProcessor",
+                "TestPlansAndSuitesMigrationProcessor": "TfsTestPlansAndSuitesMigrationProcessor",
+                "TestPlansAndSuitesMigrationContext": "TfsTestPlansAndSuitesMigrationProcessor",
+                "TestVariablesMigration": "TfsTestVariablesMigrationProcessor",
+                "TestVariablesMigrationProcessor": "TfsTestVariablesMigrationProcessor",
+                "TestVariablesMigrationContext": "TfsTestVariablesMigrationProcessor",
+                "WorkItemBulkEditProcessor": "TfsWorkItemBulkEditProcessor",
+                "WorkItemUpdate": "TfsWorkItemBulkEditProcessor",
+                "WorkItemDelete": "TfsWorkItemDeleteProcessor",
+                "WorkItemDeleteProcessor": "TfsWorkItemDeleteProcessor",
+                "WorkItemPostProcessingContext": "TfsWorkItemOverwriteProcessor",
+                "WorkItemPostProcessing": "TfsWorkItemOverwriteProcessor",
+                "WorkItemPostProcessingProcessor": "TfsWorkItemOverwriteProcessor",
+                "WorkItemUpdateAreasAsTagsContext": "TfsWorkItemOverwriteProcessor",
+                "WorkItemUpdateAreasAsTagsProcessor": "TfsWorkItemOverwriteProcessor"
             }
         }
-      },
-      "TfsChangeSetMappingTool": {
-        "Enabled": true,
-        "File": "c:\\changesetmappings.json"
-      },
-      "TfsNodeStructureTool": {
-        "Enabled": true,
-        "Areas": {
-          "Filters": [],
-          "Mappings": [
-            {
-              "Match": "^Skypoint Cloud$",
-              "Replacement": "MigrationTest5"
-            }
-          ]
-        },
-        "Iterations": {
-          "Filters": [],
-          "Mappings": [
-            {
-              "Match": "^Skypoint Cloud\\\\Sprint 1$",
-              "Replacement": "MigrationTest5\\Sprint 1"
-            }
-          ]
-        },
-        "ShouldCreateMissingRevisionPaths": true,
-        "ReplicateAllExistingNodes": true
-      },
-      "TfsTeamSettingsTool": {
-        "Enabled": true,
-        "MigrateTeamSettings": true,
-        "UpdateTeamSettings": true,
-        "MigrateTeamCapacities": true,
-        "Teams": [ "Team 1", "Team 2" ]
-      },
-      "TfsWorkItemLinkTool": {
-        "Enabled": true,
-        "FilterIfLinkCountMatches": true,
-        "SaveAfterEachLinkIsAdded": false
-      },
-      "TfsRevisionManagerTool": {
-        "Enabled": true,
-        "ReplayRevisions": true,
-        "MaxRevisions": 0
-      },
-      "TfsAttachmentTool": {
-        "RefName": "TfsAttachmentTool",
-        "Enabled": true,
-        "ExportBasePath": "c:\\temp\\WorkItemAttachmentExport",
-        "MaxAttachmentSize": 480000000
-      },
-      "StringManipulatorTool": {
-        "Enabled": true,
-        "MaxStringLength": 1000000,
-        "Manipulators": [
-          {
-            "$type": "RegexStringManipulator",
-            "Enabled": true,
-            "Pattern": "[^( -~)\n\r\t]+",
-            "Replacement": "",
-            "Description": "Remove invalid characters from the end of the string"
-          }
-        ]
-      },
-      "TfsUserMappingTool": {
-        "Enabled": true,
-        "UserMappingFile": "C:\\temp\\userExport.json",
-        "IdentityFieldsToCheck": [
-          "System.AssignedTo",
-          "System.ChangedBy",
-          "System.CreatedBy",
-          "Microsoft.VSTS.Common.ActivatedBy",
-          "Microsoft.VSTS.Common.ResolvedBy",
-          "Microsoft.VSTS.Common.ClosedBy"
-        ]
-      },
-      "WorkItemTypeMappingTool": {
-        "Enabled": true,
-        "Mappings": {
-          "User Story": "Product Backlog Item"
-        }
-      },
-      "TfsWorkItemEmbededLinkTool": {
-        "Enabled": true
-      },
-      "TfsEmbededImagesTool": {
-        "Enabled": true
-      }
-    },
-    "ProcessorDefaults": {
-      "AzureDevOpsPipelineProcessor": {
-        "Enabled": false,
-        "MigrateBuildPipelines": true,
-        "MigrateReleasePipelines": true,
-        "MigrateTaskGroups": true,
-        "MigrateVariableGroups": true,
-        "MigrateServiceConnections": true,
-        "BuildPipelines": null,
-        "ReleasePipelines": null,
-        "SourceName": "sourceName",
-        "TargetName": "targetName"
-      },
-      "TfsWorkItemMigrationProcessor": {
-        "Enabled": false,
-        "UpdateCreatedDate": true,
-        "UpdateCreatedBy": true,
-        "WIQLQuery": "SELECT [System.Id] FROM WorkItems WHERE [System.TeamProject] = @TeamProject AND [System.WorkItemType] NOT IN ('Test Suite', 'Test Plan','Shared Steps','Shared Parameter','Feedback Request') ORDER BY [System.ChangedDate] desc",
-        "FixHtmlAttachmentLinks": true,
-        "WorkItemCreateRetryLimit": 5,
-        "FilterWorkItemsThatAlreadyExistInTarget": false,
-        "PauseAfterEachWorkItem": false,
-        "AttachRevisionHistory": false,
-        "GenerateMigrationComment": true,
-        "SourceName": "Source",
-        "TargetName": "Target",
-        "WorkItemIDs": [],
-        "MaxGracefulFailures": 0,
-        "SkipRevisionWithInvalidIterationPath": false,
-        "SkipRevisionWithInvalidAreaPath": false
-      }
-    },
-    "ProcessorSamples": {
-      "AzureDevOpsPipelineProcessor": {
-        "Enabled": false,
-        "MigrateBuildPipelines": true,
-        "MigrateReleasePipelines": true,
-        "MigrateTaskGroups": true,
-        "MigrateVariableGroups": true,
-        "MigrateServiceConnections": true,
-        "BuildPipelines": null,
-        "ReleasePipelines": null,
-        "SourceName": "sourceName",
-        "TargetName": "targetName"
-      },
-      "TfsWorkItemMigrationProcessor": {
-        "Enabled": false,
-        "WIQLQuery": "SELECT [System.Id] FROM WorkItems WHERE [System.TeamProject] = @TeamProject AND [System.WorkItemType] NOT IN ('Test Suite', 'Test Plan','Shared Steps','Shared Parameter','Feedback Request') ORDER BY [System.ChangedDate] desc",
-        "FilterWorkItemsThatAlreadyExistInTarget": false,
-        "SourceName": "Source",
-        "TargetName": "Target"
-      },
-      "ExportUsersForMappingProcessor": {
-        "Enabled": true,
-        "WIQLQuery": "SELECT [System.Id] FROM WorkItems WHERE [System.TeamProject] = @TeamProject AND [System.WorkItemType] NOT IN ('Test Suite', 'Test Plan','Shared Steps','Shared Parameter','Feedback Request') ORDER BY [System.ChangedDate] desc",
-        "OnlyListUsersInWorkItems": true,
-        "SourceName": "Source",
-        "TargetName": "Target"
-      }
-    },
-    "Infrastructure": {
-      "ClassNameChangeMappings": {
-        "TfsGitRepositoryTool": "TfsGitRepositoryTool",
-        "TfsTeamSettingsEnricher": "TfsTeamSettingsTool",
-        "TfsWorkItemLinkEnricher": "TfsWorkItemLinkTool",
-        "TfsAttachmentEnricher": "TfsAttachmentTool",
-        "StringManipulatorEnricher": "StringManipulatorTool",
-        "TfsUserMappingEnricher": "TfsUserMappingTool",
-        "FieldBlankMap": "FieldClearMap",
-        "FieldtoTagMap": "FieldToTagFieldMap",
-        "TreeToTagMap": "TreeToTagFieldMap",
-        "TeamMigration": "TfsTeamSettingsProcessor",
-        "WorkItemQueryMigration": "TfsSharedQueryProcessor",
-        "WorkItemMigration": "TfsWorkItemMigrationProcessor",
-        "WorkItemMigrationContext": "TfsWorkItemMigrationProcessor",
-        "TfsTeamProjectConfig": "TfsTeamProjectEndpoint",
-        "WorkItemGitRepoMappingTool": "TfsGitRepositoryTool",
-        "WorkItemFieldMappingTool": "FieldMappingTool",
-        "CreateTeamFolders": "TfsCreateTeamFoldersProcessor",
-        "ExportProfilePicture": "TfsExportProfilePictureFromADProcessor",
-        "ExportProfilePictureFromAD": "TfsExportProfilePictureFromADProcessor",
-        "ImportProfilePicture": "TfsImportProfilePictureProcessor",
-        "ImportProfilePictureFromAD": "TfsImportProfilePictureProcessor",
-        "ExportUsersForMapping": "TfsExportUsersForMappingProcessor",
-        "ExportUsersForMappingContext": "TfsExportUsersForMappingProcessor",
-        "ExportTeamListProcessor": "TfsExportTeamListProcessor",
-        "ExportTeamList": "TfsExportTeamListProcessor",
-        "ExportUsersForMappingProcessor": "TfsExportUsersForMappingProcessor",
-        "TestConfigurationsMigration": "TfsTestConfigurationsMigrationProcessor",
-        "TestConfigurationsMigrationProcessor": "TfsTestConfigurationsMigrationProcessor",
-        "TestConfigurationsMigrationContext": "TfsTestConfigurationsMigrationProcessor",
-        "TestPlansAndSuitesMigration": "TfsTestPlansAndSuitesMigrationProcessor",
-        "TestPlansAndSuitesMigrationProcessor": "TfsTestPlansAndSuitesMigrationProcessor",
-        "TestPlansAndSuitesMigrationContext": "TfsTestPlansAndSuitesMigrationProcessor",
-        "TestVariablesMigration": "TfsTestVariablesMigrationProcessor",
-        "TestVariablesMigrationProcessor": "TfsTestVariablesMigrationProcessor",
-        "TestVariablesMigrationContext": "TfsTestVariablesMigrationProcessor",
-        "WorkItemBulkEditProcessor": "TfsWorkItemBulkEditProcessor",
-        "WorkItemUpdate": "TfsWorkItemBulkEditProcessor",
-        "WorkItemDelete": "TfsWorkItemDeleteProcessor",
-        "WorkItemDeleteProcessor": "TfsWorkItemDeleteProcessor",
-        "WorkItemPostProcessingContext": "TfsWorkItemOverwriteProcessor",
-        "WorkItemPostProcessing": "TfsWorkItemOverwriteProcessor",
-        "WorkItemPostProcessingProcessor": "TfsWorkItemOverwriteProcessor",
-        "WorkItemUpdateAreasAsTagsContext": "TfsWorkItemOverwriteProcessor",
-        "WorkItemUpdateAreasAsTagsProcessor": "TfsWorkItemOverwriteProcessor"
-      }
     }
-  }
 }

--- a/docs/data/classes/reference.endpoints.tfsendpoint.yaml
+++ b/docs/data/classes/reference.endpoints.tfsendpoint.yaml
@@ -116,5 +116,5 @@ options:
   defaultValue: missing XML code comments
 status: missing XML code comments
 processingTarget: missing XML code comments
-classFile: src/MigrationTools.Clients.TfsObjectModel/Endpoints/TfsEndpoint.cs
-optionsClassFile: src/MigrationTools.Clients.TfsObjectModel/Endpoints/TfsEndpointOptions.cs
+classFile: src/MigrationTools.Clients.TfsObjectModel/EndPoints/TfsEndpoint.cs
+optionsClassFile: src/MigrationTools.Clients.TfsObjectModel/EndPoints/TfsEndpointOptions.cs

--- a/docs/data/classes/reference.endpoints.tfsteamprojectendpoint.yaml
+++ b/docs/data/classes/reference.endpoints.tfsteamprojectendpoint.yaml
@@ -112,5 +112,5 @@ options:
   defaultValue: missing XML code comments
 status: missing XML code comments
 processingTarget: missing XML code comments
-classFile: src/MigrationTools.Clients.TfsObjectModel/Endpoints/TfsTeamProjectEndpoint.cs
+classFile: src/MigrationTools.Clients.TfsObjectModel/EndPoints/TfsTeamProjectEndpoint.cs
 optionsClassFile: src/MigrationTools.Clients.TfsObjectModel/EndPoints/TfsTeamProjectEndPointOptions.cs

--- a/docs/data/classes/reference.endpoints.tfsteamsettingsendpoint.yaml
+++ b/docs/data/classes/reference.endpoints.tfsteamsettingsendpoint.yaml
@@ -53,5 +53,5 @@ options:
   defaultValue: missing XML code comments
 status: missing XML code comments
 processingTarget: missing XML code comments
-classFile: src/MigrationTools.Clients.TfsObjectModel/Endpoints/TfsTeamSettingsEndpoint.cs
-optionsClassFile: src/MigrationTools.Clients.TfsObjectModel/Endpoints/TfsTeamSettingsEndpointOptions.cs
+classFile: src/MigrationTools.Clients.TfsObjectModel/EndPoints/TfsTeamSettingsEndpoint.cs
+optionsClassFile: src/MigrationTools.Clients.TfsObjectModel/EndPoints/TfsTeamSettingsEndpointOptions.cs

--- a/docs/data/classes/reference.endpoints.tfsworkitemendpoint.yaml
+++ b/docs/data/classes/reference.endpoints.tfsworkitemendpoint.yaml
@@ -58,5 +58,5 @@ options:
   defaultValue: missing XML code comments
 status: missing XML code comments
 processingTarget: missing XML code comments
-classFile: src/MigrationTools.Clients.TfsObjectModel/Endpoints/TfsWorkItemEndpoint.cs
-optionsClassFile: src/MigrationTools.Clients.TfsObjectModel/Endpoints/TfsWorkItemEndpointOptions.cs
+classFile: src/MigrationTools.Clients.TfsObjectModel/EndPoints/TfsWorkItemEndpoint.cs
+optionsClassFile: src/MigrationTools.Clients.TfsObjectModel/EndPoints/TfsWorkItemEndpointOptions.cs

--- a/docs/data/classes/reference.processors.keepoutboundlinktargetprocessor.yaml
+++ b/docs/data/classes/reference.processors.keepoutboundlinktargetprocessor.yaml
@@ -20,7 +20,7 @@ configurationSamples:
       "Enabled": false,
       "WIQLQuery": "Select [System.Id] From WorkItems Where [System.TeamProject] = @project and not [System.WorkItemType] contains 'Test Suite, Test Plan,Shared Steps,Shared Parameter,Feedback Request'",
       "TargetLinksToKeepOrganization": "https://dev.azure.com/nkdagility",
-      "TargetLinksToKeepProject": "c0eff8c5-0c42-4f6a-9b7d-f892eeaf7ad5",
+      "TargetLinksToKeepProject": "10464ecf-816d-4fca-a547-81f230b9069a",
       "CleanupFileName": "c:/temp/OutboundLinkTargets.bat",
       "PrependCommand": "start",
       "DryRun": true,

--- a/docs/data/classes/reference.tools.tfsvalidaterequiredfieldtool.yaml
+++ b/docs/data/classes/reference.tools.tfsvalidaterequiredfieldtool.yaml
@@ -9,7 +9,22 @@ configurationSamples:
 - name: sample
   order: 1
   description: 
-  code: There is no sample, but you can check the classic below for a general feel.
+  code: >-
+    {
+      "MigrationTools": {
+        "Version": "16.0",
+        "CommonTools": {
+          "TfsValidateRequiredFieldTool": {
+            "Enabled": "True",
+            "Exclusions": [
+              "Work Request",
+              "Opertunity",
+              "Assumption"
+            ]
+          }
+        }
+      }
+    }
   sampleFor: MigrationTools.Tools.TfsValidateRequiredFieldToolOptions
 - name: classic
   order: 3
@@ -17,7 +32,12 @@ configurationSamples:
   code: >-
     {
       "$type": "TfsValidateRequiredFieldToolOptions",
-      "Enabled": false
+      "Enabled": true,
+      "Exclusions": [
+        "Work Request",
+        "Opertunity",
+        "Assumption"
+      ]
     }
   sampleFor: MigrationTools.Tools.TfsValidateRequiredFieldToolOptions
 description: Tool for validating that required fields exist in target work item types before migration, preventing migration failures due to missing required fields.
@@ -28,6 +48,10 @@ options:
   type: Boolean
   description: If set to `true` then the tool will run. Set to `false` and the processor will not run.
   defaultValue: missing XML code comments
+- parameterName: Exclusions
+  type: List
+  description: 'Add a list of work item types from the source that you want to exclude from validation. This is a case-insensitive comparison. WARNING: If you exclude a work item type that exists in the migration dataset, the migration will fail when trying to.'
+  defaultValue: '[]'
 status: missing XML code comments
 processingTarget: missing XML code comments
 classFile: src/MigrationTools.Clients.TfsObjectModel/Tools/TfsValidateRequiredFieldTool.cs

--- a/docs/data/classes/reference.tools.tfsworkitemtypevalidatortool.yaml
+++ b/docs/data/classes/reference.tools.tfsworkitemtypevalidatortool.yaml
@@ -1,0 +1,44 @@
+optionsClassName: TfsWorkItemTypeValidatorToolOptions
+optionsClassFullName: MigrationTools.Tools.TfsWorkItemTypeValidatorToolOptions
+configurationSamples:
+- name: defaults
+  order: 2
+  description: 
+  code: There are no defaults! Check the sample for options!
+  sampleFor: MigrationTools.Tools.TfsWorkItemTypeValidatorToolOptions
+- name: sample
+  order: 1
+  description: 
+  code: There is no sample, but you can check the classic below for a general feel.
+  sampleFor: MigrationTools.Tools.TfsWorkItemTypeValidatorToolOptions
+- name: classic
+  order: 3
+  description: 
+  code: >-
+    {
+      "$type": "TfsWorkItemTypeValidatorToolOptions",
+      "Enabled": true,
+      "IncludeWorkItemtypes": [],
+      "FieldMappings": {}
+    }
+  sampleFor: MigrationTools.Tools.TfsWorkItemTypeValidatorToolOptions
+description: missing XML code comments
+className: TfsWorkItemTypeValidatorTool
+typeName: Tools
+options:
+- parameterName: Enabled
+  type: Boolean
+  description: If set to `true` then the tool will run. Set to `false` and the processor will not run.
+  defaultValue: missing XML code comments
+- parameterName: FieldMappings
+  type: Dictionary
+  description: Field reference name mappings. Key is work item type name, value is dictionary of mapping source filed name to target field name. Target field name can be empty string to indicate that this field will not be validated in target. As work item type name, you can use * to define mappings which will be applied to all work item types.
+  defaultValue: missing XML code comments
+- parameterName: IncludeWorkItemtypes
+  type: List
+  description: List of work item types which will be validated. If this list is empty, all work item types will be validated.
+  defaultValue: missing XML code comments
+status: missing XML code comments
+processingTarget: missing XML code comments
+classFile: src/MigrationTools.Clients.TfsObjectModel/Tools/TfsWorkItemTypeValidatorTool.cs
+optionsClassFile: src/MigrationTools.Clients.TfsObjectModel/Tools/TfsWorkItemTypeValidatorToolOptions.cs

--- a/docs/static/schema/configuration.schema.json
+++ b/docs/static/schema/configuration.schema.json
@@ -1429,6 +1429,11 @@
                 "enabled": {
                   "description": "If set to `true` then the tool will run. Set to `false` and the processor will not run.",
                   "type": "boolean"
+                },
+                "exclusions": {
+                  "description": "Add a list of work item types from the source that you want to exclude from validation. This is a case-insensitive comparison. WARNING: If you exclude a work item type that exists in the migration dataset, the migration will fail when trying to.",
+                  "type": "array",
+                  "default": "[]"
                 }
               }
             },
@@ -1460,6 +1465,25 @@
                   "description": "Save the work item after each link is added. This will slow the migration as it will cause many saves to the TFS database.",
                   "type": "boolean",
                   "default": "false"
+                }
+              }
+            },
+            "tfsworkitemtypevalidatortool": {
+              "title": "TfsWorkItemTypeValidatorTool",
+              "description": "missing XML code comments",
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "description": "If set to `true` then the tool will run. Set to `false` and the processor will not run.",
+                  "type": "boolean"
+                },
+                "fieldMappings": {
+                  "description": "Field reference name mappings. Key is work item type name, value is dictionary of mapping source filed name to target field name. Target field name can be empty string to indicate that this field will not be validated in target. As work item type name, you can use * to define mappings which will be applied to all work item types.",
+                  "type": "object"
+                },
+                "includeWorkItemtypes": {
+                  "description": "List of work item types which will be validated. If this list is empty, all work item types will be validated.",
+                  "type": "array"
                 }
               }
             },

--- a/docs/static/schema/schema.tools.tfsvalidaterequiredfieldtool.json
+++ b/docs/static/schema/schema.tools.tfsvalidaterequiredfieldtool.json
@@ -8,6 +8,11 @@
     "enabled": {
       "description": "If set to `true` then the tool will run. Set to `false` and the processor will not run.",
       "type": "boolean"
+    },
+    "exclusions": {
+      "description": "Add a list of work item types from the source that you want to exclude from validation. This is a case-insensitive comparison. WARNING: If you exclude a work item type that exists in the migration dataset, the migration will fail when trying to.",
+      "type": "array",
+      "default": "[]"
     }
   }
 }

--- a/docs/static/schema/schema.tools.tfsworkitemtypevalidatortool.json
+++ b/docs/static/schema/schema.tools.tfsworkitemtypevalidatortool.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://devopsmigration.io/schema/schema.tools.tfsworkitemtypevalidatortool.json",
+  "title": "TfsWorkItemTypeValidatorTool",
+  "description": "missing XML code comments",
+  "type": "object",
+  "properties": {
+    "enabled": {
+      "description": "If set to `true` then the tool will run. Set to `false` and the processor will not run.",
+      "type": "boolean"
+    },
+    "fieldMappings": {
+      "description": "Field reference name mappings. Key is work item type name, value is dictionary of mapping source filed name to target field name. Target field name can be empty string to indicate that this field will not be validated in target. As work item type name, you can use * to define mappings which will be applied to all work item types.",
+      "type": "object"
+    },
+    "includeWorkItemtypes": {
+      "description": "List of work item types which will be validated. If this list is empty, all work item types will be validated.",
+      "type": "array"
+    }
+  }
+}

--- a/src/MigrationTools.Clients.TfsObjectModel/Tools/TfsValidateRequiredFieldTool.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/Tools/TfsValidateRequiredFieldTool.cs
@@ -54,6 +54,11 @@ namespace MigrationTools.Tools
                 {
 
                     var workItemTypeName = sourceWorkItemType.Name;
+                    if (Options.Exclusions.Any(exclusion => string.Equals(exclusion, sourceWorkItemType.Name, StringComparison.OrdinalIgnoreCase)))
+                    {
+                        Log.LogDebug("ValidatingRequiredField: Skipping excluded work item type {WorkItemTypeName}", workItemTypeName);
+                        continue;
+                    }
                     if (workItemTypeMappingTool.Mappings != null && workItemTypeMappingTool.Mappings.ContainsKey(workItemTypeName))
                     {
                         workItemTypeName = workItemTypeMappingTool.Mappings[workItemTypeName];
@@ -79,22 +84,5 @@ namespace MigrationTools.Tools
             return result;
         }
 
-        //private void ConfigValidation()
-        //{
-        //    //Make sure that the ReflectedWorkItemId field name specified in the config exists in the target process, preferably on each work item type
-        //    var fields = _witClient.GetFieldsAsync(Engine.Target.Config.AsTeamProjectConfig().Project).Result;
-        //    bool rwiidFieldExists = fields.Any(x => x.ReferenceName == Engine.Target.Config.AsTeamProjectConfig().ReflectedWorkItemIdField || x.Name == Engine.Target.Config.AsTeamProjectConfig().ReflectedWorkItemIdField);
-        //    contextLog.Information("Found {FieldsFoundCount} work item fields.", fields.Count.ToString("n0"));
-        //    if (rwiidFieldExists)
-        //        contextLog.Information("Found '{ReflectedWorkItemIdField}' in this project, proceeding.", Engine.Target.Config.AsTeamProjectConfig().ReflectedWorkItemIdField);
-        //    else
-        //    {
-        //        contextLog.Information("Config file specifies '{ReflectedWorkItemIdField}', which wasn't found.", Engine.Target.Config.AsTeamProjectConfig().ReflectedWorkItemIdField);
-        //        contextLog.Information("Instead, found:");
-        //        foreach (var field in fields.OrderBy(x => x.Name))
-        //            contextLog.Information("{FieldType} - {FieldName} - {FieldRefName}", field.Type.ToString().PadLeft(15), field.Name.PadRight(20), field.ReferenceName ?? "");
-        //        throw new Exception("Running a replay migration requires a ReflectedWorkItemId field to be defined in the target project's process.");
-        //    }
-        //}
     }
 }

--- a/src/MigrationTools.Clients.TfsObjectModel/Tools/TfsValidateRequiredFieldToolOptions.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/Tools/TfsValidateRequiredFieldToolOptions.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using MigrationTools.Enrichers;
+﻿using System.Collections.Generic;
 using MigrationTools.Tools.Infrastructure;
 
 namespace MigrationTools.Tools
@@ -9,6 +8,11 @@ namespace MigrationTools.Tools
     /// </summary>
     public class TfsValidateRequiredFieldToolOptions : ToolOptions
     {
-
+        /// <summary>
+        /// Add a list of work item types from the source that you want to exclude from validation. This is a case-insensitive comparison.
+        /// WARNING: If you exclude a work item type that exists in the migration dataset, the migration will fail when trying to.
+        /// </summary>
+        /// <default>[]</default>
+        public List<string> Exclusions { get; set; } = new List<string>();
     }
 }


### PR DESCRIPTION
- Implemented a check in TfsValidateRequiredFieldTool.cs to skip validation for excluded work item types, with debug logging.
- Added an `Exclusions` property in TfsValidateRequiredFieldToolOptions.cs to allow users to specify work item types to exclude from validation, including documentation on its usage.
- Removed deprecated commented-out code related to configuration validation in TfsValidateRequiredFieldTool.cs.

Resolves: #2897

Co-authored-by: rpollick <rpollick@users.noreply.github.com>
