### PR TITLE
Always check for globally excluded fields

### DIFF
--- a/src/MigrationTools.Clients.TfsObjectModel/Tools/TfsWorkItemTypeValidatorToolOptions.cs
+++ b/src/MigrationTools.Clients.TfsObjectModel/Tools/TfsWorkItemTypeValidatorToolOptions.cs
@@ -101,13 +101,15 @@ namespace MigrationTools.Tools
         /// <param name="fieldReferenceName">Target field reference name.</param>
         public bool IsSourceFieldExcluded(string workItemType, string fieldReferenceName)
         {
-            if (ExcludeSourceFields.TryGetValue(workItemType, out List<string> excludedFields))
+            if (ExcludeSourceFields.TryGetValue(workItemType, out List<string> excludedFields)
+                && excludedFields.Contains(fieldReferenceName, _normalizedComparer))
             {
-                return excludedFields.Contains(fieldReferenceName, _normalizedComparer);
+                return true;
             }
-            if (ExcludeSourceFields.TryGetValue(AllWorkItemTypes, out excludedFields))
+            if (ExcludeSourceFields.TryGetValue(AllWorkItemTypes, out excludedFields)
+                && excludedFields.Contains(fieldReferenceName, _normalizedComparer))
             {
-                return excludedFields.Contains(fieldReferenceName, _normalizedComparer);
+                return true;
             }
             return false;
         }


### PR DESCRIPTION
When deciding whether a field is excluded in the work item validation, check both the list of excluded fields specific to the work item type, and the list from the `AllWorkItemTypes` (`*`) section that should apply to all work item types.

Previously, if the work item type had its own list of excluded fields, the global list of excluded fields was not checked anymore, requiring duplication in the configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code structure improvements with no user-visible changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->