### PR TITLE
Update to field to fields

### DIFF
--- a/src/MigrationTools.Clients.TfsObjectModel/Tools/FieldMappingTool/FieldMaps/FieldToFieldMap.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/Tools/FieldMappingTool/FieldMaps/FieldToFieldMap.cs
@@ -66,9 +66,17 @@ public class FieldToFieldMap : FieldMapBase
             value = Config.defaultValue;
         }
 
-        target.Fields[Config.targetField].Value = value;
-        Log.LogDebug("FieldToFieldMap: [UPDATE] Successfully mapped field {SourceField} to {TargetField} with value '{Value}' using mode {FieldMapMode} | Source WorkItem: {SourceId} -> Target WorkItem: {TargetId}", 
-            Config.sourceField, Config.targetField, value, Config.fieldMapMode, source.Id, target.Id);
+        if (!string.IsNullOrEmpty(value))
+        {
+            target.Fields[Config.targetField].Value = value;
+            Log.LogDebug("FieldToFieldMap: [UPDATE] Successfully mapped field {SourceField} to {TargetField} with value '{Value}' using mode {FieldMapMode} | Source WorkItem: {SourceId} -> Target WorkItem: {TargetId}",
+               Config.sourceField, Config.targetField, value, Config.fieldMapMode, source.Id, target.Id);
+        }
+        else
+        {
+            Log.LogDebug("FieldToFieldMap: [SKIPPED] Proposed value is empty {SourceField} to {TargetField} with value '{Value}' using mode {FieldMapMode} | Source WorkItem: {SourceId} -> Target WorkItem: {TargetId}",
+               Config.sourceField, Config.targetField, value, Config.fieldMapMode, source.Id, target.Id);
+        }
     }
 
     private bool IsValid(WorkItem source, WorkItem target)

--- a/src/MigrationTools.Clients.TfsObjectModel/Tools/TfsEmbededImagesTool.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/Tools/TfsEmbededImagesTool.cs
@@ -150,6 +150,10 @@ namespace MigrationTools.Tools
                         }
                         else
                         {
+                            // Provide more detailed error information for non-404 failures
+                            Log.LogWarning("EmbededImagesRepairEnricher: Failed to download image {MatchValue} from WorkItem {WorkItemId}, Field {FieldName}. Status: {StatusCode} ({ReasonPhrase})",
+                                matchedSourceUri, targetWorkItem.Id, sourceFieldName, (int)result.StatusCode, result.ReasonPhrase);
+                            
                             result.EnsureSuccessStatusCode();
                         }
                     }

--- a/src/MigrationTools/Tools/Infrastructure/EmbededImagesRepairEnricherBase.cs
+++ b/src/MigrationTools/Tools/Infrastructure/EmbededImagesRepairEnricherBase.cs
@@ -18,7 +18,7 @@ namespace MigrationTools.Tools.Infrastructure
 
         protected EmbededImagesRepairToolBase(IOptions<ToolOptions> options, IServiceProvider services, ILogger<ITool> logger, ITelemetryLogger telemetry) : base(options, services, logger, telemetry)
         {
-            _httpClientHandler = new HttpClientHandler { AllowAutoRedirect = false, UseDefaultCredentials = true, AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate };
+            _httpClientHandler = new HttpClientHandler { AllowAutoRedirect = true, UseDefaultCredentials = true, AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate };
         }
 
         /**
@@ -40,6 +40,13 @@ namespace MigrationTools.Tools.Infrastructure
                         stream.CopyTo(fileWriter);
                     }
                 }
+            }
+            else
+            {
+                // Log details about non-success responses for debugging
+                var logger = Microsoft.Extensions.Logging.LoggerFactory.Create(builder => builder.AddConsole()).CreateLogger("EmbededImagesRepairEnricher");
+                logger.LogDebug("DownloadFile failed for URL {Url}. Status: {StatusCode} ({ReasonPhrase}). Location header: {LocationHeader}",
+                    url, (int)response.StatusCode, response.ReasonPhrase, response.Headers.Location?.ToString() ?? "None");
             }
 
             return response;


### PR DESCRIPTION
This pull request introduces improvements to error handling and logging for image download and field mapping operations in the migration tools. The most notable changes are enhanced diagnostics for failed image downloads and field value mappings, and a modification to HTTP client configuration to allow redirects.

**Error handling and diagnostics improvements:**

* Added detailed logging for failed image downloads in `TfsEmbededImagesTool.cs`, including HTTP status codes and reason phrases for non-404 errors.
* Enhanced debugging information in `EmbededImagesRepairEnricherBase.cs` by logging failed HTTP responses, including status codes, reason phrases, and location headers.

**Field mapping logic:**

* Updated `FieldToFieldMap.cs` to log when a field mapping is skipped due to an empty value, providing clearer diagnostics for mapping operations.

**HTTP client configuration:**

* Changed the HTTP client handler in `EmbededImagesRepairEnricherBase.cs` to allow automatic redirects, improving compatibility with redirected image URLs.