### PR TITLE
Fix measuring duration of processor and command

### DIFF
--- a/src/MigrationTools.Host/Commands/CommandBase.cs
+++ b/src/MigrationTools.Host/Commands/CommandBase.cs
@@ -65,7 +65,6 @@ namespace MigrationTools.Host.Commands
                 {
                     Log.Debug("Disabling Telemetry {CommandName}", this.GetType().Name);
                     CommandActivity.AddTag("DisableTelemetry", settings.DisableTelemetry);
-                    CommandActivity.Stop();
                     ActivitySourceProvider.DisableActivitySource();
                 }
                 //Enable Debug Trace
@@ -105,7 +104,7 @@ namespace MigrationTools.Host.Commands
 
         internal virtual Task<int> ExecuteInternalAsync(CommandContext context, TSettings settings)
         {
-            return Task.FromResult( 0);
+            return Task.FromResult(0);
         }
 
         public void RunStartupLogic(TSettings settings)

--- a/src/MigrationTools/Processors/Infrastructure/Processor.cs
+++ b/src/MigrationTools/Processors/Infrastructure/Processor.cs
@@ -1,14 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.ComponentModel.Design;
 using System.Diagnostics;
 using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using MigrationTools._EngineV1.Configuration;
 using MigrationTools.Endpoints;
-using MigrationTools.Endpoints.Infrastructure;
 using MigrationTools.Enrichers;
 using MigrationTools.Exceptions;
 using MigrationTools.Services;
@@ -139,6 +136,7 @@ namespace MigrationTools.Processors.Infrastructure
                 }
                 finally
                 {
+                    ProcessorActivity.Stop();
                     Log.LogInformation("{ProcessorName} completed in {ProcessorDuration} ", Name, ProcessorActivity.Duration.ToString("c"));
                 }
 


### PR DESCRIPTION
I noticed this when i had my migration run for a long time and at the end I wanted to know, how long it really took. The migration duration was zero.

## Processor

Although the log outputs `Duration` of the processor activity, this is always zero. Its because `Duration` is not dynamic – it does not return real current duration. Its value is calculated and updated only when `Stop()` is called.

## Command base

Basically the same problem as in `Processor`, but from the other side. The activity is stopped immediately after it is started, so it reports zero duration at the end. Even when the telemetry is disabled, there is no need to not measure duration of the command. Because even wihout telemetry, we want to see duration in the log outputs. And `Stop()` basically does nothing just updates duration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Enhanced activity lifecycle management within telemetry and processing workflows.
  * Removed unused code dependencies.

* **Style**
  * Minor formatting improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->