### PR TITLE
Fix regex pattern in TfsWorkItemMigrationProcessorOptionsValidator 

### DIFF
--- a/src/MigrationTools.Clients.TfsObjectModel/Processors/TfsWorkItemMigrationProcessorOptionsValidator.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/Processors/TfsWorkItemMigrationProcessorOptionsValidator.cs
@@ -13,7 +13,7 @@ namespace MigrationTools.Processors
     {
         public ValidateOptionsResult Validate(string name, TfsWorkItemMigrationProcessorOptions options)
         {
-            
+
             var errors = new List<string>();
             ValidateOptionsResult baseResult = options.Validate(name, options);
             if (baseResult != ValidateOptionsResult.Success)
@@ -50,7 +50,7 @@ namespace MigrationTools.Processors
         private bool ContainsTeamProjectCondition(string query)
         {
             // Regex to match '[System.TeamProject] = @TeamProject'
-            string teamProjectPattern = @"\[System\.TeamProject\]\s*=\s*@TeamProject";
+            string teamProjectPattern = @"\[System\.TeamProject\]\s*=\s*'?@TeamProject'?";
 
             return Regex.IsMatch(query, teamProjectPattern, RegexOptions.IgnoreCase);
         }


### PR DESCRIPTION
This pull request updates the regular expression used to detect the `[System.TeamProject] = @TeamProject` condition in queries, making it more robust by allowing optional single quotes around `@TeamProject`.

- Improved query validation:
  * Updated the regular expression in `TfsWorkItemMigrationProcessorOptionsValidator.cs` to match `[System.TeamProject] = @TeamProject` with or without single quotes around `@TeamProject`, increasing flexibility and reducing false negatives.

Fixes  #2915

Co-Authored-By:  colin-cdp <colin-cdp@users.noreply.github.com>


