### PR TITLE
Implement work item type validator processor

### DIFF
--- a/src/MigrationTools.Clients.TfsObjectModel/Processors/TfsWorkItemTypeValidatorProcessor.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/Processors/TfsWorkItemTypeValidatorProcessor.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.TeamFoundation.WorkItemTracking.Client;
+using MigrationTools.Enrichers;
+using MigrationTools.Processors.Infrastructure;
+using MigrationTools.Tools;
+
+namespace MigrationTools.Processors
+{
+    /// <summary>
+    /// Work item type validation processor. Basically it just runs the <see cref="TfsWorkItemTypeValidatorTool"/>
+    /// to validate work item types. The validation is run always, even if the tool iself is disabled.
+    /// Neither this processor, nor the tool do not perform any changes to the source or target system.
+    /// </summary>
+    public class TfsWorkItemTypeValidatorProcessor : TfsProcessor
+    {
+        public TfsWorkItemTypeValidatorProcessor(
+            IOptions<TfsWorkItemTypeValidatorProcessorOptions> options,
+            TfsCommonTools tfsCommonTools,
+            ProcessorEnricherContainer processorEnrichers,
+            IServiceProvider services,
+            ITelemetryLogger telemetry,
+            ILogger<TfsWorkItemTypeValidatorProcessor> logger)
+            : base(options, tfsCommonTools, processorEnrichers, services, telemetry, logger)
+        {
+        }
+
+        public new TfsWorkItemTypeValidatorProcessorOptions Options => (TfsWorkItemTypeValidatorProcessorOptions)base.Options;
+
+        protected override void InternalExecute()
+        {
+            if (!CommonTools.WorkItemTypeValidatorTool.Enabled)
+            {
+                Log.LogInformation("Work item type validation tool is disabled, but this processor will still"
+                    + " run the validation. No changes are done to source or target system.");
+            }
+            List<WorkItemType> sourceWits = Source.WorkItems.Project
+                .ToProject()
+                .WorkItemTypes
+                .Cast<WorkItemType>()
+                .ToList();
+            List<WorkItemType> targetWits = Target.WorkItems.Project
+                .ToProject()
+                .WorkItemTypes
+                .Cast<WorkItemType>()
+                .ToList();
+            bool validationResult = CommonTools.WorkItemTypeValidatorTool
+                .ValidateWorkItemTypes(sourceWits, targetWits, Target.Options.ReflectedWorkItemIdField);
+            if (Options.StopIfValidationFails && !validationResult)
+            {
+                Log.LogInformation($"'{nameof(Options.StopIfValidationFails)}' is set to 'true', so migration process will stop now.");
+                Environment.Exit(-1);
+            }
+        }
+    }
+}

--- a/src/MigrationTools.Clients.TfsObjectModel/Processors/TfsWorkItemTypeValidatorProcessorOptions.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/Processors/TfsWorkItemTypeValidatorProcessorOptions.cs
@@ -1,0 +1,18 @@
+﻿using MigrationTools.Processors.Infrastructure;
+
+namespace MigrationTools.Processors
+{
+    /// <summary>
+    /// Options for processor <see cref="TfsWorkItemTypeValidatorProcessor"/>.
+    /// </summary>
+    public class TfsWorkItemTypeValidatorProcessorOptions : ProcessorOptions
+    {
+        /// <summary>
+        /// If set to <see langword="true"/>, migration process will stop if there are some validation errors.
+        /// If set to <see langword="false"/>, migration process will continue, for example to support some other validation
+        /// processors.
+        /// Default value is <see langword="true"/>.
+        /// </summary>
+        public bool StopIfValidationFails { get; set; } = true;
+    }
+}


### PR DESCRIPTION
This PR follows my previous PR #2894 that implements work item type validator tool. I also implemented the porcessor, which uses tool and just validates work item types.

This validation is run automatically during work item migrations, but I need (and hope it is useful for others) just to validate things ad do not continue even if everything is OK. I was whinking implementing it as separate processor, or just some boolean option in `TfsWorkItemMigrationProcessor` and chose separate processor. I think it is cleaner because it is simple and it is very clear what is this processor for.

The processor supports just one option `StopIfValidationFails`. If `true`, the migration process will stop if the validation fails – this is the default. If set to `false`, the migration process (other processors) will continue to run.

The processor configuration is:

``` json
{
  "ProcessorType": "TfsWorkItemTypeValidatorProcessor",
  "Enabled": true,
  "SourceName": "Source",
  "TargetName": "Target",
  "StopIfValidationFails": true
},
```