### PR TITLE
Added seconds to WorkItemMigrationProcessor estimation

### DIFF
--- a/src/MigrationTools.Clients.TfsObjectModel/Processors/TfsWorkItemMigrationProcessor.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/Processors/TfsWorkItemMigrationProcessor.cs
@@ -695,7 +695,7 @@ namespace MigrationTools.Processors
                 activity?.Stop();
                 progressTimer.AddProcessedItem(activity.Duration, retries > 0);
                 TraceWriteLine(LogEventLevel.Information,
-                    "Average time of {average:%s}.{average:%fff} per work item and {remaining:%h} hours {remaining:%m} minutes {remaining:%s} seconds estimated to completion.",
+                    "Average time of {average:%s}.{average:%fff} seconds per work item and {remaining:%h} hours {remaining:%m} minutes {remaining:%s} seconds estimated to completion.",
                     new Dictionary<string, object>() {
                         { "average", progressTimer.AverageTime },
                         { "remaining", progressTimer.RemainingTime }


### PR DESCRIPTION
Issue:

`
Test Case][Complete:  2124/3118][sid:174211|Rev: 26][tid:  null | Average time of 3.221 per work item and 0 hours 53 minutes 12 seconds estimated to completion
`

Unit is missing in the message

Added seconds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal logging message formatting for migration processing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nkdAgility/azure-devops-migration-tools/pull/3140)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->