### PR TITLE
add query to logging in shared queries exception

### DIFF
--- a/src/MigrationTools.Clients.TfsObjectModel/Processors/TfsSharedQueryProcessor.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/Processors/TfsSharedQueryProcessor.cs
@@ -178,8 +178,8 @@ namespace MigrationTools.Processors
             catch (Exception ex)
             {
                 _totalQueryFailed++;
-                Log.LogDebug("Source Query: '{query}'");
-                Log.LogDebug("Target Query: '{fixedQueryText}'");
+                Log.LogDebug("Source Query: '{query}'", query);
+                Log.LogDebug("Target Query: '{fixedQueryText}'", fixedQueryText);
                 Log.LogError(ex, "Error saving query '{queryName}', probably due to invalid area or iteration paths", query.Name);
                 targetHierarchy.Refresh(); // get the tree without the last edit
             }


### PR DESCRIPTION
On a failed migration test for the shared quieries, I missed the information about the query string in the log.