### PR TITLE
Add project validation and retrieval functionality

### DIFF
--- a/src/MigrationTools.Clients.TfsObjectModel/Clients/TfsWorkItemMigrationClient.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/Clients/TfsWorkItemMigrationClient.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Text;
 using Microsoft.Extensions.Options;
 using Microsoft.TeamFoundation.Client;
+using Microsoft.TeamFoundation.Core.WebApi;
 using Microsoft.TeamFoundation.WorkItemTracking.Client;
 using MigrationTools._EngineV1.DataContracts;
 using MigrationTools.DataContracts;
@@ -343,6 +344,16 @@ namespace MigrationTools.Clients
                 }
                 return store;
             }
+        }
+
+        public override List<ProjectData> GetProjects()
+        {
+            List<ProjectData> projects = new List<ProjectData>();
+            foreach (Project p in Store.Projects)
+            {
+                projects.Add(p?.ToProjectData());
+            }
+            return projects;
         }
     }
 }

--- a/src/MigrationTools.Clients.TfsObjectModel/Processors/TfsWorkItemMigrationProcessor.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/Processors/TfsWorkItemMigrationProcessor.cs
@@ -123,6 +123,8 @@ namespace MigrationTools.Processors
 
             ValidateWorkItemTypes();
 
+            ValidateProject();
+
             CommonTools.NodeStructure.ProcessorExecutionBegin(this);
             if (CommonTools.TeamSettings.Enabled)
             {
@@ -245,6 +247,45 @@ namespace MigrationTools.Processors
                 }
 
             }
+        }
+
+        private void ValidateProject()
+        {
+            Log.LogInformation("[ValidateProject]");
+            Log.LogInformation("------------------------------------");
+            Log.LogInformation("Source Project Check");
+            Log.LogInformation("------------------------------------");
+            var sourceProjectName = Source.Options.Project;
+            var sourceProjects = Source.WorkItems.GetProjects();
+            var foundSourceProject = sourceProjects.FirstOrDefault(p => p.Name.Equals(sourceProjectName, StringComparison.OrdinalIgnoreCase));
+            if (foundSourceProject == null)
+            {
+                Log.LogError("Source project '{ProjectName}' not found!", sourceProjectName);
+                Log.LogInformation("Available projects are: {@sourceProjects}", string.Join(", ", sourceProjects.Select(p => p.Name)));
+                Environment.Exit(-1);
+            }
+            else
+            {
+                Log.LogInformation("Found source project as {@sourceProject}", foundSourceProject.Name);
+            }
+            Log.LogInformation("------------------------------------");
+            Log.LogInformation("Target Project Check");
+            Log.LogInformation("------------------------------------");
+            var targetProjectName = Target.Options.Project;
+            var targetProjects = Target.WorkItems.GetProjects();
+            var foundTargetProject = targetProjects.FirstOrDefault(p => p.Name.Equals(targetProjectName, StringComparison.OrdinalIgnoreCase));
+            if (foundTargetProject == null)
+            {
+                Log.LogError("Target project '{ProjectName}' not found!", targetProjectName);
+                Log.LogInformation("Available projects are: {@targetProjects}", string.Join(", ", targetProjects.Select(p => p.Name)));
+                Environment.Exit(-1);
+            }
+            else
+            {
+                Log.LogInformation("Found target project as {@targetProject}", foundTargetProject.Name);
+            }
+
+            Log.LogInformation("[/ValidateProject]");
         }
 
         private void ValidateWorkItemTypes()

--- a/src/MigrationTools.Tests/Core/Clients/WorkItemMigrationClientMock.cs
+++ b/src/MigrationTools.Tests/Core/Clients/WorkItemMigrationClientMock.cs
@@ -165,5 +165,10 @@ namespace MigrationTools.Clients.Tests
         {
             throw new System.NotImplementedException();
         }
+
+        public List<ProjectData> GetProjects()
+        {
+            throw new System.NotImplementedException();
+        }
     }
 }

--- a/src/MigrationTools/_EngineV1/Clients/IWorkItemMigrationClient.cs
+++ b/src/MigrationTools/_EngineV1/Clients/IWorkItemMigrationClient.cs
@@ -14,6 +14,8 @@ namespace MigrationTools.Clients
 
         ProjectData GetProject();
 
+        List<ProjectData> GetProjects();
+
         List<WorkItemData> GetWorkItems();
 
         WorkItemData GetWorkItem(string id, bool stopOnError = true);

--- a/src/MigrationTools/_EngineV1/Clients/WorkItemMigrationClientBase.cs
+++ b/src/MigrationTools/_EngineV1/Clients/WorkItemMigrationClientBase.cs
@@ -79,5 +79,10 @@ namespace MigrationTools.Clients
             }
             return null;
         }
+
+        public abstract List<ProjectData> GetProjects();
+
+
+
     }
 }


### PR DESCRIPTION
Introduced `GetProjects` method to `IWorkItemMigrationClient` and its implementations, enabling retrieval of project lists. Added `ValidateProject` method in `TfsWorkItemMigrationProcessor` to ensure source and target projects exist before migration. Updated `TfsWorkItemMigrationProcessor` to call `ValidateProject` during execution.

Included `System.Collections.Generic` namespace in `TfsWorkItemMigrationClient.cs` to support generic collections. Made minor formatting adjustments to maintain code structure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added project retrieval functionality to migration clients across the platform.
  * Introduced project validation that verifies source and target projects exist before work item migration processing begins.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->