### PR TITLE
Update TfsWorkItemTypeValidatorTool documentation

### DIFF
--- a/appsettings.json
+++ b/appsettings.json
@@ -181,10 +181,9 @@
             },
             "TfsWorkItemTypeValidatorTool": {
                 "Enabled": true,
-                "ExcludeWorkItemtypes": [],
+                "ExcludeWorkItemTypes": [],
                 "ExcludeDefaultWorkItemTypes": true,
-                "SourceFieldMappings": [],
-                "FixedTargetFields": []
+                "ExcludeSourceFields": {}
             }
         },
         "CommonToolSamples": {
@@ -196,15 +195,13 @@
             },
             "TfsWorkItemTypeValidatorTool": {
                 "Enabled": true,
-                "ExcludeWorkItemtypes": [
-                ],
-                "SourceFieldMappings": {
-                    "User Story": {
-                        "Microsoft.VSTS.Common.Prirucka": "Custom.Prirucka"
-                    }
-                },
-                "FixedTargetFields": {
-                    "User Story": ["Custom.Prirucka"]
+                "ExcludeWorkItemTypes": [],
+                "ExcludeDefaultWorkItemTypes": true,
+                "ExcludeSourceFields": {
+                    "Bug": [
+                        "Microsoft.VSTS.Common.AcceptanceCriteria",
+                        "Microsoft.VSTS.Scheduling.Effort"
+                    ]
                 }
             },
             "FieldMappingTool": {

--- a/docs/data/classes/reference.tools.tfsworkitemtypevalidatortool.yaml
+++ b/docs/data/classes/reference.tools.tfsworkitemtypevalidatortool.yaml
@@ -12,9 +12,8 @@ configurationSamples:
           "TfsWorkItemTypeValidatorTool": {
             "Enabled": "True",
             "ExcludeDefaultWorkItemTypes": "True",
-            "ExcludeWorkItemtypes": null,
-            "FixedTargetFields": null,
-            "SourceFieldMappings": null
+            "ExcludeSourceFields": null,
+            "ExcludeWorkItemTypes": null
           }
         }
       }
@@ -30,17 +29,14 @@ configurationSamples:
         "CommonTools": {
           "TfsWorkItemTypeValidatorTool": {
             "Enabled": "True",
-            "ExcludeWorkItemtypes": null,
-            "FixedTargetFields": {
-              "User Story": [
-                "Custom.Prirucka"
+            "ExcludeDefaultWorkItemTypes": "True",
+            "ExcludeSourceFields": {
+              "Bug": [
+                "Microsoft.VSTS.Common.AcceptanceCriteria",
+                "Microsoft.VSTS.Scheduling.Effort"
               ]
             },
-            "SourceFieldMappings": {
-              "User Story": {
-                "Microsoft.VSTS.Common.Prirucka": "Custom.Prirucka"
-              }
-            }
+            "ExcludeWorkItemTypes": null
           }
         }
       }
@@ -56,7 +52,12 @@ configurationSamples:
       "IncludeWorkItemTypes": [],
       "ExcludeWorkItemTypes": [],
       "ExcludeDefaultWorkItemTypes": true,
-      "ExcludeSourceFields": {}
+      "ExcludeSourceFields": {
+        "Bug": [
+          "Microsoft.VSTS.Common.AcceptanceCriteria",
+          "Microsoft.VSTS.Scheduling.Effort"
+        ]
+      }
     }
   sampleFor: MigrationTools.Tools.TfsWorkItemTypeValidatorToolOptions
 description: >-
@@ -83,13 +84,13 @@ options:
 - parameterName: ExcludeSourceFields
   type: Dictionary
   description: >-
-    List of fields in source work itemt types, that are excluded from validation.
+    List of fields in source work item types, that are excluded from validation.
      Fields excluded from validation are still validated and all found issues are logged.
      But the result of the validation is 'valid' and the issues are logged as information instead of warning.
 
-     The key is the source work item type name.
-     You can also use `*` to exclude fields from all source work item types.
-  defaultValue: null
+     The key is the source work item type name. The value is list of fields' reference names which are excluded.
+     You can also use `*` as key to exclude fields from all source work item types.
+  defaultValue: Empty dictionary
   isRequired: false
   dotNetType: System.Collections.Generic.Dictionary`2[[System.String, System.Private.CoreLib, Version=8.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[System.Collections.Generic.List`1[[System.String, System.Private.CoreLib, Version=8.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]], System.Private.CoreLib, Version=8.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]], System.Private.CoreLib, Version=8.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e
 - parameterName: ExcludeWorkItemTypes

--- a/docs/static/schema/configuration.schema.json
+++ b/docs/static/schema/configuration.schema.json
@@ -2473,9 +2473,9 @@
                   "type": "boolean"
                 },
                 "ExcludeSourceFields": {
-                  "description": "List of fields in source work itemt types, that are excluded from validation.\r\n Fields excluded from validation are still validated and all found issues are logged.\r\n But the result of the validation is 'valid' and the issues are logged as information instead of warning.\r\n\n The key is the source work item type name.\r\n You can also use `*` to exclude fields from all source work item types.",
+                  "description": "List of fields in source work item types, that are excluded from validation.\r\n Fields excluded from validation are still validated and all found issues are logged.\r\n But the result of the validation is 'valid' and the issues are logged as information instead of warning.\r\n\n The key is the source work item type name. The value is list of fields' reference names which are excluded.\r\n You can also use `*` as key to exclude fields from all source work item types.",
                   "type": "object",
-                  "default": "null",
+                  "default": "Empty dictionary",
                   "additionalProperties": {
                     "type": "array",
                     "prefixItems": [

--- a/docs/static/schema/schema.tools.tfsworkitemtypevalidatortool.json
+++ b/docs/static/schema/schema.tools.tfsworkitemtypevalidatortool.json
@@ -15,9 +15,9 @@
       "type": "boolean"
     },
     "ExcludeSourceFields": {
-      "description": "List of fields in source work itemt types, that are excluded from validation.\r\n Fields excluded from validation are still validated and all found issues are logged.\r\n But the result of the validation is 'valid' and the issues are logged as information instead of warning.\r\n\n The key is the source work item type name.\r\n You can also use `*` to exclude fields from all source work item types.",
+      "description": "List of fields in source work item types, that are excluded from validation.\r\n Fields excluded from validation are still validated and all found issues are logged.\r\n But the result of the validation is 'valid' and the issues are logged as information instead of warning.\r\n\n The key is the source work item type name. The value is list of fields' reference names which are excluded.\r\n You can also use `*` as key to exclude fields from all source work item types.",
       "type": "object",
-      "default": "null"
+      "default": "Empty dictionary"
     },
     "ExcludeWorkItemTypes": {
       "description": "List of work item types which will be excluded from validation.",

--- a/src/MigrationTools.Clients.TfsObjectModel/Tools/TfsWorkItemTypeValidatorToolOptions.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/Tools/TfsWorkItemTypeValidatorToolOptions.cs
@@ -43,16 +43,16 @@ namespace MigrationTools.Tools
 
         /// <summary>
         /// <para>
-        /// List of fields in source work itemt types, that are excluded from validation.
+        /// List of fields in source work item types, that are excluded from validation.
         /// Fields excluded from validation are still validated and all found issues are logged.
         /// But the result of the validation is 'valid' and the issues are logged as information instead of warning.
         /// </para>
         /// <para>
-        /// The key is the source work item type name.
-        /// You can also use <c>*</c> to exclude fields from all source work item types.
+        /// The key is the source work item type name. The value is list of fields' reference names which are excluded.
+        /// You can also use <c>*</c> as key to exclude fields from all source work item types.
         /// </para>
         /// </summary>
-        /// <default>null</default>
+        /// <default>Empty dictionary</default>
         public Dictionary<string, List<string>> ExcludeSourceFields { get; set; } = [];
 
         /// <summary>


### PR DESCRIPTION
Update documentation of `TfsWorkItemTypeValidator` [based on this issue](https://github.com/nkdAgility/azure-devops-migration-tools/discussions/2903#discussioncomment-14895758).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Renamed configuration key to ExcludeWorkItemTypes and replaced per-field mappings with per-work-item-type excluded-field lists (ExcludeSourceFields).
  * Added ExcludeDefaultWorkItemTypes and ExcludeWorkItemTypes entries to control which types are skipped.

* **Documentation**
  * Updated docs and schema defaults to describe the new ExcludeSourceFields structure, wildcard support and updated default values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->