### PR TITLE
Refactor GetFieldMappings for missing mappings

### DIFF
--- a/src/MigrationTools/Tools/FieldMappingTool.cs
+++ b/src/MigrationTools/Tools/FieldMappingTool.cs
@@ -73,15 +73,16 @@ namespace MigrationTools.Tools
 
         public List<IFieldMap> GetFieldMappings(string witName)
         {
-            if (_fieldMaps.TryGetValue("*", out List<IFieldMap> fieldMaps))
+            var result = new List<IFieldMap>();
+            if (_fieldMaps.TryGetValue("*", out var globalMaps))
             {
-                return fieldMaps;
+                result.AddRange(globalMaps);
             }
-            else if (_fieldMaps.TryGetValue(witName, out fieldMaps))
+            if (_fieldMaps.TryGetValue(witName, out var specificMaps))
             {
-                return fieldMaps;
+                result.AddRange(specificMaps);
             }
-            return [];
+            return result;
         }
 
         public void ApplyFieldMappings(WorkItemData source, WorkItemData target)


### PR DESCRIPTION
Refactored the `GetFieldMappings` method in `FieldMappingTool.cs` to improve code clarity and functionality. Introduced a `result` list to aggregate both global (`"*"` wildcard) and specific mappings for a given work item type. The method now returns a combined list of mappings, ensuring both global and specific mappings are considered when applicable.

Co-authored-by: Mattias Nielsen <mattiascnielsen@gmail.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved field mapping logic to now aggregate both global and work item type-specific mappings together, ensuring all applicable mappings are available simultaneously rather than selecting one or the other.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->