### PR TITLE
Validation of reflected work item ID is mandatory

### DIFF
--- a/src/MigrationTools.Clients.TfsObjectModel/Processors/TfsWorkItemTypeValidatorProcessor.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/Processors/TfsWorkItemTypeValidatorProcessor.cs
@@ -47,11 +47,16 @@ namespace MigrationTools.Processors
                 .WorkItemTypes
                 .Cast<WorkItemType>()
                 .ToList();
+            bool containsReflectedWorkItemId = CommonTools.WorkItemTypeValidatorTool
+                .ValidateReflectedWorkItemIdField(sourceWits, targetWits, Target.Options.ReflectedWorkItemIdField);
             bool validationResult = CommonTools.WorkItemTypeValidatorTool
-                .ValidateWorkItemTypes(sourceWits, targetWits, Target.Options.ReflectedWorkItemIdField);
-            if (Options.StopIfValidationFails && !validationResult)
+                .ValidateWorkItemTypes(sourceWits, targetWits);
+            if ((Options.StopIfValidationFails && !validationResult) || (!containsReflectedWorkItemId))
             {
-                Log.LogInformation($"'{nameof(Options.StopIfValidationFails)}' is set to 'true', so migration process will stop now.");
+                const string message =
+                    "Either the reflected work item type ID field '{ReflectedWorkItemIdField}' is missing in some of the target work item types"
+                    + $" or '{nameof(Options.StopIfValidationFails)}' is set to 'true', so migration process will stop now.";
+                Log.LogInformation(message, Target.Options.ReflectedWorkItemIdField);
                 Environment.Exit(-1);
             }
         }

--- a/src/MigrationTools.Clients.TfsObjectModel/Tools/TfsWorkItemTypeValidatorTool.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/Tools/TfsWorkItemTypeValidatorTool.cs
@@ -30,10 +30,55 @@ namespace MigrationTools.Tools
             Options.Normalize();
         }
 
-        public bool ValidateWorkItemTypes(
+        public bool ValidateReflectedWorkItemIdField(
             List<WorkItemType> sourceWits,
             List<WorkItemType> targetWits,
             string reflectedWorkItemIdField)
+        {
+            Log.LogInformation("Validating presence of reflected work item ID field '{reflectedWorkItemIdField}'"
+                + " in target work item types.", reflectedWorkItemIdField);
+            bool isValid = true;
+            List<WorkItemType> wits = GetTargetWitsToValidate(sourceWits, targetWits);
+            foreach (WorkItemType targetWit in wits)
+            {
+                if (targetWit.FieldDefinitions.Contains(reflectedWorkItemIdField))
+                {
+                    Log.LogDebug("  '{targetWit}' contains reflected work item ID field '{fieldName}'.",
+                        targetWit.Name, reflectedWorkItemIdField);
+                }
+                else
+                {
+                    Log.LogError("  '{targetWit}' does not contain reflected work item ID field '{fieldName}'.",
+                        targetWit.Name, reflectedWorkItemIdField);
+                    isValid = false;
+                }
+            }
+            LogReflectedWorkItemIdValidationResult(isValid, reflectedWorkItemIdField);
+            return isValid;
+        }
+
+        private List<WorkItemType> GetTargetWitsToValidate(List<WorkItemType> sourceWits, List<WorkItemType> targetWits)
+        {
+            List<WorkItemType> targetWitsToValidate = [];
+            foreach (WorkItemType sourceWit in sourceWits)
+            {
+                string sourceWitName = sourceWit.Name;
+                if (!ShouldValidateWorkItemType(sourceWitName))
+                {
+                    continue;
+                }
+                string targetWitName = GetTargetWorkItemType(sourceWitName);
+                WorkItemType targetWit = targetWits
+                    .FirstOrDefault(wit => wit.Name.Equals(targetWitName, StringComparison.OrdinalIgnoreCase));
+                if (targetWit is not null)
+                {
+                    targetWitsToValidate.Add(targetWit);
+                }
+            }
+            return targetWitsToValidate;
+        }
+
+        public bool ValidateWorkItemTypes(List<WorkItemType> sourceWits, List<WorkItemType> targetWits)
         {
             LogWorkItemTypes(sourceWits, targetWits);
 
@@ -61,10 +106,6 @@ namespace MigrationTools.Tools
                 }
                 else
                 {
-                    if (!ValidateReflectedWorkItemIdField(targetWit, reflectedWorkItemIdField))
-                    {
-                        isValid = false;
-                    }
                     if (!ValidateWorkItemTypeFields(sourceWit, targetWit))
                     {
                         isValid = false;
@@ -73,22 +114,6 @@ namespace MigrationTools.Tools
             }
             LogValidationResult(isValid);
             return isValid;
-        }
-
-        private bool ValidateReflectedWorkItemIdField(WorkItemType targetWit, string reflectedWorkItemIdField)
-        {
-            if (targetWit.FieldDefinitions.Contains(reflectedWorkItemIdField))
-            {
-                Log.LogDebug("  '{targetWit}' contains reflected work item ID field '{fieldName}'.",
-                    targetWit.Name, reflectedWorkItemIdField);
-            }
-            else
-            {
-                Log.LogWarning("  '{targetWit}' does not contain reflected work item ID field '{fieldName}'.",
-                    targetWit.Name, reflectedWorkItemIdField);
-                return false;
-            }
-            return true;
         }
 
         private bool ValidateWorkItemTypeFields(WorkItemType sourceWit, WorkItemType targetWit)
@@ -264,6 +289,21 @@ namespace MigrationTools.Tools
                 string.Join(", ", sourceWits.Select(wit => wit.Name)));
             Log.LogInformation("Target work item types are: {targetWits}.",
                 string.Join(", ", targetWits.Select(wit => wit.Name)));
+        }
+
+        private void LogReflectedWorkItemIdValidationResult(bool isValid, string reflectedWorkItemIdField)
+        {
+            if (isValid)
+            {
+                Log.LogInformation("All work item types have reflected work item ID field '{reflectedWorkItemIdField}'.",
+                    reflectedWorkItemIdField);
+                return;
+            }
+
+            const string message = "Reflected work item ID field is mandatory for work item migration."
+                + " You can configure name of this field in target TFS endpoint settings as 'ReflectedWorkItemIdField' property."
+                + " Your current configured name of the field is '{reflectedWorkItemIdField}'.";
+            Log.LogError(message, reflectedWorkItemIdField);
         }
 
         private void LogValidationResult(bool isValid)


### PR DESCRIPTION
This PR solves the first item in [improve work item type validation list](https://github.com/nkdAgility/azure-devops-migration-tools/discussions/2951).

Reflected work item ID is mandatory for proper work item migration. So validation of this field is performed always, even if the validator tool itself is disabled. This field was validated always before my addition to validate full work item types, so I just returned back the old behavior.

