### PR TITLE
Implement work item type fileds validation

### DIFF
--- a/src/MigrationTools.Clients.TfsObjectModel.Tests/Tools/FieldReferenceNameMappingToolOptionsTests.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel.Tests/Tools/FieldReferenceNameMappingToolOptionsTests.cs
@@ -10,10 +10,10 @@ namespace MigrationTools.Tests.Tools
         public void FieldMappingsMustNotBeNullWhenNormalized()
         {
             TfsWorkItemTypeValidatorToolOptions options = new() { Enabled = true };
-            options.FieldMappings = null;
+            options.SourceFieldMappings = null;
             options.Normalize();
 
-            Assert.IsNotNull(options.FieldMappings);
+            Assert.IsNotNull(options.SourceFieldMappings);
         }
 
         [TestMethod]
@@ -22,7 +22,7 @@ namespace MigrationTools.Tests.Tools
             TfsWorkItemTypeValidatorToolOptions options = new()
             {
                 Enabled = true,
-                FieldMappings = new()
+                SourceFieldMappings = new()
                 {
                     ["wit"] = new()
                     {
@@ -44,7 +44,7 @@ namespace MigrationTools.Tests.Tools
             TfsWorkItemTypeValidatorToolOptions options = new()
             {
                 Enabled = true,
-                FieldMappings = new()
+                SourceFieldMappings = new()
                 {
                     ["wit"] = new()
                     {
@@ -64,7 +64,7 @@ namespace MigrationTools.Tests.Tools
             TfsWorkItemTypeValidatorToolOptions options = new()
             {
                 Enabled = true,
-                FieldMappings = new()
+                SourceFieldMappings = new()
                 {
                     ["wit"] = new()
                     {
@@ -86,7 +86,7 @@ namespace MigrationTools.Tests.Tools
             TfsWorkItemTypeValidatorToolOptions options = new()
             {
                 Enabled = true,
-                FieldMappings = new()
+                SourceFieldMappings = new()
                 {
                     [TfsWorkItemTypeValidatorToolOptions.AllWorkItemTypes] = new()
                     {

--- a/src/MigrationTools.Clients.TfsObjectModel/Tools/TfsWorkItemTypeValidatorTool.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/Tools/TfsWorkItemTypeValidatorTool.cs
@@ -283,7 +283,7 @@ namespace MigrationTools.Tools
 
             const string message1 = "Some work item types or their fields are not present in the target system (see previous logs)."
                 + " Either add these fields into target work items, or map source fields to other target fields"
-                + $" in options ({nameof(TfsWorkItemTypeValidatorToolOptions.FieldMappings)}).";
+                + $" in options ({nameof(TfsWorkItemTypeValidatorToolOptions.SourceFieldMappings)}).";
             Log.LogError(message1);
             const string message2 = "If you have some field mappings defined for validation, do not forget also to configure"
                 + $" proper field mapping in {nameof(FieldMappingTool)} so data will preserved during migration.";

--- a/src/MigrationTools.Clients.TfsObjectModel/Tools/TfsWorkItemTypeValidatorToolOptions.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/Tools/TfsWorkItemTypeValidatorToolOptions.cs
@@ -30,7 +30,7 @@ namespace MigrationTools.Tools
         /// target field name. Target field name can be empty string to indicate that this field will not be validated in target.
         /// As work item type name, you can use <c>*</c> to define mappings which will be applied to all work item types.
         /// </summary>
-        public Dictionary<string, Dictionary<string, string>> FieldMappings { get; set; } = [];
+        public Dictionary<string, Dictionary<string, string>> SourceFieldMappings { get; set; } = [];
 
         /// <summary>
         /// <para>
@@ -57,7 +57,7 @@ namespace MigrationTools.Tools
                 return;
             }
 
-            Dictionary<string, Dictionary<string, string>> oldMappings = FieldMappings;
+            Dictionary<string, Dictionary<string, string>> oldMappings = SourceFieldMappings;
             Dictionary<string, Dictionary<string, string>> newMappings = new(_normalizedComparer);
             if (oldMappings is not null)
             {
@@ -84,7 +84,7 @@ namespace MigrationTools.Tools
 
             IncludeWorkItemtypes ??= [];
             FixedTargetFields = newFixedFields;
-            FieldMappings = newMappings;
+            SourceFieldMappings = newMappings;
             _isNormalized = true;
         }
 
@@ -141,7 +141,7 @@ namespace MigrationTools.Tools
 
         private bool TryGetTargetFieldName(string workItemType, string sourceFieldName, out string targetFieldName)
         {
-            if (FieldMappings.TryGetValue(workItemType, out Dictionary<string, string> mappings))
+            if (SourceFieldMappings.TryGetValue(workItemType, out Dictionary<string, string> mappings))
             {
                 if (mappings.TryGetValue(sourceFieldName, out targetFieldName))
                 {


### PR DESCRIPTION
Current validation of work item types is not sufficient, because it validates just if the source field exists in target. But there are numerous cases, when the field exist, but is not valid:

**Field can have different data type.**

Some of the different types are OK, some are not. For example migrating from number to string is OK, but the other way may not be.

**Field have different allowed values.**

Migration process will migrate not allowed values without any warning. This happened even to me, when I migrated our backlog. But then, when backlog item was opened in DevOps UI, it immediately reported error and did not allow to save the item until it was fixes. This happenes for example, when work item types change. Than both, source and target work items have field `System.State`, but the values for them are different.

I implemented validation for these, so clients can quickly see, that there are some discrepancies between source and target work item. All this is by default reported as warning (som migration will stop). If the user resolves issue with invalid field (for example the values will be mapped using `FieldMappingTool`, it needs to state it in `FixedTargetFields` property of options. All fields listed there will not trigger warning. But the information about the differencies will still be logged, so user always knows about it.