### PR TITLE
Add version command line option

### DIFF
--- a/src/MigrationTools.Host.Tests/Commands/VersionCommandTests.cs
+++ b/src/MigrationTools.Host.Tests/Commands/VersionCommandTests.cs
@@ -16,6 +16,12 @@ namespace MigrationTools.Host.Tests.Commands
             host = MigrationToolHost.CreateDefaultBuilder(new string[] { "version", "--skipVersionCheck" }).Build();
         }
 
+        [TestCleanup]
+        public void Cleanup()
+        {
+            host?.Dispose();
+        }
+
         [TestMethod, TestCategory("L0")]
         public void VersionCommand_ServiceResolution_ShouldSucceed()
         {

--- a/src/MigrationTools.Host.Tests/Commands/VersionCommandTests.cs
+++ b/src/MigrationTools.Host.Tests/Commands/VersionCommandTests.cs
@@ -1,0 +1,37 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MigrationTools.Services;
+
+namespace MigrationTools.Host.Tests.Commands
+{
+    [TestClass()]
+    public class VersionCommandTests
+    {
+        private IHost host;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            host = MigrationToolHost.CreateDefaultBuilder(new string[] { "version", "--skipVersionCheck" }).Build();
+        }
+
+        [TestMethod, TestCategory("L0")]
+        public void VersionCommand_ServiceResolution_ShouldSucceed()
+        {
+            // Verify that all required services can be resolved
+            var migrationToolVersion = host.Services.GetRequiredService<IMigrationToolVersion>();
+            Assert.IsNotNull(migrationToolVersion);
+        }
+
+        [TestMethod, TestCategory("L0")]
+        public void VersionCommand_GetRunningVersion_ShouldReturnVersionInfo()
+        {
+            var migrationToolVersion = host.Services.GetRequiredService<IMigrationToolVersion>();
+            var versionInfo = migrationToolVersion.GetRunningVersion();
+            
+            Assert.IsNotNull(versionInfo);
+            Assert.IsNotNull(versionInfo.versionString);
+        }
+    }
+}

--- a/src/MigrationTools.Host.Tests/MigrationTools.Host.Tests.csproj
+++ b/src/MigrationTools.Host.Tests/MigrationTools.Host.Tests.csproj
@@ -9,6 +9,9 @@
     <Content Include="..\..\configuration-default.json" Link="configuration-default.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
+    <Content Include="..\..\appsettings.json" Link="appsettings.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MigrationTools.Host/Commands/CommandBase.cs
+++ b/src/MigrationTools.Host/Commands/CommandBase.cs
@@ -120,7 +120,7 @@ namespace MigrationTools.Host.Commands
                 Log.Debug("     IsRunningInDebug: {IsRunningInDebug}", _detectVersionService.IsRunningInDebug);
                 Log.Verbose("Full version data: ${_detectVersionService}", _detectVersionService);
 
-                Log.Information("Verion Info:");
+                Log.Information("Version Info:");
                 Log.Information("     Running: {RunningVersion}", _detectVersionService.RunningVersion);
                 Log.Information("     Installed: {InstalledVersion}", _detectVersionService.InstalledVersion);
                 Log.Information("     Available: {AvailableVersion}", _detectVersionService.AvailableVersion);

--- a/src/MigrationTools.Host/Commands/VersionCommand.cs
+++ b/src/MigrationTools.Host/Commands/VersionCommand.cs
@@ -16,7 +16,6 @@ namespace MigrationTools.Host.Commands
     internal class VersionCommand : CommandBase<VersionCommandSettings>
     {
         private readonly IMigrationToolVersion _migrationToolVersion;
-        private readonly ILogger<CommandBase<VersionCommandSettings>> _logger;
 
         public VersionCommand(
             IHostApplicationLifetime appLifetime,
@@ -31,7 +30,6 @@ namespace MigrationTools.Host.Commands
             : base(appLifetime, services, detectOnlineService, detectVersionService, logger, telemetryLogger, migrationToolVersion, configuration, activitySource)
         {
             _migrationToolVersion = migrationToolVersion;
-            _logger = logger;
         }
 
         internal override Task<int> ExecuteInternalAsync(CommandContext context, VersionCommandSettings settings)
@@ -54,7 +52,6 @@ namespace MigrationTools.Host.Commands
             catch (Exception ex)
             {
                 CommandActivity.RecordException(ex);
-                _logger.LogError(ex, "Error displaying version information");
                 return Task.FromResult(1);
             }
         }

--- a/src/MigrationTools.Host/Commands/VersionCommand.cs
+++ b/src/MigrationTools.Host/Commands/VersionCommand.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using MigrationTools.Host.Services;
+using MigrationTools.Services;
+using OpenTelemetry.Trace;
+using Serilog;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace MigrationTools.Host.Commands
+{
+    internal class VersionCommand : CommandBase<VersionCommandSettings>
+    {
+        private readonly IMigrationToolVersion _migrationToolVersion;
+        private readonly ILogger<CommandBase<VersionCommandSettings>> _logger;
+
+        public VersionCommand(
+            IHostApplicationLifetime appLifetime,
+            IServiceProvider services,
+            IDetectOnlineService detectOnlineService,
+            IDetectVersionService2 detectVersionService,
+            ILogger<CommandBase<VersionCommandSettings>> logger,
+            ITelemetryLogger telemetryLogger,
+            IMigrationToolVersion migrationToolVersion,
+            IConfiguration configuration,
+            ActivitySource activitySource) 
+            : base(appLifetime, services, detectOnlineService, detectVersionService, logger, telemetryLogger, migrationToolVersion, configuration, activitySource)
+        {
+            _migrationToolVersion = migrationToolVersion;
+            _logger = logger;
+        }
+
+        internal override Task<int> ExecuteInternalAsync(CommandContext context, VersionCommandSettings settings)
+        {
+            try
+            {
+                var versionInfo = _migrationToolVersion.GetRunningVersion();
+                
+                AnsiConsole.MarkupLine($"[bold cyan]Version:[/] {versionInfo.versionString}");
+                
+                if (versionInfo.version.Major == 0)
+                {
+                    AnsiConsole.MarkupLine($"[dim]Git Tag:[/] {ThisAssembly.Git.Tag}");
+                    AnsiConsole.MarkupLine($"[dim]Git Branch:[/] {ThisAssembly.Git.Branch}");
+                    AnsiConsole.MarkupLine($"[dim]Git Commits:[/] {ThisAssembly.Git.Commits}");
+                }
+                
+                return Task.FromResult(0);
+            }
+            catch (Exception ex)
+            {
+                CommandActivity.RecordException(ex);
+                _logger.LogError(ex, "Error displaying version information");
+                return Task.FromResult(1);
+            }
+        }
+    }
+}

--- a/src/MigrationTools.Host/Commands/VersionCommand.cs
+++ b/src/MigrationTools.Host/Commands/VersionCommand.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Diagnostics;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
@@ -6,8 +6,6 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using MigrationTools.Host.Services;
 using MigrationTools.Services;
-using OpenTelemetry.Trace;
-using Serilog;
 using Spectre.Console;
 using Spectre.Console.Cli;
 
@@ -26,34 +24,27 @@ namespace MigrationTools.Host.Commands
             ITelemetryLogger telemetryLogger,
             IMigrationToolVersion migrationToolVersion,
             IConfiguration configuration,
-            ActivitySource activitySource) 
-            : base(appLifetime, services, detectOnlineService, detectVersionService, logger, telemetryLogger, migrationToolVersion, configuration, activitySource)
+            ActivitySource activitySource)
+            : base(appLifetime, services, detectOnlineService, detectVersionService, logger, telemetryLogger,
+                migrationToolVersion, configuration, activitySource)
         {
             _migrationToolVersion = migrationToolVersion;
         }
 
         internal override Task<int> ExecuteInternalAsync(CommandContext context, VersionCommandSettings settings)
         {
-            try
+            var versionInfo = _migrationToolVersion.GetRunningVersion();
+
+            AnsiConsole.MarkupLine($"[bold cyan]Version:[/] {Markup.Escape(versionInfo.versionString)}");
+
+            if (versionInfo.version.Major == 0)
             {
-                var versionInfo = _migrationToolVersion.GetRunningVersion();
-                
-                AnsiConsole.MarkupLine($"[bold cyan]Version:[/] {versionInfo.versionString}");
-                
-                if (versionInfo.version.Major == 0)
-                {
-                    AnsiConsole.MarkupLine($"[dim]Git Tag:[/] {ThisAssembly.Git.Tag}");
-                    AnsiConsole.MarkupLine($"[dim]Git Branch:[/] {ThisAssembly.Git.Branch}");
-                    AnsiConsole.MarkupLine($"[dim]Git Commits:[/] {ThisAssembly.Git.Commits}");
-                }
-                
-                return Task.FromResult(0);
+                AnsiConsole.MarkupLine($"[dim]Git Tag:[/] {Markup.Escape(ThisAssembly.Git.Tag)}");
+                AnsiConsole.MarkupLine($"[dim]Git Branch:[/] {Markup.Escape(ThisAssembly.Git.Branch)}");
+                AnsiConsole.MarkupLine($"[dim]Git Commits:[/] {Markup.Escape(ThisAssembly.Git.Commits)}");
             }
-            catch (Exception ex)
-            {
-                CommandActivity.RecordException(ex);
-                return Task.FromResult(1);
-            }
+
+            return Task.FromResult(0);
         }
     }
 }

--- a/src/MigrationTools.Host/Commands/VersionCommandSettings.cs
+++ b/src/MigrationTools.Host/Commands/VersionCommandSettings.cs
@@ -1,0 +1,9 @@
+using System.ComponentModel;
+using Spectre.Console.Cli;
+
+namespace MigrationTools.Host.Commands
+{
+    internal class VersionCommandSettings : CommandSettingsBase
+    {
+    }
+}

--- a/src/MigrationTools.Host/MigrationToolHost.cs
+++ b/src/MigrationTools.Host/MigrationToolHost.cs
@@ -125,6 +125,10 @@ namespace MigrationTools.Host
                            .WithDescription("Creates or edits a configuration file")
                           .WithExample("builder --config \"configuration.json\"").IsHidden();
 
+                config.AddCommand<Commands.VersionCommand>("version")
+                           .WithDescription("Displays the version of the tool")
+                           .WithExample("version");
+
                 extraCommands?.Invoke(config);
                 config.PropagateExceptions();
             });


### PR DESCRIPTION
Idea : Being able to get the version of the tool without doing a migration but rather by using the "version" command line tool option

Generated with copilot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new "version" command to display the tool's running version; includes Git metadata (tag, branch, commits) for pre-release builds.

* **Bug Fixes**
  * Corrected a logging typo in version output.

* **Tests**
  * Added tests validating the version command and service resolution.

* **Chores**
  * Test project now ensures configuration file is included in test run outputs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->