### PR TITLE
FieldCalculationMap should include a fallback option if parsing failed

### DIFF
--- a/src/MigrationTools.Clients.TfsObjectModel/Tools/FieldMappingTool/FieldMaps/FieldCalculationMap.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/Tools/FieldMappingTool/FieldMaps/FieldCalculationMap.cs
@@ -83,18 +83,26 @@ namespace MigrationTools.FieldMaps.AzureDevops.ObjectModel
 
                     // Convert field value to numeric
                     if (!TryConvertToNumeric(fieldValue, out var numericValue)) {
-                        if (Config.parsingFallback == FieldCalculationMapParsingFallback.RaiseError) {
-                            Log.LogError(
-                                "FieldCalculationMap: Source field '{SourceField}' with value '{FieldValue}' is not numeric on work item {WorkItemId}. Skipping calculation.",
-                                parameter.Value, fieldValue, source.Id);
-                            return;
-                        }
 
-                        if (Config.parsingFallback == FieldCalculationMapParsingFallback.ResetToZero) {
-                            Log.LogWarning(
-                                "FieldCalculationMap: Source field '{SourceField}' with value '{FieldValue}' is not numeric on work item {WorkItemId}. resetting the value to 0.0.",
-                                parameter.Value, fieldValue, source.Id);
-                            numericValue = 0.0;
+                        switch (Config.parsingFallback) {
+                            case FieldCalculationMapParsingFallback.RaiseError:
+                                Log.LogError(
+                                    "FieldCalculationMap: Source field '{SourceField}' with value '{FieldValue}' is not numeric on work item {WorkItemId}. Skipping calculation.",
+                                    parameter.Value, fieldValue, source.Id);
+                                break;
+
+                            case FieldCalculationMapParsingFallback.ResetToZero:
+                                Log.LogWarning(
+                                    "FieldCalculationMap: Source field '{SourceField}' with value '{FieldValue}' is not numeric on work item {WorkItemId}. resetting the value to 0.0.",
+                                    parameter.Value, fieldValue, source.Id);
+                                numericValue = 0.0;
+                                break;
+
+                            default:
+                                Log.LogError(
+                                    "FieldCalculationMap: Unsupported parsing fallback '{ParsingFallback}' for source field '{SourceField}' on work item {WorkItemId}. Skipping calculation.",
+                                    parameter.Value, fieldValue, source.Id);
+                                break;
                         }
                     }
 

--- a/src/MigrationTools.Clients.TfsObjectModel/Tools/FieldMappingTool/FieldMaps/FieldCalculationMap.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/Tools/FieldMappingTool/FieldMaps/FieldCalculationMap.cs
@@ -97,12 +97,6 @@ namespace MigrationTools.FieldMaps.AzureDevops.ObjectModel
                                     parameter.Value, fieldValue, source.Id);
                                 numericValue = 0.0;
                                 break;
-
-                            default:
-                                Log.LogError(
-                                    "FieldCalculationMap: Unsupported parsing fallback '{ParsingFallback}' for source field '{SourceField}' on work item {WorkItemId}. Skipping calculation.",
-                                    parameter.Value, fieldValue, source.Id);
-                                break;
                         }
                     }
 

--- a/src/MigrationTools.Clients.TfsObjectModel/Tools/FieldMappingTool/FieldMaps/FieldCalculationMap.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/Tools/FieldMappingTool/FieldMaps/FieldCalculationMap.cs
@@ -83,14 +83,14 @@ namespace MigrationTools.FieldMaps.AzureDevops.ObjectModel
 
                     // Convert field value to numeric
                     if (!TryConvertToNumeric(fieldValue, out var numericValue)) {
-                        if (Config.ParsingFallback == FieldCalculationMapParsingFallback.RaiseError) {
+                        if (Config.parsingFallback == FieldCalculationMapParsingFallback.RaiseError) {
                             Log.LogError(
                                 "FieldCalculationMap: Source field '{SourceField}' with value '{FieldValue}' is not numeric on work item {WorkItemId}. Skipping calculation.",
                                 parameter.Value, fieldValue, source.Id);
                             return;
                         }
 
-                        if (Config.ParsingFallback == FieldCalculationMapParsingFallback.ResetToZero) {
+                        if (Config.parsingFallback == FieldCalculationMapParsingFallback.ResetToZero) {
                             Log.LogWarning(
                                 "FieldCalculationMap: Source field '{SourceField}' with value '{FieldValue}' is not numeric on work item {WorkItemId}. resetting the value to 0.0.",
                                 parameter.Value, fieldValue, source.Id);

--- a/src/MigrationTools.Clients.TfsObjectModel/Tools/FieldMappingTool/FieldMaps/FieldCalculationMap.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/Tools/FieldMappingTool/FieldMaps/FieldCalculationMap.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
 using Microsoft.Extensions.Logging;
@@ -82,10 +82,20 @@ namespace MigrationTools.FieldMaps.AzureDevops.ObjectModel
                     }
 
                     // Convert field value to numeric
-                    if (!TryConvertToNumeric(fieldValue, out var numericValue))
-                    {
-                        Log.LogWarning("FieldCalculationMap: Source field '{SourceField}' with value '{FieldValue}' is not numeric on work item {WorkItemId}. Skipping calculation.", parameter.Value, fieldValue, source.Id);
-                        return;
+                    if (!TryConvertToNumeric(fieldValue, out var numericValue)) {
+                        if (Config.ParsingFallback == FieldCalculationMapParsingFallback.RaiseError) {
+                            Log.LogError(
+                                "FieldCalculationMap: Source field '{SourceField}' with value '{FieldValue}' is not numeric on work item {WorkItemId}. Skipping calculation.",
+                                parameter.Value, fieldValue, source.Id);
+                            return;
+                        }
+
+                        if (Config.ParsingFallback == FieldCalculationMapParsingFallback.ResetToZero) {
+                            Log.LogWarning(
+                                "FieldCalculationMap: Source field '{SourceField}' with value '{FieldValue}' is not numeric on work item {WorkItemId}. resetting the value to 0.0.",
+                                parameter.Value, fieldValue, source.Id);
+                            numericValue = 0.0;
+                        }
                     }
 
                     parameterValues[parameter.Key] = numericValue;

--- a/src/MigrationTools/Tools/FieldMappingTool/FieldMaps/FieldCalculationMapOptions.cs
+++ b/src/MigrationTools/Tools/FieldMappingTool/FieldMaps/FieldCalculationMapOptions.cs
@@ -26,7 +26,7 @@ namespace MigrationTools.Tools
         /// Gets or sets the parsing fallback.
         /// </summary>
         /// <default>null</default>
-        public FieldCalculationMapParsingFallback ParsingFallback { get; set; }
+        public FieldCalculationMapParsingFallback parsingFallback { get; set; }
 
         /// <summary>
         /// Gets or sets a dictionary mapping variable names used in the expression to source field reference names.
@@ -52,7 +52,7 @@ namespace MigrationTools.Tools
                 { "x", "Custom.FieldB" }
             };
             targetField = "Custom.FieldC";
-            ParsingFallback = FieldCalculationMapParsingFallback.RaiseError;
+            parsingFallback = FieldCalculationMapParsingFallback.RaiseError;
         }
 
         /// <summary>

--- a/src/MigrationTools/Tools/FieldMappingTool/FieldMaps/FieldCalculationMapOptions.cs
+++ b/src/MigrationTools/Tools/FieldMappingTool/FieldMaps/FieldCalculationMapOptions.cs
@@ -1,13 +1,10 @@
 ﻿using System.Collections.Generic;
 using MigrationTools.Tools.Infrastructure;
 
-namespace MigrationTools.Tools
-{
-    public enum FieldCalculationMapParsingFallback
-    {
-        None,
-        RaiseError = 1,
-        ResetToZero = 2
+namespace MigrationTools.Tools {
+    public enum FieldCalculationMapParsingFallback {
+        RaiseError,
+        ResetToZero
     }
 
     /// <summary>
@@ -15,8 +12,7 @@ namespace MigrationTools.Tools
     /// </summary>
     /// <status>ready</status>
     /// <processingtarget>Work Item Field</processingtarget>
-    public class FieldCalculationMapOptions : FieldMapOptions
-    {
+    public class FieldCalculationMapOptions : FieldMapOptions {
         /// <summary>
         /// Gets or sets the NCalc expression to evaluate. Variables in the expression should be enclosed in square brackets (e.g., "[x]*2").
         /// </summary>
@@ -27,7 +23,8 @@ namespace MigrationTools.Tools
         /// Gets or sets the parsing fallback.
         /// </summary>
         /// <default>null</default>
-        public FieldCalculationMapParsingFallback parsingFallback { get; set; }
+        public FieldCalculationMapParsingFallback parsingFallback { get; set; } =
+            FieldCalculationMapParsingFallback.RaiseError;
 
         /// <summary>
         /// Gets or sets a dictionary mapping variable names used in the expression to source field reference names.
@@ -44,12 +41,10 @@ namespace MigrationTools.Tools
         /// <summary>
         /// Sets example configuration defaults for documentation purposes.
         /// </summary>
-        public void SetExampleConfigDefaults()
-        {
+        public void SetExampleConfigDefaults() {
             ApplyTo = new List<string>() { "SomeWorkItemType" };
             expression = "[x]*2";
-            parameters = new Dictionary<string, string>
-            {
+            parameters = new Dictionary<string, string> {
                 { "x", "Custom.FieldB" }
             };
             targetField = "Custom.FieldC";
@@ -59,8 +54,7 @@ namespace MigrationTools.Tools
         /// <summary>
         /// Initializes a new instance of the FieldCalculationMapOptions class.
         /// </summary>
-        public FieldCalculationMapOptions()
-        {
+        public FieldCalculationMapOptions() {
             parameters = new Dictionary<string, string>();
         }
     }

--- a/src/MigrationTools/Tools/FieldMappingTool/FieldMaps/FieldCalculationMapOptions.cs
+++ b/src/MigrationTools/Tools/FieldMappingTool/FieldMaps/FieldCalculationMapOptions.cs
@@ -1,8 +1,14 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using MigrationTools.Tools.Infrastructure;
 
 namespace MigrationTools.Tools
 {
+    public enum FieldCalculationMapParsingFallback
+    {
+        RaiseError,
+        ResetToZero
+    }
+
     /// <summary>
     /// Performs mathematical calculations on numeric fields using NCalc expressions during migration.
     /// </summary>
@@ -15,6 +21,12 @@ namespace MigrationTools.Tools
         /// </summary>
         /// <default>null</default>
         public string expression { get; set; }
+
+        /// <summary>
+        /// Gets or sets the parsing fallback.
+        /// </summary>
+        /// <default>null</default>
+        public FieldCalculationMapParsingFallback ParsingFallback { get; set; }
 
         /// <summary>
         /// Gets or sets a dictionary mapping variable names used in the expression to source field reference names.
@@ -40,6 +52,7 @@ namespace MigrationTools.Tools
                 { "x", "Custom.FieldB" }
             };
             targetField = "Custom.FieldC";
+            ParsingFallback = FieldCalculationMapParsingFallback.RaiseError;
         }
 
         /// <summary>

--- a/src/MigrationTools/Tools/FieldMappingTool/FieldMaps/FieldCalculationMapOptions.cs
+++ b/src/MigrationTools/Tools/FieldMappingTool/FieldMaps/FieldCalculationMapOptions.cs
@@ -5,8 +5,9 @@ namespace MigrationTools.Tools
 {
     public enum FieldCalculationMapParsingFallback
     {
-        RaiseError,
-        ResetToZero
+        None,
+        RaiseError = 1,
+        ResetToZero = 2
     }
 
     /// <summary>


### PR DESCRIPTION
Added parsing fallback option

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Field Calculation tool adds a configurable parsing-fallback setting with two behaviours: ResetToZero (use 0.0 on non-numeric input) or RaiseError (log an error and leave the value unset).

* **Bug Fixes**
  * Improved handling and logging of unsupported or unknown fallback values to avoid incorrect calculations; parsing-failure behaviour is now explicit and predictable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nkdAgility/azure-devops-migration-tools/pull/3142?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->