### PR TITLE
Refactor user group name handling in TfsUserMappingTool

### DIFF
--- a/docs/data/classes/reference.tools.tfsusermappingtool.yaml
+++ b/docs/data/classes/reference.tools.tfsusermappingtool.yaml
@@ -71,7 +71,8 @@ configurationSamples:
         "Microsoft.VSTS.Common.ClosedBy"
       ],
       "UserMappingFile": "C:\\temp\\userExport.json",
-      "MatchUsersByEmail": false
+      "MatchUsersByEmail": false,
+      "ProjectCollectionValidUsersGroupName": "Project Collection Valid Users"
     }
   sampleFor: MigrationTools.Tools.TfsUserMappingToolOptions
 description: The TfsUserMappingTool is used to map users from the source to the target system. Run it with the ExportUsersForMappingContext to create a mapping file then with WorkItemMigrationContext to use the mapping file to update the users in the target system as you migrate the work items.
@@ -89,6 +90,10 @@ options:
 - parameterName: MatchUsersByEmail
   type: Boolean
   description: By default, users in source are mapped to target users by their display name. If this is set to true, then the users will be mapped by their email address first. If no match is found, then the display name will be used.
+  defaultValue: missing XML code comments
+- parameterName: ProjectCollectionValidUsersGroupName
+  type: String
+  description: This is the regionalized "Project Collection Valid Users" group name. Default is "Project Collection Valid Users".
   defaultValue: missing XML code comments
 - parameterName: UserMappingFile
   type: String

--- a/docs/static/schema/configuration.schema.json
+++ b/docs/static/schema/configuration.schema.json
@@ -1444,6 +1444,10 @@
                   "description": "By default, users in source are mapped to target users by their display name. If this is set to true, then the users will be mapped by their email address first. If no match is found, then the display name will be used.",
                   "type": "boolean"
                 },
+                "projectCollectionValidUsersGroupName": {
+                  "description": "This is the regionalized \"Project Collection Valid Users\" group name. Default is \"Project Collection Valid Users\".",
+                  "type": "string"
+                },
                 "userMappingFile": {
                   "description": "This is the file that will be used to export or import the user mappings. Use the ExportUsersForMapping processor to create the file.",
                   "type": "string"

--- a/docs/static/schema/schema.tools.tfsusermappingtool.json
+++ b/docs/static/schema/schema.tools.tfsusermappingtool.json
@@ -17,6 +17,10 @@
       "description": "By default, users in source are mapped to target users by their display name. If this is set to true, then the users will be mapped by their email address first. If no match is found, then the display name will be used.",
       "type": "boolean"
     },
+    "projectCollectionValidUsersGroupName": {
+      "description": "This is the regionalized \"Project Collection Valid Users\" group name. Default is \"Project Collection Valid Users\".",
+      "type": "string"
+    },
     "userMappingFile": {
       "description": "This is the file that will be used to export or import the user mappings. Use the ExportUsersForMapping processor to create the file.",
       "type": "string"

--- a/src/MigrationTools.Clients.TfsObjectModel/Tools/TfsUserMappingTool.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/Tools/TfsUserMappingTool.cs
@@ -121,7 +121,7 @@ namespace MigrationTools.Tools
 
         private List<IdentityItemData> GetUsersListFromServer(IGroupSecurityService gss)
         {
-            Identity allIdentities = gss.ReadIdentity(SearchFactor.AccountName, "Project Collection Valid Users", QueryMembership.Expanded);
+            Identity allIdentities = gss.ReadIdentity(SearchFactor.AccountName, Options.ProjectCollectionValidUsersGroupName, QueryMembership.Expanded);
             Log.LogInformation("TfsUserMappingTool::GetUsersListFromServer Found {count} identities (users and groups) in server.", allIdentities.Members.Length);
 
             List<IdentityItemData> foundUsers = new List<IdentityItemData>();

--- a/src/MigrationTools.Clients.TfsObjectModel/Tools/TfsUserMappingToolOptions.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/Tools/TfsUserMappingToolOptions.cs
@@ -31,6 +31,12 @@ namespace MigrationTools.Tools
         /// </summary>
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public bool SkipValidateAllUsersExistOrAreMapped { get; set; } = false;
+
+        /// <summary>
+        /// This is the regionalized "Project Collection Valid Users" group name. Default is "Project Collection Valid Users".
+        /// </summary>
+        public string ProjectCollectionValidUsersGroupName { get; set; } = "Project Collection Valid Users";
+
     }
 
     public interface ITfsUserMappingToolOptions


### PR DESCRIPTION
Replaced hardcoded "Project Collection Valid Users" string in `TfsUserMappingTool.cs` with a configurable property `Options.ProjectCollectionValidUsersGroupName`. Added this property to `TfsUserMappingToolOptions.cs` to allow customization of the group name, with a default value of "Project Collection Valid Users".

Fixes:  #2895
Co-authored-by: sl-io <sl-io@users.noreply.github.com>

