### PR TITLE
Implement default exclude list for work item type validation

### DIFF
--- a/src/MigrationTools.Clients.TfsObjectModel/ServiceCollectionExtensions.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/ServiceCollectionExtensions.cs
@@ -26,7 +26,7 @@ namespace MigrationTools
             context.AddSingleton<TfsRevisionManagerTool>().AddMigrationToolsOptions<TfsRevisionManagerToolOptions>(configuration);
             context.AddSingleton<TfsTeamSettingsTool>().AddMigrationToolsOptions<TfsTeamSettingsToolOptions>(configuration);
             context.AddSingleton<TfsChangeSetMappingTool>().AddMigrationToolsOptions<TfsChangeSetMappingToolOptions>(configuration);
-            context.AddSingleton<TfsWorkItemTypeValidatorTool>().AddMigrationToolsOptions<TfsWorkItemTypeValidatorToolOptions>(configuration);
+            context.AddSingleton<TfsWorkItemTypeValidatorTool>().AddMigrationToolsOptions<TfsWorkItemTypeValidatorToolOptions, TfsWorkItemTypeValidatorToolOptionsValidator>(configuration);
         }
 
         public static void AddMigrationToolServicesForClientTfs_Processors(this IServiceCollection context)

--- a/src/MigrationTools.Clients.TfsObjectModel/Tools/TfsWorkItemTypeValidatorTool.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/Tools/TfsWorkItemTypeValidatorTool.cs
@@ -254,6 +254,14 @@ namespace MigrationTools.Tools
                     workItemTypeName);
                 return false;
             }
+            else if ((Options.ExcludeWorkItemtypes.Count > 0)
+                && Options.ExcludeWorkItemtypes.Contains(workItemTypeName, StringComparer.OrdinalIgnoreCase))
+            {
+                Log.LogInformation(
+                    "Skipping validation of work item type '{sourceWit}' because it is excluded from validation list.",
+                    workItemTypeName);
+                return false;
+            }
             return true;
         }
 

--- a/src/MigrationTools.Clients.TfsObjectModel/Tools/TfsWorkItemTypeValidatorToolOptions.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/Tools/TfsWorkItemTypeValidatorToolOptions.cs
@@ -22,6 +22,25 @@ namespace MigrationTools.Tools
         public List<string> IncludeWorkItemtypes { get; set; } = [];
 
         /// <summary>
+        /// List of work item types which will be excluded from validation.
+        /// </summary>
+        public List<string> ExcludeWorkItemtypes { get; set; } = [
+            "Code Review Request",
+            "Code Review Response",
+            "Feedback Request",
+            "Feedback Response",
+            "Impediment",
+            "Quality of Service Requirement",
+            "Release",
+            "Risk",
+            "Shared Parameter",
+            "Shared Steps",
+            "Test Case",
+            "Test Plan",
+            "Test Suite",
+        ];
+
+        /// <summary>
         /// Field reference name mappings. Key is work item type name, value is dictionary of mapping source filed name to
         /// target field name. Target field name can be empty string to indicate that this field will not be validated in target.
         /// As work item type name, you can use <c>*</c> to define mappings which will be applied to all work item types.
@@ -31,17 +50,17 @@ namespace MigrationTools.Tools
 
         /// <summary>
         /// <para>
-        /// List of target fields that are considered as <c>fixed</c>.  
-        /// A field marked as fixed will not stop the migration if differences are found.  
-        /// Instead of a warning, only an informational message will be logged.  
+        /// List of target fields that are considered as <c>fixed</c>.
+        /// A field marked as fixed will not stop the migration if differences are found.
+        /// Instead of a warning, only an informational message will be logged.
         /// </para>
         /// <para>
-        /// Use this list when you already know about the differences and have resolved them,  
-        /// for example by using <see cref="FieldMappingTool"/>.  
+        /// Use this list when you already know about the differences and have resolved them,
+        /// for example by using <see cref="FieldMappingTool"/>.
         /// </para>
         /// <para>
-        /// The key is the target work item type name.  
-        /// You can also use <c>*</c> to define fixed fields that apply to all work item types.  
+        /// The key is the target work item type name.
+        /// You can also use <c>*</c> to define fixed fields that apply to all work item types.
         /// </para>
         /// </summary>
         /// <default>null</default>
@@ -84,6 +103,7 @@ namespace MigrationTools.Tools
             }
 
             IncludeWorkItemtypes ??= [];
+            ExcludeWorkItemtypes ??= [];
             FixedTargetFields = newFixedFields;
             SourceFieldMappings = newMappings;
             _isNormalized = true;

--- a/src/MigrationTools.Clients.TfsObjectModel/Tools/TfsWorkItemTypeValidatorToolOptionsValidator.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/Tools/TfsWorkItemTypeValidatorToolOptionsValidator.cs
@@ -1,0 +1,21 @@
+﻿using Microsoft.Extensions.Options;
+
+namespace MigrationTools.Tools
+{
+    public class TfsWorkItemTypeValidatorToolOptionsValidator : IValidateOptions<TfsWorkItemTypeValidatorToolOptions>
+    {
+        public ValidateOptionsResult Validate(string name, TfsWorkItemTypeValidatorToolOptions options)
+        {
+            int includedCount = options.IncludeWorkItemtypes?.Count ?? 0;
+            int excludedCount = options.ExcludeWorkItemtypes?.Count ?? 0;
+
+            if ((includedCount > 0) && (excludedCount > 0))
+            {
+                const string msg = $"'{nameof(options.IncludeWorkItemtypes)}' and '{nameof(options.ExcludeWorkItemtypes)}'"
+                    + $" cannot be set both at the same time.";
+                return ValidateOptionsResult.Fail(msg);
+            }
+            return ValidateOptionsResult.Success;
+        }
+    }
+}

--- a/src/MigrationTools.Host/Commands/ExecuteMigrationCommand.cs
+++ b/src/MigrationTools.Host/Commands/ExecuteMigrationCommand.cs
@@ -65,7 +65,7 @@ namespace MigrationTools.Host.Commands
                 CommandActivity.RecordException(ex);
                 _logger.LogCritical("The config contains some invalid options. Please check the list below and refer to https://devopsmigration.io/ for the specific configration options.");
                 _logger.LogCritical("------------");
-                _logger.LogCritical("OptionName: {OptionsName}", ex.OptionsName);
+                _logger.LogCritical("OptionName: {OptionsName}", GetOptionsName(ex));
                 _logger.LogCritical("The following options are invalid:");
                 foreach (var failure in ex.Failures)
                 {
@@ -88,6 +88,16 @@ namespace MigrationTools.Host.Commands
                 _appLifetime.StopApplication();
             }
             return Task.FromResult(_exitCode);
+        }
+
+        private string GetOptionsName(OptionsValidationException ex)
+        {
+            IOptions options = Activator.CreateInstance(ex.OptionsType) as IOptions;
+            if (options is not null)
+            {
+                return options.ConfigurationMetadata.OptionFor;
+            }
+            return string.Empty;
         }
     }
 }


### PR DESCRIPTION
This PR solves the second item in [improve work item type validation list](https://github.com/nkdAgility/azure-devops-migration-tools/discussions/2951).

PR is only a draft for now. What needs to be changed is the place of default excluded WITs. I have it directly in source now, but it is not good. This list should be somewhere in configuration file. But I do not know where to write it, to make this list default in configuration. So I need your help here @MrHinsh.

Also check the list itself, of you are happy with these WITs to be excluded by default.

I kept in configuration `IncludeWorkItemtypes` list, but both lists can not be set at the same time. I do not want to remote this list, because it means to make some configuration update. But if you think that it will be better, just navigate me how to do it.

In longer run, I believe, that only the `ExcludeWorkItemtypes` will be used, mailny because I expect it to be defined by default in configuration, so people will just use this and not include list.

## Other changes

I made a small change in `ExecuteMigrationCommand`. The value of `ex.OptionsName` in log was always empty. `OptionsName` is used only, whe we use _named options_ – which we are not. We use just simple options pattern, where the options have default name of empty string.