### PR TITLE
Confusing behaviour of `UpdateCreatedDate` and `UpdateCreatedBy` in `TfsWorkItemMigrationProcessor`

### DIFF
--- a/docs/data/classes/reference.endpoints.tfsendpoint.yaml
+++ b/docs/data/classes/reference.endpoints.tfsendpoint.yaml
@@ -87,7 +87,8 @@ configurationSamples:
       "LanguageMaps": {
         "AreaPath": "Area",
         "IterationPath": "Iteration"
-      }
+      },
+      "ProductVersion": "OnPremises"
     }
   sampleFor: MigrationTools.Endpoints.TfsEndpointOptions
 description: missing XML code comments
@@ -128,7 +129,7 @@ options:
   type: TfsLanguageMapOptions
   description: Language mapping configuration for translating area and iteration path names between different language versions of TFS.
   defaultValue: missing XML code comments
-  isRequired: true
+  isRequired: false
   dotNetType: MigrationTools.Endpoints.TfsLanguageMapOptions, MigrationTools.Clients.TfsObjectModel, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
 - parameterName: Name
   type: String
@@ -136,6 +137,12 @@ options:
   defaultValue: missing XML code comments
   isRequired: false
   dotNetType: System.String, System.Private.CoreLib, Version=8.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e
+- parameterName: ProductVersion
+  type: TfsProductVersion
+  description: Specifies the TFS product version for compatibility and feature support. Default is OnPremises for TFS 2013+ and Azure DevOps Server.
+  defaultValue: missing XML code comments
+  isRequired: false
+  dotNetType: MigrationTools.Endpoints.TfsProductVersion, MigrationTools.Clients.TfsObjectModel, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
 - parameterName: Project
   type: String
   description: Name of the TFS project within the collection to connect to. This is the project that will be used for migration operations.
@@ -146,7 +153,7 @@ options:
   type: String
   description: Name of the custom field used to store the reflected work item ID for tracking migrated items. Typically "Custom.ReflectedWorkItemId".
   defaultValue: missing XML code comments
-  isRequired: true
+  isRequired: false
   dotNetType: System.String, System.Private.CoreLib, Version=8.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e
 status: missing XML code comments
 processingTarget: missing XML code comments

--- a/docs/data/classes/reference.endpoints.tfsteamprojectendpoint.yaml
+++ b/docs/data/classes/reference.endpoints.tfsteamprojectendpoint.yaml
@@ -83,7 +83,8 @@ configurationSamples:
       "LanguageMaps": {
         "AreaPath": "Area",
         "IterationPath": "Iteration"
-      }
+      },
+      "ProductVersion": "OnPremises"
     }
   sampleFor: MigrationTools.Endpoints.TfsTeamProjectEndpointOptions
 description: missing XML code comments
@@ -124,7 +125,7 @@ options:
   type: TfsLanguageMapOptions
   description: Language mapping configuration for translating area and iteration path names between different language versions of TFS.
   defaultValue: missing XML code comments
-  isRequired: true
+  isRequired: false
   dotNetType: MigrationTools.Endpoints.TfsLanguageMapOptions, MigrationTools.Clients.TfsObjectModel, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
 - parameterName: Name
   type: String
@@ -132,6 +133,12 @@ options:
   defaultValue: missing XML code comments
   isRequired: false
   dotNetType: System.String, System.Private.CoreLib, Version=8.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e
+- parameterName: ProductVersion
+  type: TfsProductVersion
+  description: Specifies the TFS product version for compatibility and feature support. Default is OnPremises for TFS 2013+ and Azure DevOps Server.
+  defaultValue: missing XML code comments
+  isRequired: false
+  dotNetType: MigrationTools.Endpoints.TfsProductVersion, MigrationTools.Clients.TfsObjectModel, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
 - parameterName: Project
   type: String
   description: Name of the TFS project within the collection to connect to. This is the project that will be used for migration operations.
@@ -142,7 +149,7 @@ options:
   type: String
   description: Name of the custom field used to store the reflected work item ID for tracking migrated items. Typically "Custom.ReflectedWorkItemId".
   defaultValue: missing XML code comments
-  isRequired: true
+  isRequired: false
   dotNetType: System.String, System.Private.CoreLib, Version=8.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e
 status: missing XML code comments
 processingTarget: missing XML code comments

--- a/docs/data/classes/reference.endpoints.tfsteamsettingsendpoint.yaml
+++ b/docs/data/classes/reference.endpoints.tfsteamsettingsendpoint.yaml
@@ -20,11 +20,12 @@ configurationSamples:
       "Collection": null,
       "Project": null,
       "Authentication": null,
-      "ReflectedWorkItemIdField": null,
+      "ReflectedWorkItemIdField": "Custom.ReflectedWorkItemId",
       "LanguageMaps": {
         "AreaPath": "Area",
         "IterationPath": "Iteration"
-      }
+      },
+      "ProductVersion": "OnPremises"
     }
   sampleFor: MigrationTools.Endpoints.TfsTeamSettingsEndpointOptions
 description: missing XML code comments
@@ -65,7 +66,7 @@ options:
   type: TfsLanguageMapOptions
   description: Language mapping configuration for translating area and iteration path names between different language versions of TFS.
   defaultValue: missing XML code comments
-  isRequired: true
+  isRequired: false
   dotNetType: MigrationTools.Endpoints.TfsLanguageMapOptions, MigrationTools.Clients.TfsObjectModel, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
 - parameterName: Name
   type: String
@@ -73,6 +74,12 @@ options:
   defaultValue: missing XML code comments
   isRequired: false
   dotNetType: System.String, System.Private.CoreLib, Version=8.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e
+- parameterName: ProductVersion
+  type: TfsProductVersion
+  description: Specifies the TFS product version for compatibility and feature support. Default is OnPremises for TFS 2013+ and Azure DevOps Server.
+  defaultValue: missing XML code comments
+  isRequired: false
+  dotNetType: MigrationTools.Endpoints.TfsProductVersion, MigrationTools.Clients.TfsObjectModel, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
 - parameterName: Project
   type: String
   description: Name of the TFS project within the collection to connect to. This is the project that will be used for migration operations.
@@ -83,7 +90,7 @@ options:
   type: String
   description: Name of the custom field used to store the reflected work item ID for tracking migrated items. Typically "Custom.ReflectedWorkItemId".
   defaultValue: missing XML code comments
-  isRequired: true
+  isRequired: false
   dotNetType: System.String, System.Private.CoreLib, Version=8.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e
 status: missing XML code comments
 processingTarget: missing XML code comments

--- a/docs/data/classes/reference.endpoints.tfsworkitemendpoint.yaml
+++ b/docs/data/classes/reference.endpoints.tfsworkitemendpoint.yaml
@@ -21,11 +21,12 @@ configurationSamples:
       "Project": null,
       "Query": null,
       "Authentication": null,
-      "ReflectedWorkItemIdField": null,
+      "ReflectedWorkItemIdField": "Custom.ReflectedWorkItemId",
       "LanguageMaps": {
         "AreaPath": "Area",
         "IterationPath": "Iteration"
-      }
+      },
+      "ProductVersion": "OnPremises"
     }
   sampleFor: MigrationTools.Endpoints.TfsWorkItemEndpointOptions
 description: missing XML code comments
@@ -66,7 +67,7 @@ options:
   type: TfsLanguageMapOptions
   description: Language mapping configuration for translating area and iteration path names between different language versions of TFS.
   defaultValue: missing XML code comments
-  isRequired: true
+  isRequired: false
   dotNetType: MigrationTools.Endpoints.TfsLanguageMapOptions, MigrationTools.Clients.TfsObjectModel, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
 - parameterName: Name
   type: String
@@ -74,6 +75,12 @@ options:
   defaultValue: missing XML code comments
   isRequired: false
   dotNetType: System.String, System.Private.CoreLib, Version=8.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e
+- parameterName: ProductVersion
+  type: TfsProductVersion
+  description: Specifies the TFS product version for compatibility and feature support. Default is OnPremises for TFS 2013+ and Azure DevOps Server.
+  defaultValue: missing XML code comments
+  isRequired: false
+  dotNetType: MigrationTools.Endpoints.TfsProductVersion, MigrationTools.Clients.TfsObjectModel, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
 - parameterName: Project
   type: String
   description: Name of the TFS project within the collection to connect to. This is the project that will be used for migration operations.
@@ -90,7 +97,7 @@ options:
   type: String
   description: Name of the custom field used to store the reflected work item ID for tracking migrated items. Typically "Custom.ReflectedWorkItemId".
   defaultValue: missing XML code comments
-  isRequired: true
+  isRequired: false
   dotNetType: System.String, System.Private.CoreLib, Version=8.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e
 status: missing XML code comments
 processingTarget: missing XML code comments

--- a/docs/data/classes/reference.processors.tfsworkitemmigrationprocessor.yaml
+++ b/docs/data/classes/reference.processors.tfsworkitemmigrationprocessor.yaml
@@ -59,8 +59,6 @@ configurationSamples:
     {
       "$type": "TfsWorkItemMigrationProcessorOptions",
       "Enabled": false,
-      "UpdateCreatedDate": true,
-      "UpdateCreatedBy": true,
       "WIQLQuery": "SELECT [System.Id] FROM WorkItems WHERE [System.TeamProject] = @TeamProject AND [System.WorkItemType] NOT IN ('Test Suite', 'Test Plan','Shared Steps','Shared Parameter','Feedback Request') ORDER BY [System.ChangedDate] desc",
       "FixHtmlAttachmentLinks": true,
       "WorkItemCreateRetryLimit": 5,
@@ -161,24 +159,6 @@ options:
   defaultValue: missing XML code comments
   isRequired: true
   dotNetType: System.String, System.Private.CoreLib, Version=8.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e
-- parameterName: UpdateCreatedBy
-  type: Boolean
-  description: >-
-    If this is enabled the creation process on the target project will create the items with the original creation date.
-     (Important: The item history is always pointed to the date of the migration, it's change only the data column CreateDate,
-     not the internal create date)
-  defaultValue: true
-  isRequired: false
-  dotNetType: System.Boolean, System.Private.CoreLib, Version=8.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e
-- parameterName: UpdateCreatedDate
-  type: Boolean
-  description: >-
-    If this is enabled the creation process on the target project will create the items with the original creation date.
-     (Important: The item history is always pointed to the date of the migration, it's change only the data column CreateDate,
-     not the internal create date)
-  defaultValue: true
-  isRequired: false
-  dotNetType: System.Boolean, System.Private.CoreLib, Version=8.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e
 - parameterName: WIQLQuery
   type: String
   description: A work item query based on WIQL to select only important work items. To migrate all leave this empty. See [WIQL Query Bits](#wiql-query-bits)

--- a/docs/static/schema/configuration.schema.json
+++ b/docs/static/schema/configuration.schema.json
@@ -1466,16 +1466,6 @@
                       "description": "This is the `IEndpoint` that will be used as the Target of the Migration. Can be null for a read only processor.",
                       "type": "string"
                     },
-                    "UpdateCreatedBy": {
-                      "description": "If this is enabled the creation process on the target project will create the items with the original creation date.\r\n (Important: The item history is always pointed to the date of the migration, it's change only the data column CreateDate,\r\n not the internal create date)",
-                      "type": "boolean",
-                      "default": "true"
-                    },
-                    "UpdateCreatedDate": {
-                      "description": "If this is enabled the creation process on the target project will create the items with the original creation date.\r\n (Important: The item history is always pointed to the date of the migration, it's change only the data column CreateDate,\r\n not the internal create date)",
-                      "type": "boolean",
-                      "default": "true"
-                    },
                     "WIQLQuery": {
                       "description": "A work item query based on WIQL to select only important work items. To migrate all leave this empty. See [WIQL Query Bits](#wiql-query-bits)",
                       "type": "string",

--- a/docs/static/schema/configuration.schema.json
+++ b/docs/static/schema/configuration.schema.json
@@ -175,6 +175,10 @@
                     "description": "missing XML code comments",
                     "type": "string"
                   },
+                  "ProductVersion": {
+                    "description": "Specifies the TFS product version for compatibility and feature support. Default is OnPremises for TFS 2013+ and Azure DevOps Server.",
+                    "type": "string"
+                  },
                   "Project": {
                     "description": "Name of the TFS project within the collection to connect to. This is the project that will be used for migration operations.",
                     "type": "string"
@@ -193,9 +197,7 @@
                 "required": [
                   "Authentication",
                   "Collection",
-                  "LanguageMaps",
                   "Project",
-                  "ReflectedWorkItemIdField",
                   "EndpointType"
                 ]
               },
@@ -263,6 +265,10 @@
                     "description": "missing XML code comments",
                     "type": "string"
                   },
+                  "ProductVersion": {
+                    "description": "Specifies the TFS product version for compatibility and feature support. Default is OnPremises for TFS 2013+ and Azure DevOps Server.",
+                    "type": "string"
+                  },
                   "Project": {
                     "description": "Name of the TFS project within the collection to connect to. This is the project that will be used for migration operations.",
                     "type": "string"
@@ -281,9 +287,7 @@
                 "required": [
                   "Authentication",
                   "Collection",
-                  "LanguageMaps",
                   "Project",
-                  "ReflectedWorkItemIdField",
                   "EndpointType"
                 ]
               },
@@ -351,6 +355,10 @@
                     "description": "missing XML code comments",
                     "type": "string"
                   },
+                  "ProductVersion": {
+                    "description": "Specifies the TFS product version for compatibility and feature support. Default is OnPremises for TFS 2013+ and Azure DevOps Server.",
+                    "type": "string"
+                  },
                   "Project": {
                     "description": "Name of the TFS project within the collection to connect to. This is the project that will be used for migration operations.",
                     "type": "string"
@@ -369,9 +377,7 @@
                 "required": [
                   "Authentication",
                   "Collection",
-                  "LanguageMaps",
                   "Project",
-                  "ReflectedWorkItemIdField",
                   "EndpointType"
                 ]
               },
@@ -439,6 +445,10 @@
                     "description": "missing XML code comments",
                     "type": "string"
                   },
+                  "ProductVersion": {
+                    "description": "Specifies the TFS product version for compatibility and feature support. Default is OnPremises for TFS 2013+ and Azure DevOps Server.",
+                    "type": "string"
+                  },
                   "Project": {
                     "description": "Name of the TFS project within the collection to connect to. This is the project that will be used for migration operations.",
                     "type": "string"
@@ -475,9 +485,7 @@
                 "required": [
                   "Authentication",
                   "Collection",
-                  "LanguageMaps",
                   "Project",
-                  "ReflectedWorkItemIdField",
                   "EndpointType"
                 ]
               }

--- a/docs/static/schema/schema.endpoints.tfsendpoint.json
+++ b/docs/static/schema/schema.endpoints.tfsendpoint.json
@@ -33,6 +33,10 @@
       "description": "missing XML code comments",
       "type": "string"
     },
+    "ProductVersion": {
+      "description": "Specifies the TFS product version for compatibility and feature support. Default is OnPremises for TFS 2013+ and Azure DevOps Server.",
+      "type": "string"
+    },
     "Project": {
       "description": "Name of the TFS project within the collection to connect to. This is the project that will be used for migration operations.",
       "type": "string"
@@ -45,8 +49,6 @@
   "required": [
     "authentication",
     "collection",
-    "languageMaps",
-    "project",
-    "reflectedWorkItemIdField"
+    "project"
   ]
 }

--- a/docs/static/schema/schema.endpoints.tfsteamprojectendpoint.json
+++ b/docs/static/schema/schema.endpoints.tfsteamprojectendpoint.json
@@ -33,6 +33,10 @@
       "description": "missing XML code comments",
       "type": "string"
     },
+    "ProductVersion": {
+      "description": "Specifies the TFS product version for compatibility and feature support. Default is OnPremises for TFS 2013+ and Azure DevOps Server.",
+      "type": "string"
+    },
     "Project": {
       "description": "Name of the TFS project within the collection to connect to. This is the project that will be used for migration operations.",
       "type": "string"
@@ -45,8 +49,6 @@
   "required": [
     "authentication",
     "collection",
-    "languageMaps",
-    "project",
-    "reflectedWorkItemIdField"
+    "project"
   ]
 }

--- a/docs/static/schema/schema.endpoints.tfsteamsettingsendpoint.json
+++ b/docs/static/schema/schema.endpoints.tfsteamsettingsendpoint.json
@@ -33,6 +33,10 @@
       "description": "missing XML code comments",
       "type": "string"
     },
+    "ProductVersion": {
+      "description": "Specifies the TFS product version for compatibility and feature support. Default is OnPremises for TFS 2013+ and Azure DevOps Server.",
+      "type": "string"
+    },
     "Project": {
       "description": "Name of the TFS project within the collection to connect to. This is the project that will be used for migration operations.",
       "type": "string"
@@ -45,8 +49,6 @@
   "required": [
     "authentication",
     "collection",
-    "languageMaps",
-    "project",
-    "reflectedWorkItemIdField"
+    "project"
   ]
 }

--- a/docs/static/schema/schema.endpoints.tfsworkitemendpoint.json
+++ b/docs/static/schema/schema.endpoints.tfsworkitemendpoint.json
@@ -33,6 +33,10 @@
       "description": "missing XML code comments",
       "type": "string"
     },
+    "ProductVersion": {
+      "description": "Specifies the TFS product version for compatibility and feature support. Default is OnPremises for TFS 2013+ and Azure DevOps Server.",
+      "type": "string"
+    },
     "Project": {
       "description": "Name of the TFS project within the collection to connect to. This is the project that will be used for migration operations.",
       "type": "string"
@@ -49,8 +53,6 @@
   "required": [
     "authentication",
     "collection",
-    "languageMaps",
-    "project",
-    "reflectedWorkItemIdField"
+    "project"
   ]
 }

--- a/docs/static/schema/schema.processors.tfsworkitemmigrationprocessor.json
+++ b/docs/static/schema/schema.processors.tfsworkitemmigrationprocessor.json
@@ -63,16 +63,6 @@
       "description": "This is the `IEndpoint` that will be used as the Target of the Migration. Can be null for a read only processor.",
       "type": "string"
     },
-    "UpdateCreatedBy": {
-      "description": "If this is enabled the creation process on the target project will create the items with the original creation date.\r\n (Important: The item history is always pointed to the date of the migration, it's change only the data column CreateDate,\r\n not the internal create date)",
-      "type": "boolean",
-      "default": "true"
-    },
-    "UpdateCreatedDate": {
-      "description": "If this is enabled the creation process on the target project will create the items with the original creation date.\r\n (Important: The item history is always pointed to the date of the migration, it's change only the data column CreateDate,\r\n not the internal create date)",
-      "type": "boolean",
-      "default": "true"
-    },
     "WIQLQuery": {
       "description": "A work item query based on WIQL to select only important work items. To migrate all leave this empty. See [WIQL Query Bits](#wiql-query-bits)",
       "type": "string",

--- a/src/MigrationTools.Clients.TfsObjectModel/Endpoints/TfsEndpointOptions.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/Endpoints/TfsEndpointOptions.cs
@@ -19,17 +19,17 @@ namespace MigrationTools.Endpoints
         /// <summary>
         /// Represents legacy Team Foundation Server versions prior to 2013. Not technically supported but may work.
         /// </summary>
-        OnPremisesClassic,
+        OnPremisesClassic = 0,
 
         /// <summary>
         /// Represents on-premises Team Foundation Server 2013+ and Azure DevOps Server (default).
         /// </summary>
-        OnPremises,
+        OnPremises = 1,
 
         /// <summary>
         /// Represents Azure DevOps Services (cloud version).
         /// </summary>
-        Cloud
+        Cloud = 2
     }
 
     /// <summary>

--- a/src/MigrationTools.Clients.TfsObjectModel/Processors/TfsWorkItemMigrationProcessor.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/Processors/TfsWorkItemMigrationProcessor.cs
@@ -369,13 +369,10 @@ namespace MigrationTools.Processors
                 activity?.Stop();
                 activity?.SetStatus(ActivityStatusCode.Ok);
                 activity?.SetTag("http.response.status_code", "200");
-                if (Options.UpdateCreatedBy)
+                if (Target.Options.ProductVersion != Endpoints.TfsProductVersion.OnPremisesClassic)
                 {
                     newwit.Fields["System.CreatedBy"].Value = currentRevisionWorkItem.ToWorkItem().Revisions[0].Fields["System.CreatedBy"].Value;
                     workItemLog.Debug("Setting 'System.CreatedBy'={SystemCreatedBy}", currentRevisionWorkItem.ToWorkItem().Revisions[0].Fields["System.CreatedBy"].Value);
-                }
-                if (Options.UpdateCreatedDate)
-                {
                     newwit.Fields["System.CreatedDate"].Value = currentRevisionWorkItem.ToWorkItem().Revisions[0].Fields["System.CreatedDate"].Value;
                     workItemLog.Debug("Setting 'System.CreatedDate'={SystemCreatedDate}", currentRevisionWorkItem.ToWorkItem().Revisions[0].Fields["System.CreatedDate"].Value);
                 }

--- a/src/MigrationTools.Clients.TfsObjectModel/Processors/TfsWorkItemMigrationProcessorOptions.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/Processors/TfsWorkItemMigrationProcessorOptions.cs
@@ -12,24 +12,6 @@ namespace MigrationTools.Processors
     public class TfsWorkItemMigrationProcessorOptions : ProcessorOptions, IWorkItemProcessorConfig
     {
         /// <summary>
-        /// If this is enabled the creation process on the target project will create the items with the original creation date.
-        /// (Important: The item history is always pointed to the date of the migration, it's change only the data column CreateDate,
-        /// not the internal create date)
-        /// </summary>
-        /// <default>true</default>
-        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
-        public bool UpdateCreatedDate { get; set; } = true;
-
-        /// <summary>
-        /// If this is enabled the creation process on the target project will create the items with the original creation date.
-        /// (Important: The item history is always pointed to the date of the migration, it's change only the data column CreateDate,
-        /// not the internal create date)
-        /// </summary>
-        /// <default>true</default>
-        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
-        public bool UpdateCreatedBy { get; set; } = true;
-
-        /// <summary>
         /// A work item query based on WIQL to select only important work items. To migrate all leave this empty. See [WIQL Query Bits](#wiql-query-bits)
         /// </summary>
         /// <default>SELECT [System.Id] FROM WorkItems WHERE [System.TeamProject] = @TeamProject AND [System.WorkItemType] NOT IN ('Test Suite', 'Test Plan','Shared Steps','Shared Parameter','Feedback Request') ORDER BY [System.ChangedDate] desc</default>


### PR DESCRIPTION
Users are reporting confusion when rerunning the migration tool. Specifically, they expect changes to sync across but find that nothing happens when `UpdateCreatedDate` and `UpdateCreatedBy` are set to `false`.

This confusion arises because:

* When `UpdateCreatedDate` and `UpdateCreatedBy` are `false`, revisions in the source must have a higher date than the target, otherwise they are filtered out.
* This behaviour is correct but not obvious, leading users to believe updates are being skipped incorrectly.
* These flags were originally introduced only to support TFS 2008, which does not allow setting revision dates in the past.

### Current Behaviour

* If `UpdateCreatedDate` and `UpdateCreatedBy` are set to `false`, rerunning the tool does not sync new changes unless the revision date in the source is newer than the target.
* Users mistake this for incorrect syncing behaviour.

### Expected Behaviour

* The tool should make it clear that these settings are legacy, only relevant for TFS 2008, and not recommended for modern TFS/Azure DevOps versions.

### Resolution

* **Removed** `UpdateCreatedDate` and `UpdateCreatedBy` properties from `TfsWorkItemMigrationProcessor`.
* **Added** a new property `ProductVersion` on the Target to clarify intent and scope:

  * `OnPremises` (default)
  * `OnPremisesLegacy` (for older TFS versions like 2008)
  * `Cloud` (for Azure DevOps Services)

### Benefits

* Removes ambiguity around legacy flags.
* Makes it clear that behaviour differs by product version rather than hidden behind boolean switches.
* Provides a more explicit and maintainable way to configure processor behaviour.
