### PR TITLE
#2952 issue ,check target field allowed values contain all allowed source  field values

### DIFF
--- a/src/MigrationTools.Clients.TfsObjectModel/Tools/TfsWorkItemTypeValidatorTool.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/Tools/TfsWorkItemTypeValidatorTool.cs
@@ -189,7 +189,7 @@ namespace MigrationTools.Tools
                     + " source = '{sourceFieldAllowedValueType}', target = '{targetFieldAllowedValueType}'.",
                     sourceField.ReferenceName, targetField.ReferenceName, sourceValueType, targetValueType);
             }
-            if (!AllowedValuesAreSame(sourceAllowedValues, targetAllowedValues))
+            if (!DoesTargetContainsAllSourceValues(sourceAllowedValues, targetAllowedValues))
             {
                 isValid = false;
                 Log.Log(logLevel,
@@ -204,21 +204,9 @@ namespace MigrationTools.Tools
             return isValid;
         }
 
-        private bool AllowedValuesAreSame(List<string> sourceAllowedValues, List<string> targetAllowedValues)
-        {
-            if (sourceAllowedValues.Count != targetAllowedValues.Count)
-            {
-                return false;
-            }
-            foreach (string sourceValue in sourceAllowedValues)
-            {
-                if (!targetAllowedValues.Contains(sourceValue, StringComparer.OrdinalIgnoreCase))
-                {
-                    return false;
-                }
-            }
-            return true;
-        }
+        private bool DoesTargetContainsAllSourceValues(List<string> sourceAllowedValues, List<string> targetAllowedValues) =>
+            sourceAllowedValues.Except(targetAllowedValues, StringComparer.OrdinalIgnoreCase).Count() == 0;
+
 
         private (string valueType, List<string> allowedValues) GetAllowedValues(FieldDefinition field)
         {


### PR DESCRIPTION
When trying to migrate from Azure Devops 2019 to Azure Devops 2022, in user story , Resolved reason which is of type Microsoft.VSTS.Common.ResolvedReason , has extra value "Will not fix" in target values.

in source code, instead of checking equality of source field count and target field count modified check to targetfields.count< sourcefields.count.

Source Azure Devops Version : 2019
Target Azure Devops Version: 2022

Microsoft.VSTS.Common.ResolvedReason in 2022 , has extra value "will not fix". There is no way in Azure Devops 2022 or Azure Devops 2019 to modify Microsoft.VSTS.Common.ResolvedReason. Therefore, instead of checking number of fields, checking all allowed source field values in allowed target field values is enough. 

Also modified name of method from **AllowedValuesAreSame** to **DoesTargetContainsAllSourceValues**