### PR TITLE
Upgrade projects to .NET 10.0 framework

### DIFF
--- a/src/MigrationTools.Clients.AzureDevops.Rest/MigrationTools.Clients.AzureDevops.Rest.csproj
+++ b/src/MigrationTools.Clients.AzureDevops.Rest/MigrationTools.Clients.AzureDevops.Rest.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net10.0</TargetFrameworks>
     <Product>MigrationTools.Clients.AzureDevops.Rest</Product>
   </PropertyGroup>
 

--- a/src/MigrationTools.Clients.FileSystem/MigrationTools.Clients.FileSystem.csproj
+++ b/src/MigrationTools.Clients.FileSystem/MigrationTools.Clients.FileSystem.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net10.0</TargetFrameworks>
     <Product>MigrationTools.Sinks.FileSystem</Product>
     <RootNamespace>MigrationTools</RootNamespace>
   </PropertyGroup>

--- a/src/MigrationTools.ConsoleCore/MigrationTools.ConsoleCore.csproj
+++ b/src/MigrationTools.ConsoleCore/MigrationTools.ConsoleCore.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Product>Azure DevOps Migration Tools [REST API]</Product>
     <AssemblyName>devopsmigration</AssemblyName>
   </PropertyGroup>

--- a/src/MigrationTools.ConsoleDataGenerator/MigrationTools.ConsoleDataGenerator.csproj
+++ b/src/MigrationTools.ConsoleDataGenerator/MigrationTools.ConsoleDataGenerator.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/MigrationTools.Host/MigrationTools.Host.csproj
+++ b/src/MigrationTools.Host/MigrationTools.Host.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net10.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/MigrationTools.Telemetery/MigrationTools.Telemetery.csproj
+++ b/src/MigrationTools.Telemetery/MigrationTools.Telemetery.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/MigrationTools/MigrationTools.csproj
+++ b/src/MigrationTools/MigrationTools.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net10.0</TargetFrameworks>
     <Product>Azure DevOps Migration Tools API</Product>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Description>Reference API for creating plugins for the Azure DevOps Migration Tools</Description>


### PR DESCRIPTION
Updated the target framework for multiple projects from `net8.0` to `net10.0` to leverage the latest features and improvements in the .NET ecosystem.

The following projects were updated:
- MigrationTools.Clients.AzureDevops.Rest.csproj
- MigrationTools.Clients.FileSystem.csproj
- MigrationTools.ConsoleCore.csproj
- MigrationTools.ConsoleDataGenerator.csproj
- MigrationTools.Host.csproj
- MigrationTools.Telemetery.csproj
- MigrationTools.csproj

Maintained compatibility with `netstandard2.0` where applicable. No changes were made to additional metadata or properties.